### PR TITLE
[RPS-316] CI migration: update ASCOF to follow CCG structure

### DIFF
--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/TaxonomyMigrator.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/TaxonomyMigrator.java
@@ -31,6 +31,8 @@ public class TaxonomyMigrator {
     private static final String TAXONOMY_JCR_PATH = "/content/taxonomies/publication_taxonomy";
     private static final String TAXONOMY_MAPPING_COLUMN_PREFIX = "Leaf";
     private static final String P_CODE_COLUMN = "P Code";
+    private static final String TAXONOMY_DEFINITION_SHEET_NAME = "Taxonomy with structure";
+    private static final String TAXONOMY_MAPPING_SHEET_NAME = "Examples";
 
     private MigrationReport migrationReport;
     private ExecutionParameters executionParameters;
@@ -91,7 +93,7 @@ public class TaxonomyMigrator {
             return;
         }
 
-        Iterator<Row> rowIterator = getRowIterator(taxonomyMappingImportPath);
+        Iterator<Row> rowIterator = getRowIterator(taxonomyMappingImportPath, TAXONOMY_MAPPING_SHEET_NAME);
 
         Row headerRow = rowIterator.next();
         List<Integer> pCodeCols = streamRow(headerRow)
@@ -133,7 +135,7 @@ public class TaxonomyMigrator {
 
     private void readTaxonomyDefinition() {
 
-        Iterator<Row> rowIterator = getRowIterator(executionParameters.getTaxonomyDefinitionImportPath());
+        Iterator<Row> rowIterator = getRowIterator(executionParameters.getTaxonomyDefinitionImportPath(), TAXONOMY_DEFINITION_SHEET_NAME);
 
         // Which column headers are for the taxonomy terms that we are interested in
         Row headerRow = rowIterator.next();
@@ -200,7 +202,7 @@ public class TaxonomyMigrator {
         return StreamSupport.stream(((Iterable<Cell>) row::cellIterator).spliterator(), false);
     }
 
-    private static Iterator<Row> getRowIterator(Path path) {
+    private static Iterator<Row> getRowIterator(Path path, final String sheetName) {
         XSSFWorkbook workbook;
         try {
             workbook = new XSSFWorkbook(path.toString());
@@ -208,7 +210,13 @@ public class TaxonomyMigrator {
             throw new RuntimeException(e);
         }
 
-        XSSFSheet sheet = workbook.getSheetAt(0);
+        XSSFSheet sheet = workbook.getSheet(sheetName);
+
+        if (sheet == null) {
+            throw new RuntimeException(sheetName + " not found in " + path);
+        }
+
+
         return sheet.rowIterator();
     }
 }

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/about/accessibility-help.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/about/accessibility-help.yaml
@@ -77,7 +77,6 @@
       jcr:primaryType: hippostd:html
     common:Title: Accessibility help
     hippo:availability: []
-    hippostd:holder: admin
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-12-22T15:05:58.519Z


### PR DESCRIPTION
[RPS-316] CI migration: update ASCOF to follow CCG structure

The Migrator now applies folder structure to Social Care/ASCOF CI
content following the same pattern as that used for CCG.

Also:
- TaxonomyMigrator was updated to handle the latest format of Taxonomy
  definition spreadsheet.
- Accessibility page has been 'unflaged' as being held by admin
  so that it no longer opens by default when admin logs into CMS.