### PR TITLE
[RPS-296] CI migration: modify links filtering

### DIFF
--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/Attachment.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/Attachment.java
@@ -102,6 +102,14 @@ public class Attachment {
         }
     }
 
+    @Override
+    public String toString() {
+        return "Attachment{" +
+            "title='" + title + '\'' +
+            ", uri='" + uri + '\'' +
+            '}';
+    }
+
     private static float getMb(long bytes) {
         return bytes / (1024f * 1024);
     }

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/ResourceLink.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/ResourceLink.java
@@ -17,4 +17,12 @@ public class ResourceLink  {
     public String getUri() {
         return uri;
     }
+
+    @Override
+    public String toString() {
+        return "ResourceLink{" +
+            "name='" + name + '\'' +
+            ", uri='" + uri + '\'' +
+            '}';
+    }
 }

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/nesstar/NesstarResource.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/nesstar/NesstarResource.java
@@ -24,12 +24,6 @@ public class NesstarResource {
         return getUri().matches("https?://.*");
     }
 
-    public boolean isNotOnIgnoreList() {
-        // Certain links with set phrases are not required to be migrated over
-        return !StringUtils.containsIgnoreCase(getTitle(), "earlier data may be available")
-            && !StringUtils.containsIgnoreCase(getTitle(), "contact us");
-    }
-
     public String getTitle() {
         return titleXpath.evaluateFirst(rootElement).getTextTrim();
     }

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/report/IncidentType.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/report/IncidentType.java
@@ -111,15 +111,16 @@ public enum IncidentType {
         DATASET_NOT_MIGRATED,
         "Failed to generate import file"
     ),
-    RESOURCE_LINK_CONTACT_US(
-        FIELD_MIGRATED_AS_IS,
-        "Resource link with 'Contact us' text encountered",
+    RESOURCE_LINK_FILTERED_OUT(
+        FIELD_NOT_MIGRATED,
+        "Resource link filtered out",
         "Resource link 'title | value'",
-        "Links associated with Datasets, where link name contains 'Contact us'"
-        + "\nshould not be migrated for Compendium datasets, less certain about."
-        + "\nDatasets from other sources."
+        "Links associated with Datasets, where link name contains 'contact us'"
+        + "\nor 'earlier data may be available'."
+        + "\nshould not be migrated for Compendium datasets."
         + "\n"
-        + "\nThis link needs reviewing and possibly manual removal."
+        + "\nThis link will not be migrated automatically, it's left to the operator."
+        + "\nto decide whether to add it manually post-migration."
     ),
     TAXONOMY_MAPPING_MISSING(
         FIELD_NOT_MIGRATED,


### PR DESCRIPTION
From now on all links with marker texts are filtered out, regardless
of whether they belong to Compendium or not, but only those that are
from outside Compendium are reported on.

All excluded links and attachments are logged.