### PR TITLE
[RPS-259] Removed hardcoded user accounts

### DIFF
--- a/ci-cd/bin/get-hippo-groups-yaml
+++ b/ci-cd/bin/get-hippo-groups-yaml
@@ -5,8 +5,10 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 function main {
     local users_file=$1
+    local developer_users_file=$2
     local authors="      - author"
     local editors="      - editor"
+    local admins="      - admin"
 
     while read -r line; do
         id=$(echo "${line}" | sed -e 's/ /./' | tr '[:upper:]' '[:lower:]')
@@ -20,6 +22,12 @@ function main {
       - ${id}.e"
     done < "$users_file"
 
+    while read -r line; do
+        id=$(echo "${line}" | sed -e 's/ /./' | tr '[:upper:]' '[:lower:]')
+        admins="${admins}
+      - ${id}"
+    done < "$developer_users_file"
+
     cat "${DIR}/../groups.base.yaml"
     echo "
   /author:
@@ -32,6 +40,12 @@ ${authors}
     hipposys:members:
 ${editors}
     hipposys:securityprovider: internal
+  /admin:
+      jcr:primaryType: hipposys:group
+      hipposys:members:
+      - workflowuser
+${admins}
+      hipposys:securityprovider: internal
 "
 }
 

--- a/ci-cd/bin/get-hippo-user-yaml
+++ b/ci-cd/bin/get-hippo-user-yaml
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+function main {
+    local name="$1"
+    local firstName
+    local id
+
+    firstName=$(echo "$name" | awk '{print $1;}')
+    id=$(echo "${name}" | sed -e 's/ /./' | tr '[:upper:]' '[:lower:]')
+
+    echo "
+  # ${name}
+  /${id}:
+    jcr:primaryType: hipposys:user
+    hipposys:active: true
+    hipposys:firstname: ${firstName}
+    hipposys:password: \"\$SHA-256\$hGJdRtJvQF8=\$ha7WodFhAJu2VuuT9uw6CVrKBlnMN/8NrCwebRA6+88=\"
+    hipposys:passwordlastmodified: 2017-11-15T09:00:00.000Z
+    hipposys:securityprovider: internal
+"
+}
+
+main "$@"

--- a/ci-cd/bin/get-hippo-users-yaml
+++ b/ci-cd/bin/get-hippo-users-yaml
@@ -5,11 +5,17 @@ DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 function main {
     local users_file=$1
+    local developers_users_file=$2
 
     cat "${DIR}/../users.base.yaml"
     while read -r line; do
         ${DIR}/get-hippo-test-user-yaml "${line}"
     done < "$users_file"
+
+    while read -r line; do
+        ${DIR}/get-hippo-user-yaml "${line}"
+    done < "$developers_users_file"
+
 }
 
 main "$@"

--- a/ci-cd/groups.base.yaml
+++ b/ci-cd/groups.base.yaml
@@ -4,7 +4,7 @@
   jcr:primaryType: hipposys:groupfolder
   /admin:
     jcr:primaryType: hipposys:group
-    hipposys:members: [admin, workflowuser, ngaitang, ivorcaldwell]
+    hipposys:members: [admin, workflowuser]
     hipposys:securityprovider: internal
   /everybody:
     jcr:primaryType: hipposys:group

--- a/ci-cd/users.base.yaml
+++ b/ci-cd/users.base.yaml
@@ -7,16 +7,6 @@
     hipposys:active: true
     hipposys:password: $SHA-256$3vB5lqrvOts=$866Q2ch2uCcyIrROCoI6jf2y3Iuy7QXRxBeQSZIJfmA=
     hipposys:securityprovider: internal
-  /ngaitang:
-    jcr:primaryType: hipposys:user
-    hipposys:active: true
-    hipposys:password: $SHA-256$Wzs0Fcfhutw=$CYKoPHIDGN9DEe7KvaGOppprXzg6zfL44RrKP7ZvUso=
-    hipposys:securityprovider: internal
-  /ivorcaldwell:
-    jcr:primaryType: hipposys:user
-    hipposys:active: true
-    hipposys:password: $SHA-256$3vB5lqrvOts=$866Q2ch2uCcyIrROCoI6jf2y3Iuy7QXRxBeQSZIJfmA=
-    hipposys:securityprovider: internal
   /workflowuser:
     jcr:primaryType: hipposys:user
     hipposys:active: true

--- a/docs/what-if/reset-test-accounts.md
+++ b/docs/what-if/reset-test-accounts.md
@@ -3,14 +3,14 @@
 In order to reset (!) users and groups settings follow these steps.
 
 > **Note:** Please note that this will remove all users and groups configuration
-> and replace it with "test" users and groups
+> and replace it with new users and groups.
 
-Generate users and groups config:
+Generate users and groups config from 2 text files (testers and admins):
 
 * Generate `users.yaml` by running
-  `ci-cd/bin/get-hippo-users-yaml ci-cd/test-users > users.yaml`
+  `ci-cd/bin/get-hippo-users-yaml test-users admin-users > users.yaml`
 * Generate `groups.yaml` by running
-  `ci-cd/bin/get-hippo-groups-yaml ci-cd/test-users > groups.yaml`
+  `ci-cd/bin/get-hippo-groups-yaml test-users admin-users > groups.yaml`
 
 Import users and groups config to Hippo:
 
@@ -23,3 +23,29 @@ Import users and groups config to Hippo:
 * Paste content of `groups.yaml` file to text field under "Or paste your yaml dump
   here:"
 * Click on "Write changes to repository" to persist changes.
+
+Example `test-users` file:
+
+```
+John Smith
+Muriel Williams
+```
+
+and example `admin-users` file:
+
+```
+Nelly Brown
+Ronny Evans
+```
+
+Users listed in `test-users` files will get 2 accounts:
+
+* john.smith.a (author)
+* john.smith.e (editor)
+* muriel.williams.a (author)
+* muriel.williams.e (editor)
+
+Users listed in `admin-users` file will get 1 account
+
+* nelly.brown (admin)
+* ronny.evans (admin)


### PR DESCRIPTION
Removed all the hard coded user accounts (including hashed passwords)
except for admin. We are leaving admin with a random hashed password
as this is better than having admin:admin and we will delete the
admin account as soon as we have set up individual accounts in prod.