### PR TITLE
[RPS-291] Indicate document type of each search result

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/DashboardPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/DashboardPage.java
@@ -40,7 +40,7 @@ public class DashboardPage extends AbstractCmsPage {
     }
 
     public List<String> getPasswordErrorMessages() {
-        WebElement errorPanel = getWebDriver().findElement(By.className("feedbackPanel"));
+        WebElement errorPanel = helper.findElement(By.className("feedbackPanel"));
         return errorPanel.findElements(By.tagName("li")).stream()
             .map(WebElement::getText)
             .collect(toList());

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/widgets/SearchResultWidget.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/widgets/SearchResultWidget.java
@@ -24,9 +24,14 @@ public class SearchResultWidget {
         return findElement("summary").getText();
     }
 
+    public String getType()  {
+        return findElement("type").getText();
+    }
+
     @Override
     public String toString() {
         return new ToStringBuilder(this)
+            .append("type", getType())
             .append("title", getTitle())
             .append("date", getDate())
             .append("summary", getSummary())

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/SearchSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/SearchSteps.java
@@ -67,6 +67,19 @@ public class SearchSteps extends AbstractSpringSteps {
         assertThat("Search results match", actualResults, contains(expectedResults));
     }
 
+    @Then("^I should see search results which also include:$")
+    public void iShouldSeeSearchResultsWhichAlsoInclude(DataTable expectedResults) throws Throwable {
+
+        List<SearchResultWidget> actualResults = searchPage.getSearchResultWidgets();
+
+        for (List<String> elementItem : expectedResults.raw()) {
+            assertTrue("Search result includes item specified",
+                actualResults.stream()
+                    .anyMatch(result->result.getType().equals(elementItem.get(0))
+                    && result.getTitle().equals(elementItem.get(1))));
+        }
+    }
+
     @Then("^I should see the search term \"(.+)\" on the results page$")
     public void iShouldSeeTheSearchTermOnTheResultsPage(String term) throws Throwable {
         assertThat("Result count ends with search term", searchPage.getResultCount(), endsWith(term));

--- a/acceptance-tests/src/test/resources/features/site/datasets.feature
+++ b/acceptance-tests/src/test/resources/features/site/datasets.feature
@@ -11,7 +11,7 @@ Feature: As a consumer I need to be able to navigate to publication data sets
             | Dataset Granularity           | NHS Trusts                                                  |
             | Dataset Geographic Coverage   | England                                                     |
             | Dataset Date Range            | 01/02/2016 to 01/07/2017                                    |
-            | Dataset Nominal Date          | 10/10/2017                                                  |
+            | Dataset Nominal Date          | 10 Oct 2017                                                 |
             | Dataset Next Publication Date | 09/07/2018                                                  |
 
     Scenario: Headers don't display for empty fields
@@ -36,10 +36,10 @@ Feature: As a consumer I need to be able to navigate to publication data sets
     Scenario: Dataset label displayed for dataset document type
         Given I navigate to the "bare minimum dataset" page
         Then I should see headers:
-            | Dataset |
+            | Data set                  |
         And I should not see headers:
-            | Publication       |
-            | Series/Collection |
+            | Publication               |
+            | Series / Collection       |
 
     Scenario: View resource links and download attachments from dataset
         Given I navigate to the "publication with datasets Dataset" data set page

--- a/acceptance-tests/src/test/resources/features/site/publication.feature
+++ b/acceptance-tests/src/test/resources/features/site/publication.feature
@@ -63,8 +63,8 @@ Feature: Ensure publication page displays required fields.
         Then I should see headers:
             | Publication               |
         And I should not see headers:
-            | Series/Collection         |
-            | Dataset                   |
+            | Series / Collection       |
+            | Data set                  |
 
     Scenario: Display multiparagraph summary
         Given I navigate to "publication with datasets" page

--- a/acceptance-tests/src/test/resources/features/site/search.feature
+++ b/acceptance-tests/src/test/resources/features/site/search.feature
@@ -110,3 +110,14 @@ Feature: Basic search
         Given I navigate to the "home" page
         When I search for " "
         Then I should see the blank search results page
+
+    Scenario: Each document type label is correctly displayed in search results
+        Given I navigate to the "home" page
+        When I search for "Bare Minimum"
+        Then I should see search results which also include:
+            | Data set              | Bare Minimum Dataset              |
+            | Publication           | Bare Minimum Publication          |
+        When I navigate to the "home" page
+        When I search for "series"
+        Then I should see search results which also include:
+            | Series / Collection   | Time Series Lorem Ipsum Dolor     |

--- a/acceptance-tests/src/test/resources/features/site/timeSeriesDisplay.feature
+++ b/acceptance-tests/src/test/resources/features/site/timeSeriesDisplay.feature
@@ -24,10 +24,10 @@ Feature: Display of publications forming a series
             | Pellentesque rutrum neque at felis cursus, scelerisque faucibus lacus ... |
             | Fusce sapien quam, dictum eget commodo vel, finibus condimentum ...       |
 
-    Scenario: Series/Collection label displayed for series document type
+    Scenario: Series / Collection label displayed for series document type
         Given I navigate to the "valid publication series" page
         Then I should see headers:
-            | Series/Collection     |
+            | Series / Collection   |
         And I should not see headers:
             | Publication           |
-            | Dataset               |
+            | Data set              |

--- a/ci-cd/Makefile
+++ b/ci-cd/Makefile
@@ -71,15 +71,15 @@ github.status.success:
 upload: $(VENV)
 	@echo "Task: upload Hippo $(VERSION) build distribution to S3 bucket"
 	aws s3 \
-		cp ../target/publication-system-$(VERSION)-cms-distribution.tar.gz \
-		s3://artefacts.ps.digital.nhs.uk/hippo_authoring/$(VERSION)/publication-system.tgz
+		cp ../target/website-$(VERSION)-cms-distribution.tar.gz \
+		s3://artefacts.ps.digital.nhs.uk/hippo_authoring/$(VERSION)/website.tgz
 	aws s3 \
-		cp ../target/publication-system-$(VERSION)-site-distribution.tar.gz \
-		s3://artefacts.ps.digital.nhs.uk/hippo_delivery/$(VERSION)/publication-system.tgz
+		cp ../target/website-$(VERSION)-site-distribution.tar.gz \
+		s3://artefacts.ps.digital.nhs.uk/hippo_delivery/$(VERSION)/website.tgz
 
 ## Upload distribution file to ondemand sftp server
 ondemand.upload:
-	echo "put ../target/publication-system-$(VERSION)-on-demand-distribution.tar.gz /uploads/dists/$(VERSION).tar.gz" \
+	echo "put ../target/website-$(VERSION)-on-demand-distribution.tar.gz /uploads/dists/$(VERSION).tar.gz" \
 		| sftp nhs@static.hosting.onehippo.com
 
 ondemand.deploy: vendor/rd
@@ -92,9 +92,9 @@ ondemand.restart: vendor/rd
 		-action restart
 
 deploy.vagrant: build
-	cp ../target/publication-system-$(VERSION)-site-distribution.tar.gz $(PS_BUILD_DIR)/.artefacts/
-	cp ../target/publication-system-$(VERSION)-cms-distribution.tar.gz $(PS_BUILD_DIR)/.artefacts/
-	cd $(PS_BUILD_DIR) && ROLE=hippo_authoring vagrant ssh -c "/home/hippo_authoring/shipit /vagrant/.artefacts/publication-system-$(VERSION)-cms-distribution.tar.gz"
+	cp ../target/website-$(VERSION)-site-distribution.tar.gz $(PS_BUILD_DIR)/.artefacts/
+	cp ../target/website-$(VERSION)-cms-distribution.tar.gz $(PS_BUILD_DIR)/.artefacts/
+	cd $(PS_BUILD_DIR) && ROLE=hippo_authoring vagrant ssh -c "/home/hippo_authoring/shipit /vagrant/.artefacts/website-$(VERSION)-cms-distribution.tar.gz"
 
 ## Create new version tag based on the nearest tag
 version.bumpup:

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/publication-system/labels.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/publication-system/labels.yaml
@@ -21,8 +21,8 @@
     - labels.series
     resourcebundle:messages:
     - Publication
-    - Dataset
-    - Series/Collection
+    - Data set
+    - Series / Collection
   /labels[2]:
     hippo:availability:
     - preview
@@ -46,8 +46,8 @@
     - labels.series
     resourcebundle:messages:
     - Publication
-    - Dataset
-    - Series/Collection
+    - Data set
+    - Series / Collection
   /labels[3]:
     hippo:availability:
     - live
@@ -71,8 +71,8 @@
     - labels.series
     resourcebundle:messages:
     - Publication
-    - Dataset
-    - Series/Collection
+    - Data set
+    - Series / Collection
   hippo:name: Labels
   jcr:mixinTypes:
   - hippo:named

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/results.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/results.ftl
@@ -1,0 +1,54 @@
+<#ftl output_format="HTML">
+<@hst.setBundle basename="publicationsystem.labels"/>
+<#assign formatRestrictableDate="uk.nhs.digital.ps.directives.RestrictableDateFormatterDirective"?new() />
+
+<#macro searchResutls items>
+    <#list items as document>
+        <#if document.class.name == "uk.nhs.digital.ps.beans.Publication">
+            <@publication item=document />
+        <#elseif document.class.name == "uk.nhs.digital.ps.beans.Series">
+            <@series item=document />
+        <#elseif document.class.name == "uk.nhs.digital.ps.beans.Dataset">
+            <@dataset item=document />
+        </#if>
+    </#list>
+</#macro>
+
+<#macro publication item>
+    <div class="push-double--bottom" data-uipath="ps.search-results.result">
+        <h3 class="flush zeta" data-uipath="ps.search-results.result.type" style="font-weight:bold"><@fmt.message key="labels.publication"/></h3>
+        <p class="flush">
+            <a href="<@hst.link hippobean=item.selfLinkBean/>" title="${item.title}" data-uipath="ps.search-results.result.title">
+                ${item.title}
+            </a>
+        </p>
+        <p class="flush zeta" data-uipath="ps.search-results.result.date"><@formatRestrictableDate value=item.nominalPublicationDate/></p>
+        <p class="flush" data-uipath="ps.search-results.result.summary"><@truncate text=item.summary.firstParagraph size="300"/></p>
+    </div>
+</#macro>
+
+<#macro series item>
+    <div class="push-double--bottom" data-uipath="ps.search-results.result">
+        <h3 class="flush zeta" data-uipath="ps.search-results.result.type" style="font-weight:bold"><@fmt.message key="labels.series"/></h3>
+        <p class="flush">
+            <a href="<@hst.link hippobean=item.selfLinkBean/>" title="${item.title}" data-uipath="ps.search-results.result.title">
+                ${item.title}
+            </a>
+        </p>
+        <p class="flush zeta" data-uipath="ps.search-results.result.date"><@formatRestrictableDate value=item.nominalPublicationDate/></p>
+        <p class="flush" data-uipath="ps.search-results.result.summary"><@truncate text=item.summary.firstParagraph size="300"/></p>
+    </div>
+</#macro>
+
+<#macro dataset item>
+    <div class="push-double--bottom" data-uipath="ps.search-results.result">
+        <h3 class="flush zeta" data-uipath="ps.search-results.result.type" style="font-weight:bold"><@fmt.message key="labels.dataset"/></h3>
+        <p class="flush">
+            <a href="<@hst.link hippobean=item.selfLinkBean/>" title="${item.title}" data-uipath="ps.search-results.result.title">
+                ${item.title}
+            </a>
+        </p>
+        <p class="flush zeta" data-uipath="ps.search-results.result.date"><@formatRestrictableDate value=item.nominalDate/></p>
+        <p class="flush" data-uipath="ps.search-results.result.summary"><@truncate text=item.summary.firstParagraph size="300"/></p>
+    </div>
+</#macro>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/searchresults.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/searchresults.ftl
@@ -1,32 +1,20 @@
 <#ftl output_format="HTML">
 <#include "../include/imports.ftl">
-<#assign formatRestrictableDate="uk.nhs.digital.ps.directives.RestrictableDateFormatterDirective"?new() />
+<#include "./macro/results.ftl">
 
 <#if pageable??>
     <div data-uipath="ps.search-results" data-totalresults="${pageable.total}">
         <#if pageable.total == 0>
             <h1 data-uipath="ps.search-results.count">No results for: ${query}</h1>
         <#else>
-
             <h1 data-uipath="ps.search-results.count">${pageable.total} result<#if pageable.total gt 1>s</#if> found</h1>
             <h4 class="push-double--bottom">Displaying  ${pageable.startOffset +1 } to ${pageable.endOffset} of ${pageable.total} results for '${query}'</h4>
 
-            <#list pageable.items as publication>
-                <div class="push-double--bottom" data-uipath="ps.search-results.result">
-                    <p class="flush">
-                        <a href="<@hst.link hippobean=publication.selfLinkBean/>" title="${publication.title}" data-uipath="ps.search-results.result.title">
-                            ${publication.title}
-                        </a>
-                    </p>
-                    <p class="flush zeta" data-uipath="ps.search-results.result.date"><@formatRestrictableDate value=publication.nominalPublicationDate/></p>
-                    <p class="flush" data-uipath="ps.search-results.result.summary"><@truncate text=publication.summary.firstParagraph size="300"/></p>
-                </div>
-            </#list>
+            <@searchResutls items=pageable.items/>
 
             <#if cparam.showPagination>
                 <#include "../include/pagination.ftl">
             </#if>
-
         </#if>
     </div>
 <#else>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/dataset.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/dataset.ftl
@@ -2,6 +2,7 @@
 <#include "../include/imports.ftl">
 <#include "./macro/structured-text.ftl">
 <@hst.setBundle basename="publicationsystem.headers,publicationsystem.labels"/>
+<#assign formatRestrictableDate="uk.nhs.digital.ps.directives.RestrictableDateFormatterDirective"?new() />
 
 <#assign dateFormat="dd/MM/yyyy"/>
 <#assign formatFileSize="uk.nhs.digital.ps.directives.FileSizeFormatterDirective"?new() >
@@ -68,7 +69,7 @@
                     <dl class="media__body">
                         <dt><@fmt.message key="headers.publication-date"/></dt>
                         <dd data-uipath="ps.dataset.nominal-date">
-                            ${dataset.nominalDate.time?string[dateFormat]}
+                            <@formatRestrictableDate value=dataset.nominalDate/>
                         </dd>
                     </dl>
                 </div>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
@@ -42,7 +42,9 @@
             <h3 class="flush--bottom push-half--top"><@fmt.message key="labels.publication"/></h3>
 
             <h3 data-uipath="ps.publication.information-types" class="flush--bottom push-half--top">
-                <#list publication.informationType as type><#if type?index != 0>, </#if>${type}</#list>
+                <#if publication.informationType?has_content>
+                    <#list publication.informationType as type><#if type?index != 0>, </#if>${type}</#list>
+                </#if>
             </h3>
 
             <h1 class="layout-5-6" data-uipath="ps.document.title">${publication.title}</h1>

--- a/site/src/main/java/uk/nhs/digital/ps/beans/BaseDocument.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/BaseDocument.java
@@ -4,10 +4,15 @@ import org.hippoecm.hst.content.beans.Node;
 import org.hippoecm.hst.content.beans.standard.HippoBean;
 import org.hippoecm.hst.content.beans.standard.HippoDocument;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Calendar;
 import java.util.List;
 
 @Node(jcrType = "publicationsystem:basedocument")
 public class BaseDocument extends HippoDocument {
+
+    private static final int WEEKS_TO_CUTOFF = 8;
 
     /**
      * <p>
@@ -39,4 +44,22 @@ public class BaseDocument extends HippoDocument {
     protected void assertPropertyPermitted(String propertyName) {
         // To be overwritten by subclasses for specific implementation
     }
+
+    /**
+     * Converts given {@linkplain Calendar} to {@linkplain RestrictableDate}.
+     */
+    protected RestrictableDate nominalPublicationDateCalendarToRestrictedDate(final Calendar calendar) {
+
+        final LocalDate nominalPublicationDate = LocalDateTime.ofInstant(
+            calendar.toInstant(),
+            calendar.getTimeZone().toZoneId()
+        ).toLocalDate();
+
+        final LocalDate cutOffPoint = LocalDate.now().plusWeeks(WEEKS_TO_CUTOFF);
+
+        return nominalPublicationDate.isAfter(cutOffPoint)
+            ? RestrictableDate.restrictedDateFrom(nominalPublicationDate)
+            : RestrictableDate.fullDateFrom(nominalPublicationDate);
+    }
+
 }

--- a/site/src/main/java/uk/nhs/digital/ps/beans/Dataset.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/Dataset.java
@@ -8,13 +8,13 @@ import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerat
 import uk.nhs.digital.ps.beans.structuredText.StructuredText;
 import uk.nhs.digital.ps.site.exceptions.DataRestrictionViolationException;
 
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 
 @HippoEssentialsGenerated(internalName = "publicationsystem:dataset")
 @Node(jcrType = "publicationsystem:dataset")
 public class Dataset extends BaseDocument {
+
+    private RestrictableDate nominalDate;
 
     private static final Collection<String> propertiesPermittedWhenUpcoming = asList(
         PropertyKeys.TITLE,
@@ -33,9 +33,14 @@ public class Dataset extends BaseDocument {
         return new StructuredText(getProperty(PropertyKeys.SUMMARY, ""));
     }
 
-    @HippoEssentialsGenerated(internalName = PropertyKeys.NOMINAL_DATE)
-    public Calendar getNominalDate() {
-        return getPropertyIfPermitted(PropertyKeys.NOMINAL_DATE);
+    public RestrictableDate getNominalDate() {
+        if (nominalDate == null) {
+            nominalDate = Optional.ofNullable(getProperty(PropertyKeys.NOMINAL_DATE))
+                .map(object -> (Calendar)object)
+                .map(this::nominalPublicationDateCalendarToRestrictedDate)
+                .orElse(null);
+        }
+        return nominalDate;
     }
 
     @HippoEssentialsGenerated(internalName = PropertyKeys.NEXT_PUBLICATION_DATE)

--- a/site/src/main/java/uk/nhs/digital/ps/beans/Publication.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/Publication.java
@@ -16,8 +16,6 @@ import org.slf4j.LoggerFactory;
 import uk.nhs.digital.ps.beans.structuredText.StructuredText;
 import uk.nhs.digital.ps.site.exceptions.DataRestrictionViolationException;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.*;
 
 @HippoEssentialsGenerated(internalName = "publicationsystem:publication")
@@ -25,8 +23,6 @@ import java.util.*;
 public class Publication extends BaseDocument {
 
     private static final Logger log = LoggerFactory.getLogger(Publication.class);
-
-    private static final int WEEKS_TO_CUTOFF = 8;
 
     private static final Collection<String> propertiesPermittedWhenUpcoming = asList(
         PropertyKeys.TITLE,
@@ -213,23 +209,6 @@ public class Publication extends BaseDocument {
     private boolean isPropertyAlwaysPermitted(final String propertyKey) {
         return PropertyKeys.PARENT_BEAN.equals(propertyKey)
             || PropertyKeys.PUBLICLY_ACCESSIBLE.equals(propertyKey);
-    }
-
-    /**
-     * Converts given {@linkplain Calendar} to {@linkplain RestrictableDate}.
-     */
-    private RestrictableDate nominalPublicationDateCalendarToRestrictedDate(final Calendar calendar) {
-
-        final LocalDate nominalPublicationDate = LocalDateTime.ofInstant(
-                calendar.toInstant(),
-                calendar.getTimeZone().toZoneId()
-            ).toLocalDate();
-
-        final LocalDate cutOffPoint = LocalDate.now().plusWeeks(WEEKS_TO_CUTOFF);
-
-        return nominalPublicationDate.isAfter(cutOffPoint)
-            ? RestrictableDate.restrictedDateFrom(nominalPublicationDate)
-            : RestrictableDate.fullDateFrom(nominalPublicationDate);
     }
 
     interface PropertyKeys {


### PR DESCRIPTION
Also includes refactoring of search result templates to use a separate
macro for each document type.  Fixed issue where dataset nominal
date was not being displayed on search results page. Includes small
change to password rules acceptance test to try resolve random fails.
Update to Makefile to replace publication-system with website.