### PR TITLE
[RPS-289] Filter out certain hyperlinks for CI migration

### DIFF
--- a/ci-cd/bin/set-commit-status
+++ b/ci-cd/bin/set-commit-status
@@ -22,7 +22,7 @@ function set_status {
 }"
 
     git_hash=$(git rev-parse HEAD)
-    curl "https://api.github.com/repos/NHS-digital-website/ps-hippo/statuses/${git_hash}?access_token=${GITHUB_TOKEN}" \
+    curl "https://api.github.com/repos/NHS-digital-website/hippo/statuses/${git_hash}?access_token=${GITHUB_TOKEN}" \
         -H "Content-Type: application/json" \
         -X POST \
         -d "${payload}"

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/nesstar/NesstarResource.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/nesstar/NesstarResource.java
@@ -2,19 +2,7 @@ package uk.nhs.digital.ps.migrator.model.nesstar;
 
 import org.jdom2.Element;
 import org.jdom2.xpath.XPathExpression;
-import org.jdom2.xpath.XPathFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLConnection;
-import java.nio.channels.Channels;
-import java.nio.channels.FileChannel;
-import java.nio.channels.ReadableByteChannel;
+import org.apache.commons.lang3.StringUtils;
 
 public class NesstarResource {
 
@@ -34,6 +22,12 @@ public class NesstarResource {
 
     public boolean isLink() {
         return getUri().matches("https?://.*");
+    }
+
+    public boolean isNotOnIgnoreList() {
+        // Certain links with set phrases are not required to be migrated over
+        return !StringUtils.containsIgnoreCase(getTitle(), "earlier data may be available")
+            && !StringUtils.containsIgnoreCase(getTitle(), "contact us");
     }
 
     public String getTitle() {

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/ImportableItemsFactory.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/ImportableItemsFactory.java
@@ -1,5 +1,6 @@
 package uk.nhs.digital.ps.migrator.task;
 
+import org.apache.commons.lang3.StringUtils;
 import uk.nhs.digital.ps.migrator.MigrationReport;
 import uk.nhs.digital.ps.migrator.config.ExecutionParameters;
 import uk.nhs.digital.ps.migrator.model.hippo.*;
@@ -106,6 +107,14 @@ public class ImportableItemsFactory {
     public List<ResourceLink> getResourceLinks(List<NesstarResource> resources) {
       return resources.stream()
             .filter(NesstarResource::isLink)
+            .peek(resource -> {
+                // There should not be any link text with contact us, but if there are report it
+                if (resource.isLink() && StringUtils.containsIgnoreCase(resource.getTitle(), "contact us")) {
+                    migrationReport.add("Resource Link Text with 'contact us' found: " + resource.getTitle(),
+                        "Link Uri is: " + resource.getUri());
+                }
+            })
+            .filter(NesstarResource::isNotOnIgnoreList)
             .map(resource -> new ResourceLink(resource.getTitle(), resource.getUri()))
             .collect(Collectors.toList());
     }


### PR DESCRIPTION
Filter out links with set phrases which the CI team do not want
migrated over. This include the following text:
- earlier data may be available
- contact us

As 'contact us' was not found in the nesstar export, if one is
found going forward, it will be logged to the migration report
for attention.