### PR TITLE
[RPS-257] Removed link text hint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -337,6 +337,16 @@
         </plugins>
     </build>
 
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jxr-plugin</artifactId>
+                <version>2.5</version>
+            </plugin>
+        </plugins>
+    </reporting>
+
     <profiles>
 
         <profile>

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/relatedlink.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/relatedlink.yaml
@@ -24,7 +24,6 @@ definitions:
               jcr:primaryType: frontend:pluginconfig
             caption: Link Text
             field: link_text
-            hint: If not provided, the URL will be displayed
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.css:

--- a/site/src/main/java/uk/nhs/digital/ps/beans/Dataset.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/Dataset.java
@@ -94,7 +94,7 @@ public class Dataset extends BaseDocument {
         return publicationBean;
     }
 
-    public List getTaxonomyList() {
+    public List<List<String>> getTaxonomyList() {
         assertPropertyPermitted(PropertyKeys.TAXONOMY);
 
         return HippoBeanHelper.getTaxonomyList(getKeys());

--- a/site/src/main/java/uk/nhs/digital/ps/beans/HippoBeanHelper.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/HippoBeanHelper.java
@@ -43,7 +43,7 @@ public class HippoBeanHelper {
         return taxonomyName;
     }
 
-    public static List getTaxonomyList(String[] keys) {
+    public static List<List<String>> getTaxonomyList(String[] keys) {
         List<List<String>> taxonomyList = new ArrayList<>();
 
         // For each taxonomy tag key, get the name and also include hierarchy context (ancestors)

--- a/site/src/main/java/uk/nhs/digital/ps/beans/Publication.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/Publication.java
@@ -56,7 +56,7 @@ public class Publication extends BaseDocument {
         return this;
     }
 
-    public List getTaxonomyList() {
+    public List<List<String>> getTaxonomyList() {
         assertPropertyPermitted(PropertyKeys.TAXONOMY);
 
         return HippoBeanHelper.getTaxonomyList(getKeys());


### PR DESCRIPTION
The field is now mandatory so the hint needed removing.
Also fixed a warning with they code checker by adding a reporting
maven plugin.
Also added some generics missed in my previous PR.