### PR TITLE
[RPS-271] Fixed bugs with searching for quoted terms

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/common/SearchPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/common/SearchPage.java
@@ -44,6 +44,10 @@ public class SearchPage extends AbstractSitePage {
         return helper.findElement(By.id("btnSearch"));
     }
 
+    public String getSearchFieldValue() {
+        return findSearchField().getAttribute("value");
+    }
+
     public WebElement searchForTerm(final String queryTerm) {
         // type, click search
         findSearchField().sendKeys(queryTerm);

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/SearchSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/SearchSteps.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.*;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -31,7 +32,7 @@ public class SearchSteps extends AbstractSpringSteps {
     @Autowired
     private TestDataRepo testDataRepo;
 
-    @When("^I search for \"([^\"]+)\"$")
+    @When("^I search for \"(.+)\"$")
     public void iSearchFor(String searchTerm) throws Throwable {
         searchPage.searchForTerm(searchTerm);
     }
@@ -65,4 +66,17 @@ public class SearchSteps extends AbstractSpringSteps {
 
         assertThat("Search results match", actualResults, contains(expectedResults));
     }
+
+    @Then("^I should see the search term \"(.+)\" on the results page$")
+    public void iShouldSeeTheSearchTermOnTheResultsPage(String term) throws Throwable {
+        assertThat("Result count ends with search term", searchPage.getResultCount(), endsWith(term));
+        assertEquals("Search query is maintained in search box", term, searchPage.getSearchFieldValue());
+    }
+
+    @Then("^I should see the blank search results page$")
+    public void iShouldSeeTheBlankSearchResultsPage() throws Throwable {
+        assertEquals("Blank search helper text is shown", "Please fill in a search term", searchPage.getResultCount());
+        assertEquals("Search query is blank", "", searchPage.getSearchFieldValue());
+    }
+
 }

--- a/acceptance-tests/src/test/resources/features/site/search.feature
+++ b/acceptance-tests/src/test/resources/features/site/search.feature
@@ -95,3 +95,18 @@ Feature: Basic search
             | Search Test Publication Key Facts |
             | Search Test Dataset Title         |
             | Search Test Dataset Summary       |
+
+    Scenario: Search terms are displayed correctly on the results page
+        Given I navigate to the "home" page
+        When I search for "test_search"
+        Then I should see the search term "test_search" on the results page
+
+    Scenario: Quoted search terms are displayed correctly on the results page
+        Given I navigate to the "home" page
+        When I search for ""test_search""
+        Then I should see the search term ""test_search"" on the results page
+
+    Scenario: Blank search terms display the correct results page
+        Given I navigate to the "home" page
+        When I search for " "
+        Then I should see the blank search results page

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/search.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/search.ftl
@@ -8,7 +8,8 @@
   <form class="navbar-form" role="search" action="${searchLink}" method="get">
     <div class="common-search__inner">
       <span class="common-search__input">
-        <input type="text" class="common-search__input__field" id="query" name="query" aria-labelledby="btnSearch" placeholder="What are you looking for today?" value="${query!""}">
+        <!--Need to strip escape characters from quotes as they are present in the query variable given to us by hippo-->
+        <input type="text" class="common-search__input__field" id="query" name="query" aria-labelledby="btnSearch" placeholder="What are you looking for today?" value="${(query!"")?replace("\\\"", "\"")}">
       </span>
       <input type="submit" class="common-search__submit" id="btnSearch" value="Search">
     </div>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/searchresults.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/searchresults.ftl
@@ -30,5 +30,7 @@
         </#if>
     </div>
 <#else>
-    <h3>Please fill in a search term</h3>
+    <div data-uipath="ps.search-results">
+        <h1 data-uipath="ps.search-results.count">Please fill in a search term</h1>
+    </div>
 </#if>

--- a/site/src/test/java/uk/nhs/digital/common/components/SearchComponentTest.java
+++ b/site/src/test/java/uk/nhs/digital/common/components/SearchComponentTest.java
@@ -30,8 +30,8 @@ public class SearchComponentTest {
             // queryInput                   expectedQueryOutput
             {"lorem",                       "lorem*"},
             {"lorem*",                      "lorem*"},
-            {"lorem?",                      "lorem*"},
-            {"lorem? ipsum",                "lorem* ipsum*"},
+            {"lorem*?",                     "lorem*"},
+            {"lorem*? ipsum",               "lorem* ipsum*"},
             {"lorem ipsum",                 "lorem* ipsum*"},
             {"lorem ipsum*",                "lorem* ipsum*"},
             {"lor* ipsum",                  "lor* ipsum*"},
@@ -48,11 +48,11 @@ public class SearchComponentTest {
             {"-lorem",                      "-lorem*"},
             {"lorem -ipsum",                "lorem* -ipsum*"},
             {"lor* -ipsum",                 "lor* -ipsum*"},
-            {"\"dolor sit\" -\"lorem ipsum\"","\"dolor sit\" -\"lorem ipsum\""},
+            {"\"dolor sit\" -\"lorem ipsum\"","\"dolor sit\" \"lorem ipsum\""},
 
             {"lorem OR ipsum",              "lorem* OR ipsum*"},
             {"lorem OR ipsum sit",          "lorem* OR ipsum* sit*"},
-            {"OR lorem",                    "OR lorem*"},
+            {"OR lorem",                    "lorem*"},
             {"lorem OR ipsum \"dolor sit\"","lorem* OR ipsum* \"dolor sit\""},
             {"\"dolor sit\" lorem OR ipsum","\"dolor sit\" lorem* OR ipsum*"},
 
@@ -62,6 +62,10 @@ public class SearchComponentTest {
             {"elit. -lorem",                "elit. -lorem*"},
             {"-elit. lorem",                "-elit. lorem*"},
             {"elit. \"dolor sit\"",         "elit. \"dolor sit\""},
+
+            // Check that odd numbers of quotes are sanitized
+            {"elit \"dolor sit",         "elit* dolor* sit*"},
+            {"elit \"dolor\" sit\"",     "elit* \"dolor\" sit*"}
 
         };
     }
@@ -86,7 +90,7 @@ public class SearchComponentTest {
         // setUp
 
         // when
-        final String actualQueryOutput = searchComponent.applyWildcardsToQuery(queryInput);
+        final String actualQueryOutput = searchComponent.parseAndApplyWildcards(queryInput);
 
         // then
         assertThat("Wildcard query is correct", actualQueryOutput, is(expectedQueryOutput));


### PR DESCRIPTION
- Fixed a bug where a search term with an odd number of quotes
caused an error.

- Fixed a display bug where quoted search terms were shown with
escape characters.