### PR TITLE
[RPS-317] Create CI Hub and landing pages

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ContentPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ContentPage.java
@@ -370,6 +370,7 @@ public class ContentPage extends AbstractCmsPage {
     }
 
     public void openDocumentForEdit(String name) {
+        openContentTab();
         navigateToDocument(name);
         findEdit().click();
         isDocumentEditScreenOpen();

--- a/acceptance-tests/src/test/resources/features/site/clinicalIndicatorsHub.feature
+++ b/acceptance-tests/src/test/resources/features/site/clinicalIndicatorsHub.feature
@@ -1,0 +1,40 @@
+Feature: Clinical Indicator hub page and sub sections
+
+    As a site user I should see a summary page of all the Clinical Indicator
+    sections so I can navigate to each one individually to find out more.
+
+    Scenario: Clinical Indicators hub page
+        Given I navigate to the "home" page
+        Then I should see a page titled "Clinical Indicators"
+
+    Scenario: CI landing pages - CCG Outcomes (and back link)
+        Given I navigate to the "home" page
+        When I click on link "Clinical Commissioning Group Outcomes Indicator Set"
+        Then I should see page titled "CCG Outcomes - Indicator Set"
+        When I click on link "Back to Clinical Indicators"
+        Then I should see a page titled "Clinical Indicators"
+
+    Scenario: CI landing pages - Compendium
+        Given I navigate to the "home" page
+        When I click on link "Compendium of Population Health Indicators"
+        Then I should see page titled "Compendium of Population Health Indicators"
+
+    Scenario: CI landing pages - Social Care
+        Given I navigate to the "home" page
+        When I click on link "Social Care"
+        Then I should see page titled "Social Care"
+
+    Scenario: CI landing pages - NHS Outcomes Framework
+        Given I navigate to the "home" page
+        When I click on link "NHS Outcomes Framework"
+        Then I should see page titled "NHS Outcomes Framework"
+
+    Scenario: CI landing pages - SHMI
+        Given I navigate to the "home" page
+        When I click on link "Summary Hospital-level Mortality Indicator (SHMI)"
+        Then I should see page titled "Summary Hospital-level Mortality Indicator (SHMI)"
+
+    Scenario: CI landing pages - POMI
+        Given I navigate to the "home" page
+        When I click on link "Patient Online Management Information (POMI)"
+        Then I should see page titled "Patient Online Management Information (POMI)"

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/pages/cihub.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/pages/cihub.yaml
@@ -1,0 +1,10 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/common/hst:pages/cihub:
+      /main:
+        hst:componentclassname: uk.nhs.digital.ps.components.CiHubComponent
+        hst:template: cihub
+        jcr:primaryType: hst:component
+      hst:referencecomponent: hst:abstractpages/basepage
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
@@ -18,6 +18,10 @@ definitions:
           hst:componentconfigurationid: hst:pages/404
           jcr:primaryType: hst:sitemapitem
         jcr:primaryType: hst:sitemapitem
+      /root:
+        hst:componentconfigurationid: hst:pages/cihub
+        hst:relativecontentpath: publication-system/ci-hub/main-sections
+        jcr:primaryType: hst:sitemapitem
       /search:
         /_any_:
           hst:componentconfigurationid: hst:pages/search

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates.yaml
@@ -11,6 +11,9 @@ definitions:
       /base:
         hst:renderpath: webfile:/freemarker/common/base-layout.ftl
         jcr:primaryType: hst:template
+      /cihub:
+        hst:renderpath: webfile:/freemarker/publicationsystem/cihub.ftl
+        jcr:primaryType: hst:template
       /facets:
         hst:renderpath: webfile:/freemarker/common/facets.ftl
         jcr:primaryType: hst:template

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/pages/cilanding.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/pages/cilanding.yaml
@@ -1,0 +1,10 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/publicationsystem/hst:pages/cilanding:
+      /main:
+        hst:componentclassname: uk.nhs.digital.ps.components.CiLandingComponent
+        hst:template: cilanding
+        jcr:primaryType: hst:component
+      hst:referencecomponent: hst:abstractpages/basepage
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/sitemap.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/sitemap.yaml
@@ -16,6 +16,13 @@ definitions:
         - hst:pages/series
         hst:relativecontentpath: ${1}
         jcr:primaryType: hst:sitemapitem
+      /ci-hub:
+        /_any_:
+          hst:componentconfigurationid: hst:pages/cilanding
+          hst:relativecontentpath: ci-hub/${1}
+          jcr:primaryType: hst:sitemapitem
+        hst:relativecontentpath: ci-hub
+        jcr:primaryType: hst:sitemapitem
       /root:
         hst:componentconfigurationid: hst:pages/home
         jcr:primaryType: hst:sitemapitem

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/templates.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/publicationsystem/templates.yaml
@@ -2,6 +2,9 @@
 definitions:
   config:
     /hst:hst/hst:configurations/publicationsystem/hst:templates:
+      /cilanding:
+        hst:renderpath: webfile:/freemarker/publicationsystem/cilanding.ftl
+        jcr:primaryType: hst:template
       /dataset:
         hst:renderpath: webfile:/freemarker/publicationsystem/dataset.ftl
         jcr:primaryType: hst:template

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem.cnd
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem.cnd
@@ -2,6 +2,7 @@
 <'hippo'='http://www.onehippo.org/jcr/hippo/nt/2.0.4'>
 <'hippostd'='http://www.onehippo.org/jcr/hippostd/nt/2.0'>
 <'hippostdpubwf'='http://www.onehippo.org/jcr/hippostdpubwf/nt/1.0'>
+<'common'='http://digital.nhs.uk/jcr/common/nt/1.0'>
 <'hippotranslation'='http://www.onehippo.org/jcr/hippotranslation/nt/1.0'>
 
 [publicationsystem:attachment] > hippo:compound, hippostd:relaxed
@@ -10,6 +11,15 @@
 [publicationsystem:basedocument] > hippo:document, hippostd:publishableSummary, hippostdpubwf:document
   orderable
   - common:searchable (boolean) = 'true' autocreated
+
+[publicationsystem:cihub] > hippostd:relaxed, hippotranslation:translated, publicationsystem:basedocument
+  orderable
+
+[publicationsystem:cihublink] > hippo:compound, hippostd:relaxed
+  orderable
+
+[publicationsystem:cilanding] > hippostd:relaxed, hippotranslation:translated, publicationsystem:basedocument
+  orderable
 
 [publicationsystem:dataset] > hippostd:relaxed, hippotranslation:translated, publicationsystem:basedocument
   orderable

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/cihub.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/cihub.yaml
@@ -1,0 +1,114 @@
+---
+definitions:
+  config:
+    /hippo:namespaces/publicationsystem/cihub:
+      /editor:templates:
+        /_default_:
+          jcr:primaryType: frontend:plugincluster
+          frontend:properties:
+          - mode
+          frontend:references:
+          - wicket.model
+          - model.compareTo
+          - engine
+          - validator.id
+          frontend:services:
+          - wicket.id
+          - validator.id
+          /root:
+            item: ${cluster.id}.field
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+          /title:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Title
+            field: title
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /summary:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Summary
+            field: summary
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /cihublink:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Clinical Indicator hub links
+            field: cihublink
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.field
+        jcr:primaryType: editor:templateset
+      /hipposysedit:nodetype:
+        /hipposysedit:nodetype:
+          /cihublink:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: true
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:cihublink
+            hipposysedit:primary: false
+            hipposysedit:type: publicationsystem:cihublink
+            jcr:primaryType: hipposysedit:field
+          /summary:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:summary
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            hipposysedit:validators:
+            - non-empty
+            - required
+            jcr:primaryType: hipposysedit:field
+          /title:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:title
+            hipposysedit:primary: false
+            hipposysedit:type: String
+            hipposysedit:validators:
+            - non-empty
+            - required
+            jcr:primaryType: hipposysedit:field
+          hipposysedit:node: true
+          hipposysedit:supertype:
+          - publicationsystem:basedocument
+          - hippostd:relaxed
+          - hippotranslation:translated
+          hipposysedit:uri: http://digital.nhs.uk/jcr/publicationsystem/nt/1.0
+          jcr:mixinTypes:
+          - mix:referenceable
+          - hipposysedit:remodel
+          jcr:primaryType: hipposysedit:nodetype
+        jcr:mixinTypes:
+        - mix:referenceable
+        jcr:primaryType: hippo:handle
+      /hipposysedit:prototypes:
+        /hipposysedit:prototype:
+          common:searchable: true
+          hippostd:holder: holder
+          hippostd:state: draft
+          hippostdpubwf:createdBy: ''
+          hippostdpubwf:creationDate: 2018-01-23T11:28:33.095Z
+          hippostdpubwf:lastModificationDate: 2018-01-23T11:28:33.094Z
+          hippostdpubwf:lastModifiedBy: ''
+          hippotranslation:id: document-type-locale-id
+          hippotranslation:locale: document-type-locale
+          jcr:mixinTypes:
+          - mix:referenceable
+          jcr:primaryType: publicationsystem:cihub
+          publicationsystem:summary: ''
+          publicationsystem:title: ''
+        jcr:primaryType: hipposysedit:prototypeset
+      jcr:mixinTypes:
+      - editor:editable
+      - mix:referenceable
+      jcr:primaryType: hipposysedit:templatetype

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/cihublink.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/cihublink.yaml
@@ -1,0 +1,110 @@
+---
+definitions:
+  config:
+    /hippo:namespaces/publicationsystem/cihublink:
+      /editor:templates:
+        /_default_:
+          jcr:primaryType: frontend:plugincluster
+          frontend:properties:
+          - mode
+          frontend:references:
+          - wicket.model
+          - model.compareTo
+          - engine
+          - validator.id
+          frontend:services:
+          - wicket.id
+          - validator.id
+          /root:
+            item: ${cluster.id}.field
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+          /title:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Title
+            field: title
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /summary:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Summary
+            field: summary
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /pagelink:
+            /cluster.options:
+              base.path: /content/documents/corporate-website/publication-system/ci-hub
+              jcr:primaryType: frontend:pluginconfig
+              nodetypes: []
+            caption: Landing page link
+            field: pagelink
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.field
+        jcr:primaryType: editor:templateset
+      /hipposysedit:nodetype:
+        /hipposysedit:nodetype:
+          /pagelink:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:pagelink
+            hipposysedit:primary: false
+            hipposysedit:type: hippo:mirror
+            hipposysedit:validators:
+            - required
+            jcr:primaryType: hipposysedit:field
+          /summary:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:summary
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            hipposysedit:validators:
+            - non-empty
+            - required
+            jcr:primaryType: hipposysedit:field
+          /title:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:title
+            hipposysedit:primary: false
+            hipposysedit:type: String
+            hipposysedit:validators:
+            - non-empty
+            - required
+            jcr:primaryType: hipposysedit:field
+          hipposysedit:node: true
+          hipposysedit:supertype:
+          - hippo:compound
+          - hippostd:relaxed
+          hipposysedit:uri: http://digital.nhs.uk/jcr/publicationsystem/nt/1.0
+          jcr:mixinTypes:
+          - mix:referenceable
+          - hipposysedit:remodel
+          jcr:primaryType: hipposysedit:nodetype
+          jcr:uuid: 90a7ac4d-ab98-4843-b445-cd01aaec8de1
+        jcr:mixinTypes:
+        - mix:referenceable
+        jcr:primaryType: hippo:handle
+        jcr:uuid: 5231d738-842a-4b14-87e1-1612da756582
+      /hipposysedit:prototypes:
+        /hipposysedit:prototype:
+          /publicationsystem:pagelink:
+            hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+            jcr:primaryType: hippo:mirror
+          jcr:primaryType: publicationsystem:cihublink
+          publicationsystem:summary: ''
+          publicationsystem:title: ''
+        jcr:primaryType: hipposysedit:prototypeset
+      jcr:mixinTypes:
+      - editor:editable
+      - mix:referenceable
+      jcr:primaryType: hipposysedit:templatetype

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/cilanding.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/cilanding.yaml
@@ -1,0 +1,110 @@
+---
+definitions:
+  config:
+    /hippo:namespaces/publicationsystem/cilanding:
+      /editor:templates:
+        /_default_:
+          jcr:primaryType: frontend:plugincluster
+          frontend:properties:
+          - mode
+          frontend:references:
+          - wicket.model
+          - model.compareTo
+          - engine
+          - validator.id
+          frontend:services:
+          - wicket.id
+          - validator.id
+          /root:
+            item: ${cluster.id}.field
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+          /title:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Title
+            field: title
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /content:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Content
+            field: content
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /resourceLinks:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Resource Links
+            field: resourceLinks
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.field
+        jcr:primaryType: editor:templateset
+      /hipposysedit:nodetype:
+        /hipposysedit:nodetype:
+          /content:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:content
+            hipposysedit:primary: false
+            hipposysedit:type: hippostd:html
+            jcr:primaryType: hipposysedit:field
+          /resourceLinks:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: true
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:resourceLinks
+            hipposysedit:primary: false
+            hipposysedit:type: publicationsystem:relatedlink
+            jcr:primaryType: hipposysedit:field
+          /title:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:title
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
+          hipposysedit:node: true
+          hipposysedit:supertype:
+          - publicationsystem:basedocument
+          - hippostd:relaxed
+          - hippotranslation:translated
+          hipposysedit:uri: http://digital.nhs.uk/jcr/publicationsystem/nt/1.0
+          jcr:mixinTypes:
+          - mix:referenceable
+          - hipposysedit:remodel
+          jcr:primaryType: hipposysedit:nodetype
+        jcr:mixinTypes:
+        - mix:referenceable
+        jcr:primaryType: hippo:handle
+      /hipposysedit:prototypes:
+        /hipposysedit:prototype:
+          /publicationsystem:content:
+            hippostd:content: ''
+            jcr:primaryType: hippostd:html
+          common:searchable: true
+          hippostd:holder: holder
+          hippostd:state: draft
+          hippostdpubwf:createdBy: ''
+          hippostdpubwf:creationDate: 2018-01-23T12:21:21.974Z
+          hippostdpubwf:lastModificationDate: 2018-01-23T12:21:21.974Z
+          hippostdpubwf:lastModifiedBy: ''
+          hippotranslation:id: document-type-locale-id
+          hippotranslation:locale: document-type-locale
+          jcr:mixinTypes:
+          - mix:referenceable
+          jcr:primaryType: publicationsystem:cilanding
+          publicationsystem:title: ''
+        jcr:primaryType: hipposysedit:prototypeset
+      jcr:mixinTypes:
+      - editor:editable
+      - mix:referenceable
+      jcr:primaryType: hipposysedit:templatetype

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/publication-system/headers.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/publication-system/headers.yaml
@@ -22,6 +22,9 @@
     - ''
     - ''
     - ''
+    - ''
+    - ''
+    - ''
     resourcebundle:id: publicationsystem.headers
     resourcebundle:keys:
     - headers.summary
@@ -35,6 +38,9 @@
     - headers.geographical-granularity
     - headers.publication-date
     - headers.next-publication-date
+    - headers.ci-hub-overview
+    - headers.ci-landing-actions
+    - headers.ci-landing-resources
     resourcebundle:messages:
     - Summary
     - Key Facts
@@ -47,6 +53,9 @@
     - 'Geographical Granularity:'
     - 'Publication Date:'
     - 'Next Publication Date:'
+    - Overview
+    - Actions
+    - Resources
   /headers[2]:
     hippo:availability:
     - preview
@@ -71,6 +80,9 @@
     - ''
     - ''
     - ''
+    - ''
+    - ''
+    - ''
     resourcebundle:id: publicationsystem.headers
     resourcebundle:keys:
     - headers.summary
@@ -84,6 +96,9 @@
     - headers.geographical-granularity
     - headers.publication-date
     - headers.next-publication-date
+    - headers.ci-hub-overview
+    - headers.ci-landing-actions
+    - headers.ci-landing-resources
     resourcebundle:messages:
     - Summary
     - Key Facts
@@ -96,6 +111,9 @@
     - 'Geographical Granularity:'
     - 'Publication Date:'
     - 'Next Publication Date:'
+    - Overview
+    - Actions
+    - Resources
   /headers[3]:
     hippo:availability:
     - live
@@ -120,6 +138,9 @@
     - ''
     - ''
     - ''
+    - ''
+    - ''
+    - ''
     resourcebundle:id: publicationsystem.headers
     resourcebundle:keys:
     - headers.summary
@@ -133,6 +154,9 @@
     - headers.geographical-granularity
     - headers.publication-date
     - headers.next-publication-date
+    - headers.ci-hub-overview
+    - headers.ci-landing-actions
+    - headers.ci-landing-resources
     resourcebundle:messages:
     - Summary
     - Key Facts
@@ -145,6 +169,9 @@
     - 'Geographical Granularity:'
     - 'Publication Date:'
     - 'Next Publication Date:'
+    - Overview
+    - Actions
+    - Resources
   hippo:name: Headers
   jcr:mixinTypes:
   - hippo:named

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/ci-hub.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/ci-hub.yaml
@@ -1,0 +1,1639 @@
+---
+/content/documents/corporate-website/publication-system/ci-hub:
+  /ccg-outcomes:
+    /ccg-outcomes[1]:
+      /publicationsystem:content:
+        hippostd:content: |-
+          <p>The Clinical Commissioning Group Outcomes Indicator Set (CCG OIS) is an integral part of NHS England’s systematic approach to quality improvement. Its primary aim is to support and enable CCGs and health and wellbeing partners to plan for health improvement by providing information for measuring and benchmarking outcomes of services commissioned by CCGs. It is also intended to provide clear, comparative information for patients and the public about the quality of health services commissioned by CCGs and the associated health outcomes.</p>
+
+          <p>&nbsp;</p>
+
+          <p>The CCG Outcomes Indicator Set uses the registered patient population of England as its subject population, and where standardisation is required, the Office for National Statistics mid-year population estimates for England. All indicators are reported at CCG and National level, where 'National' represents the sum total of patients registered with a GP in England.</p>
+
+          <p>The NHS Outcomes Framework uses the ONS mid-year population estimates for England as its subject population, and where standardisation is required the European Standard Population is generally used. All indicators are reported at England level, and are broken down, where possible, by a combination of Age, Lower tier local authority, Upper tier local authority, Region, Religion, Ethnicity, Deprivation decile, Sexual orientation, Gender and Condition.</p>
+
+          <p>The indicators are structured around the five NHS Outcomes Framework domains.</p>
+
+          <ul style="list-style-type:disc">
+           <li><strong>Domain 1, Preventing people from dying prematurely</strong>&nbsp;<br />
+           This domain captures how successful the NHS is in reducing the number of avoidable deaths.</li>
+           <li><strong>Domain 2, Enhancing quality of life for people with long-term conditions</strong>&nbsp;<br />
+           This domain captures how successfully the NHS is supporting people with long-term conditions to live as normal a life as possible.</li>
+           <li><strong>Domain 3, Helping people to recover from episodes of ill health or following injury</strong>&nbsp;<br />
+           This domain captures how people recover from ill health or injury and wherever possible how it can be prevented.</li>
+           <li><strong>Domain 4, Ensuring that people have a positive experience of care</strong>&nbsp;<br />
+           This domain looks at the importance of providing a positive experience of care for patients, service users and carers.</li>
+           <li><strong>Domain 5, Treating and caring for people in a safe environment and protecting them from avoidable harm</strong>&nbsp;<br />
+           This domain explores patient safety and its importance in terms of quality of care to deliver better health outcomes.</li>
+          </ul>
+
+          <p><strong>Further information</strong>&nbsp;</p>
+
+          <p>CCG Outcomes Indicator Set on the NHS England website:</p>
+
+          <p><a href="http://www.england.nhs.uk/ccg-ois/" target="_blank">http://www.england.nhs.uk/ccg-ois/</a></p>
+        jcr:primaryType: hippostd:html
+      /publicationsystem:resourceLinks:
+        jcr:primaryType: publicationsystem:relatedlink
+        publicationsystem:linkText: CCG Outcomes Indicator Set on the NHS England
+          website
+        publicationsystem:linkUrl: http://www.england.nhs.uk/ccg-ois/
+      common:searchable: true
+      hippo:availability: []
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T14:54:36.279Z
+      hippostdpubwf:lastModificationDate: 2018-01-24T23:19:37.443Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: be1317d6-5605-40f4-a2f3-1195643d6549
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:cilanding
+      jcr:uuid: 2a907018-5360-4a02-99a0-9264b72d828f
+      publicationsystem:title: CCG Outcomes - Indicator Set
+    /ccg-outcomes[2]:
+      /publicationsystem:content:
+        hippostd:content: |-
+          <p>The Clinical Commissioning Group Outcomes Indicator Set (CCG OIS) is an integral part of NHS England’s systematic approach to quality improvement. Its primary aim is to support and enable CCGs and health and wellbeing partners to plan for health improvement by providing information for measuring and benchmarking outcomes of services commissioned by CCGs. It is also intended to provide clear, comparative information for patients and the public about the quality of health services commissioned by CCGs and the associated health outcomes.</p>
+
+          <p>&nbsp;</p>
+
+          <p>The CCG Outcomes Indicator Set uses the registered patient population of England as its subject population, and where standardisation is required, the Office for National Statistics mid-year population estimates for England. All indicators are reported at CCG and National level, where 'National' represents the sum total of patients registered with a GP in England.</p>
+
+          <p>The NHS Outcomes Framework uses the ONS mid-year population estimates for England as its subject population, and where standardisation is required the European Standard Population is generally used. All indicators are reported at England level, and are broken down, where possible, by a combination of Age, Lower tier local authority, Upper tier local authority, Region, Religion, Ethnicity, Deprivation decile, Sexual orientation, Gender and Condition.</p>
+
+          <p>The indicators are structured around the five NHS Outcomes Framework domains.</p>
+
+          <ul style="list-style-type:disc">
+           <li><strong>Domain 1, Preventing people from dying prematurely</strong>&nbsp;<br />
+           This domain captures how successful the NHS is in reducing the number of avoidable deaths.</li>
+           <li><strong>Domain 2, Enhancing quality of life for people with long-term conditions</strong>&nbsp;<br />
+           This domain captures how successfully the NHS is supporting people with long-term conditions to live as normal a life as possible.</li>
+           <li><strong>Domain 3, Helping people to recover from episodes of ill health or following injury</strong>&nbsp;<br />
+           This domain captures how people recover from ill health or injury and wherever possible how it can be prevented.</li>
+           <li><strong>Domain 4, Ensuring that people have a positive experience of care</strong>&nbsp;<br />
+           This domain looks at the importance of providing a positive experience of care for patients, service users and carers.</li>
+           <li><strong>Domain 5, Treating and caring for people in a safe environment and protecting them from avoidable harm</strong>&nbsp;<br />
+           This domain explores patient safety and its importance in terms of quality of care to deliver better health outcomes.</li>
+          </ul>
+
+          <p><strong>Further information</strong>&nbsp;</p>
+
+          <p>CCG Outcomes Indicator Set on the NHS England website:</p>
+
+          <p><a href="http://www.england.nhs.uk/ccg-ois/" target="_blank">http://www.england.nhs.uk/ccg-ois/</a></p>
+        jcr:primaryType: hippostd:html
+      /publicationsystem:resourceLinks:
+        jcr:primaryType: publicationsystem:relatedlink
+        publicationsystem:linkText: CCG Outcomes Indicator Set on the NHS England
+          website
+        publicationsystem:linkUrl: http://www.england.nhs.uk/ccg-ois/
+      common:searchable: true
+      hippo:availability:
+      - preview
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T14:54:36.279Z
+      hippostdpubwf:lastModificationDate: 2018-01-24T23:20:22.483Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: be1317d6-5605-40f4-a2f3-1195643d6549
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      - mix:versionable
+      jcr:primaryType: publicationsystem:cilanding
+      jcr:uuid: dc137559-ee4b-4351-98a4-83eb9629411e
+      publicationsystem:title: CCG Outcomes - Indicator Set
+    /ccg-outcomes[3]:
+      /publicationsystem:content:
+        hippostd:content: |-
+          <p>The Clinical Commissioning Group Outcomes Indicator Set (CCG OIS) is an integral part of NHS England’s systematic approach to quality improvement. Its primary aim is to support and enable CCGs and health and wellbeing partners to plan for health improvement by providing information for measuring and benchmarking outcomes of services commissioned by CCGs. It is also intended to provide clear, comparative information for patients and the public about the quality of health services commissioned by CCGs and the associated health outcomes.</p>
+
+          <p>&nbsp;</p>
+
+          <p>The CCG Outcomes Indicator Set uses the registered patient population of England as its subject population, and where standardisation is required, the Office for National Statistics mid-year population estimates for England. All indicators are reported at CCG and National level, where 'National' represents the sum total of patients registered with a GP in England.</p>
+
+          <p>The NHS Outcomes Framework uses the ONS mid-year population estimates for England as its subject population, and where standardisation is required the European Standard Population is generally used. All indicators are reported at England level, and are broken down, where possible, by a combination of Age, Lower tier local authority, Upper tier local authority, Region, Religion, Ethnicity, Deprivation decile, Sexual orientation, Gender and Condition.</p>
+
+          <p>The indicators are structured around the five NHS Outcomes Framework domains.</p>
+
+          <ul style="list-style-type:disc">
+           <li><strong>Domain 1, Preventing people from dying prematurely</strong>&nbsp;<br />
+           This domain captures how successful the NHS is in reducing the number of avoidable deaths.</li>
+           <li><strong>Domain 2, Enhancing quality of life for people with long-term conditions</strong>&nbsp;<br />
+           This domain captures how successfully the NHS is supporting people with long-term conditions to live as normal a life as possible.</li>
+           <li><strong>Domain 3, Helping people to recover from episodes of ill health or following injury</strong>&nbsp;<br />
+           This domain captures how people recover from ill health or injury and wherever possible how it can be prevented.</li>
+           <li><strong>Domain 4, Ensuring that people have a positive experience of care</strong>&nbsp;<br />
+           This domain looks at the importance of providing a positive experience of care for patients, service users and carers.</li>
+           <li><strong>Domain 5, Treating and caring for people in a safe environment and protecting them from avoidable harm</strong>&nbsp;<br />
+           This domain explores patient safety and its importance in terms of quality of care to deliver better health outcomes.</li>
+          </ul>
+
+          <p><strong>Further information</strong>&nbsp;</p>
+
+          <p>CCG Outcomes Indicator Set on the NHS England website:</p>
+
+          <p><a href="http://www.england.nhs.uk/ccg-ois/" target="_blank">http://www.england.nhs.uk/ccg-ois/</a></p>
+        jcr:primaryType: hippostd:html
+      /publicationsystem:resourceLinks:
+        jcr:primaryType: publicationsystem:relatedlink
+        publicationsystem:linkText: CCG Outcomes Indicator Set on the NHS England
+          website
+        publicationsystem:linkUrl: http://www.england.nhs.uk/ccg-ois/
+      common:searchable: true
+      hippo:availability:
+      - live
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T14:54:36.279Z
+      hippostdpubwf:lastModificationDate: 2018-01-24T23:20:22.483Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2018-01-24T23:20:25.943Z
+      hippotranslation:id: be1317d6-5605-40f4-a2f3-1195643d6549
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:cilanding
+      jcr:uuid: db20367d-5087-4612-a52f-c27ddd1c8723
+      publicationsystem:title: CCG Outcomes - Indicator Set
+    hippo:name: CCG Outcomes
+    jcr:mixinTypes:
+    - hippo:named
+    - mix:referenceable
+    jcr:primaryType: hippo:handle
+    jcr:uuid: a35c56f4-1a16-46d8-a76e-97afcff09afa
+  /compendium-indicators:
+    /compendium-indicators[1]:
+      /publicationsystem:content:
+        hippostd:content: |-
+          <p>The Compendium provides a comprehensive overview of population health at a national, regional and local level. You can use these indicators to:</p>
+
+          <ul>
+           <li>Compare the profile of your local area with other regions and national averages.</li>
+           <li>Understand what the population health challenges are in your area and how they may be changing over time.</li>
+           <li>Explore the diverse range of factors that influence health inequalities.</li>
+          </ul>
+
+          <p>&nbsp;</p>
+
+          <p><a href="https://indicators.hscic.gov.uk/download/Indicator%20Portal%20indicators.xls" target="_blank">Download the full list of indicators</a>&nbsp;contained within the Indicator Portal</p>
+
+          <p>More information for users:</p>
+
+          <ul>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#background">Background</a></li>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#Indicators">What do the indicators cover?</a></li>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#Access">Access to the Compendium</a></li>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#Archive">How can I access the archive?</a></li>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#Classification">Classification and Search features</a></li>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#User">User Engagement and changes to functionality</a></li>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#Future">Future Developments</a></li>
+          </ul>
+
+          <p><strong>Background</strong></p>
+
+          <p>In October 2011 this collection of indicators brought together information that was previously available on two different websites; the Compendium of Clinical and Health Indicators and the Local Basket of Inequalities Indicators.</p>
+
+          <p>If you previously used the Compendium of Clinical and Health Indicators website (also known as NCHOD) then please be aware that the Directory of Clinical Databases (DoCDat) and Patient Reported Outcome Measures Group resources are now located on other websites.</p>
+
+          <p>For information about the contents of the Local Basket of Indicators please select the appropriate link from the list on the left.</p>
+
+          <p><strong>What do the indicators cover?</strong></p>
+
+          <p>There are over 1,000 indicators in this collection. They cover the following areas of interest:</p>
+
+          <ul>
+           <li>Population and demography</li>
+           <li>Births, conceptions, fertility, abortions</li>
+           <li>Deaths, mortality, infant mortality and life expectancy</li>
+           <li>Cancer screening, incidence, survival and death rates</li>
+           <li>Circulatory and heart diseases</li>
+           <li>Respiratory diseases</li>
+           <li>Diabetes and other long term conditions</li>
+           <li>Infectious diseases and immunisation</li>
+           <li>Health status</li>
+           <li>Lifestyle e.g. nutrition, smoking, alcohol consumption and physical activity</li>
+           <li>Health interventions and Primary Care</li>
+           <li>Hospital care</li>
+           <li>Home and Community support</li>
+           <li>Socio-economic factors influencing health
+           <ul>
+            <li>Employment, poverty, homelessness, deprivation, crime</li>
+            <li>Education</li>
+           </ul>
+           </li>
+          </ul>
+
+          <p>&nbsp;</p>
+
+          <p>The indicators can be viewed on a national basis and at a number of different regional and local levels including Strategic Health Authority, Primary Care Trust/Organisation, Region and Local Authority. Please note that not all indicators can be viewed at every level.</p>
+
+          <p>&nbsp;</p>
+
+          <p><strong>Access to the Compendium</strong></p>
+
+          <p>This website (<a href="https://indicators.hscic.gov.uk/" target="_blank">https://indicators.hscic.gov.uk</a>) is available for any user.</p>
+
+          <p>If you are having difficulty finding what you need please contact us via&nbsp;<a href="mailto:enquiries@nhsdigital.nhs.uk?subject=Indicator%20Portal">enquiries@nhsdigital.nhs.uk</a>&nbsp;for help with your data requirement.</p>
+
+          <p>&nbsp;</p>
+
+          <p><strong>How can I access the archive?</strong></p>
+
+          <p>We have an archive of older Compendium files (going back very many years) which are available on request.</p>
+
+          <p>Please use the "contact us" button on the top right and specify which indicator files you are interested in, and for which time periods. We will do our best to assist.</p>
+
+          <p>&nbsp;</p>
+
+          <p><strong>Classification and Search features</strong></p>
+
+          <p>The Indicator Portal is hosting a number of indicators in addition to the Compendium e.g. SHMI. Users will be able to search across the entire portal and access all indicators for a subject.</p>
+
+          <p>The indicators have been classified according to subject rather than type of indicator e.g. mortality / prevalence / incidence. This ensures that all indicators are classified in a consistent manner and a user browsing around a subject grouping will have access to other types of indicators outside of the Compendium.</p>
+
+          <p>Further indicators will be added to the portal which may not necessarily be of a specific indicator type and designing the taxonomy around subject included them all.&nbsp; The portal enables keyword searching to support the user who is interested in specific attributes, for example indicator type. A user can therefore enter a search on 'mortality' and a list of all the mortality indicators will be returned, likewise a search on 'prevalence' would bring up all the prevalence indicators. Searches can be refined by adding key words e.g. "vaccination MMR".</p>
+
+          <p>However, if you continue to experience difficulty finding what you need please&nbsp;<a href="mailto:enquiries@nhsdigital.nhs.uk?subject=Indicator%20Portal">contact us</a>&nbsp;for help with your data requirement.</p>
+
+          <p>&nbsp;</p>
+
+          <p><strong>User Engagement and changes to functionality</strong></p>
+
+          <p>Through the Compendium Advisory Group, that has representation from the NHS and DH, we have kept stakeholders involved in changes to the Compendium.</p>
+
+          <p>The indicators have not been significantly reviewed for over six years and NHS Digital conducted an initial 6 month review on the Compendium in early 2012. The aim was to help shape strategy and direct the work in NHS Digital in developing the Compendium of Public Health Indicators products and services to meet changing customer demand. Through an online survey and telephone interviews, stakeholders and users were asked about their experience of using the Compendium and views on future data requirements.</p>
+
+          <p>In response to users' comments a number of initial changes have been made:</p>
+
+          <p><strong>• Improved keywords</strong></p>
+
+          <p>The content of the current keyword database has been extensively reviewed. The aim was to improve the search function by increasing the number of keywords tagged. This should improve indicator access and reduce navigation time.</p>
+
+          <p><strong>• Indicator List</strong></p>
+
+          <p>To aid users in finding indicators there is a full indicator list, which can be downloaded, on the Indicator Portal homepage and on the Compendium homepage. This covers all indicators and not just those on the Compendium.</p>
+
+          <p>From this list, users can filter on:-</p>
+
+          <ul>
+           <li>Indicator Portal code</li>
+           <li>Indicator group (e.g. Compendium)</li>
+           <li>Level 1 (e.g. Hospital care)</li>
+           <li>Level 2 (e.g. Admissions)</li>
+           <li>Indicator name</li>
+           <li>Release date</li>
+           <li>Next update expected</li>
+          </ul>
+
+          <p>&nbsp;</p>
+
+          <p>This indicator list has also been added to the section called 'Site Updates' on the Indicator Portal homepage, under the heading 'Indicator Portal news' which provides the release history of indicators- date, title and description.&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=https%3A%2F%2F192.168.228.51%3A443%2Fobj%2FfCatalog%2FCatalog9" target="_blank">Site Updates</a></p>
+
+          <p>&nbsp;</p>
+
+          <p><strong>Extra Guidance</strong></p>
+
+          <p>&nbsp;</p>
+
+          <p>Extra guidance for users on how to filter the indicator list and search is provided through the screenshot guide on the main page of the Indicator Portal.</p>
+
+          <p><a href="https://indicators.hscic.gov.uk/download/Indicator_Portal_userguide.pdf" target="_blank">http://indicators.hscic.gov.uk/download/Indicator_Portal_userguide.pdf</a></p>
+
+          <p>User feedback will be used to prioritise other developments over the next 12 months and we continue to seek such feedback on the recent changes to the Indicator Portal.</p>
+
+          <p>Users are also advised to utilise the following sections:</p>
+
+          <ul>
+           <li>Additional reading</li>
+           <li>Statistical methods and disclosure control</li>
+           <li>Terms and conditions</li>
+          </ul>
+
+          <p><strong>Future Developments</strong>&nbsp;</p>
+
+          <p>We are in the process of updating the NHS Digital website in line with our new responsibilities under the proposed Health Act which will lead to improved access and functionality for the user. We will keep users informed about how these changes will affect the Compendium and the Indicator Portal as developments occur.</p>
+        jcr:primaryType: hippostd:html
+      common:searchable: true
+      hippo:availability: []
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T20:44:47.257Z
+      hippostdpubwf:lastModificationDate: 2018-01-24T23:21:09.783Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 2a333557-f3dd-4e4b-92b3-e2c05d26e4d9
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:cilanding
+      jcr:uuid: 00d71299-b0dc-41e8-98c8-417459f48330
+      publicationsystem:title: Compendium of Population Health Indicators
+    /compendium-indicators[2]:
+      /publicationsystem:content:
+        hippostd:content: |-
+          <p>The Compendium provides a comprehensive overview of population health at a national, regional and local level. You can use these indicators to:</p>
+
+          <ul>
+           <li>Compare the profile of your local area with other regions and national averages.</li>
+           <li>Understand what the population health challenges are in your area and how they may be changing over time.</li>
+           <li>Explore the diverse range of factors that influence health inequalities.</li>
+          </ul>
+
+          <p>&nbsp;</p>
+
+          <p><a href="https://indicators.hscic.gov.uk/download/Indicator%20Portal%20indicators.xls" target="_blank">Download the full list of indicators</a>&nbsp;contained within the Indicator Portal</p>
+
+          <p>More information for users:</p>
+
+          <ul>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#background">Background</a></li>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#Indicators">What do the indicators cover?</a></li>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#Access">Access to the Compendium</a></li>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#Archive">How can I access the archive?</a></li>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#Classification">Classification and Search features</a></li>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#User">User Engagement and changes to functionality</a></li>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#Future">Future Developments</a></li>
+          </ul>
+
+          <p><strong>Background</strong></p>
+
+          <p>In October 2011 this collection of indicators brought together information that was previously available on two different websites; the Compendium of Clinical and Health Indicators and the Local Basket of Inequalities Indicators.</p>
+
+          <p>If you previously used the Compendium of Clinical and Health Indicators website (also known as NCHOD) then please be aware that the Directory of Clinical Databases (DoCDat) and Patient Reported Outcome Measures Group resources are now located on other websites.</p>
+
+          <p>For information about the contents of the Local Basket of Indicators please select the appropriate link from the list on the left.</p>
+
+          <p><strong>What do the indicators cover?</strong></p>
+
+          <p>There are over 1,000 indicators in this collection. They cover the following areas of interest:</p>
+
+          <ul>
+           <li>Population and demography</li>
+           <li>Births, conceptions, fertility, abortions</li>
+           <li>Deaths, mortality, infant mortality and life expectancy</li>
+           <li>Cancer screening, incidence, survival and death rates</li>
+           <li>Circulatory and heart diseases</li>
+           <li>Respiratory diseases</li>
+           <li>Diabetes and other long term conditions</li>
+           <li>Infectious diseases and immunisation</li>
+           <li>Health status</li>
+           <li>Lifestyle e.g. nutrition, smoking, alcohol consumption and physical activity</li>
+           <li>Health interventions and Primary Care</li>
+           <li>Hospital care</li>
+           <li>Home and Community support</li>
+           <li>Socio-economic factors influencing health
+           <ul>
+            <li>Employment, poverty, homelessness, deprivation, crime</li>
+            <li>Education</li>
+           </ul>
+           </li>
+          </ul>
+
+          <p>&nbsp;</p>
+
+          <p>The indicators can be viewed on a national basis and at a number of different regional and local levels including Strategic Health Authority, Primary Care Trust/Organisation, Region and Local Authority. Please note that not all indicators can be viewed at every level.</p>
+
+          <p>&nbsp;</p>
+
+          <p><strong>Access to the Compendium</strong></p>
+
+          <p>This website (<a href="https://indicators.hscic.gov.uk/" target="_blank">https://indicators.hscic.gov.uk</a>) is available for any user.</p>
+
+          <p>If you are having difficulty finding what you need please contact us via&nbsp;<a href="mailto:enquiries@nhsdigital.nhs.uk?subject=Indicator%20Portal">enquiries@nhsdigital.nhs.uk</a>&nbsp;for help with your data requirement.</p>
+
+          <p>&nbsp;</p>
+
+          <p><strong>How can I access the archive?</strong></p>
+
+          <p>We have an archive of older Compendium files (going back very many years) which are available on request.</p>
+
+          <p>Please use the "contact us" button on the top right and specify which indicator files you are interested in, and for which time periods. We will do our best to assist.</p>
+
+          <p>&nbsp;</p>
+
+          <p><strong>Classification and Search features</strong></p>
+
+          <p>The Indicator Portal is hosting a number of indicators in addition to the Compendium e.g. SHMI. Users will be able to search across the entire portal and access all indicators for a subject.</p>
+
+          <p>The indicators have been classified according to subject rather than type of indicator e.g. mortality / prevalence / incidence. This ensures that all indicators are classified in a consistent manner and a user browsing around a subject grouping will have access to other types of indicators outside of the Compendium.</p>
+
+          <p>Further indicators will be added to the portal which may not necessarily be of a specific indicator type and designing the taxonomy around subject included them all.&nbsp; The portal enables keyword searching to support the user who is interested in specific attributes, for example indicator type. A user can therefore enter a search on 'mortality' and a list of all the mortality indicators will be returned, likewise a search on 'prevalence' would bring up all the prevalence indicators. Searches can be refined by adding key words e.g. "vaccination MMR".</p>
+
+          <p>However, if you continue to experience difficulty finding what you need please&nbsp;<a href="mailto:enquiries@nhsdigital.nhs.uk?subject=Indicator%20Portal">contact us</a>&nbsp;for help with your data requirement.</p>
+
+          <p>&nbsp;</p>
+
+          <p><strong>User Engagement and changes to functionality</strong></p>
+
+          <p>Through the Compendium Advisory Group, that has representation from the NHS and DH, we have kept stakeholders involved in changes to the Compendium.</p>
+
+          <p>The indicators have not been significantly reviewed for over six years and NHS Digital conducted an initial 6 month review on the Compendium in early 2012. The aim was to help shape strategy and direct the work in NHS Digital in developing the Compendium of Public Health Indicators products and services to meet changing customer demand. Through an online survey and telephone interviews, stakeholders and users were asked about their experience of using the Compendium and views on future data requirements.</p>
+
+          <p>In response to users' comments a number of initial changes have been made:</p>
+
+          <p><strong>• Improved keywords</strong></p>
+
+          <p>The content of the current keyword database has been extensively reviewed. The aim was to improve the search function by increasing the number of keywords tagged. This should improve indicator access and reduce navigation time.</p>
+
+          <p><strong>• Indicator List</strong></p>
+
+          <p>To aid users in finding indicators there is a full indicator list, which can be downloaded, on the Indicator Portal homepage and on the Compendium homepage. This covers all indicators and not just those on the Compendium.</p>
+
+          <p>From this list, users can filter on:-</p>
+
+          <ul>
+           <li>Indicator Portal code</li>
+           <li>Indicator group (e.g. Compendium)</li>
+           <li>Level 1 (e.g. Hospital care)</li>
+           <li>Level 2 (e.g. Admissions)</li>
+           <li>Indicator name</li>
+           <li>Release date</li>
+           <li>Next update expected</li>
+          </ul>
+
+          <p>&nbsp;</p>
+
+          <p>This indicator list has also been added to the section called 'Site Updates' on the Indicator Portal homepage, under the heading 'Indicator Portal news' which provides the release history of indicators- date, title and description.&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=https%3A%2F%2F192.168.228.51%3A443%2Fobj%2FfCatalog%2FCatalog9" target="_blank">Site Updates</a></p>
+
+          <p>&nbsp;</p>
+
+          <p><strong>Extra Guidance</strong></p>
+
+          <p>&nbsp;</p>
+
+          <p>Extra guidance for users on how to filter the indicator list and search is provided through the screenshot guide on the main page of the Indicator Portal.</p>
+
+          <p><a href="https://indicators.hscic.gov.uk/download/Indicator_Portal_userguide.pdf" target="_blank">http://indicators.hscic.gov.uk/download/Indicator_Portal_userguide.pdf</a></p>
+
+          <p>User feedback will be used to prioritise other developments over the next 12 months and we continue to seek such feedback on the recent changes to the Indicator Portal.</p>
+
+          <p>Users are also advised to utilise the following sections:</p>
+
+          <ul>
+           <li>Additional reading</li>
+           <li>Statistical methods and disclosure control</li>
+           <li>Terms and conditions</li>
+          </ul>
+
+          <p><strong>Future Developments</strong>&nbsp;</p>
+
+          <p>We are in the process of updating the NHS Digital website in line with our new responsibilities under the proposed Health Act which will lead to improved access and functionality for the user. We will keep users informed about how these changes will affect the Compendium and the Indicator Portal as developments occur.</p>
+        jcr:primaryType: hippostd:html
+      common:searchable: true
+      hippo:availability:
+      - preview
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T20:44:47.257Z
+      hippostdpubwf:lastModificationDate: 2018-01-24T23:22:12.752Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 2a333557-f3dd-4e4b-92b3-e2c05d26e4d9
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      - mix:versionable
+      jcr:primaryType: publicationsystem:cilanding
+      jcr:uuid: 0a61aa34-b893-40bf-aa4a-61fdc098729c
+      publicationsystem:title: Compendium of Population Health Indicators
+    /compendium-indicators[3]:
+      /publicationsystem:content:
+        hippostd:content: |-
+          <p>The Compendium provides a comprehensive overview of population health at a national, regional and local level. You can use these indicators to:</p>
+
+          <ul>
+           <li>Compare the profile of your local area with other regions and national averages.</li>
+           <li>Understand what the population health challenges are in your area and how they may be changing over time.</li>
+           <li>Explore the diverse range of factors that influence health inequalities.</li>
+          </ul>
+
+          <p>&nbsp;</p>
+
+          <p><a href="https://indicators.hscic.gov.uk/download/Indicator%20Portal%20indicators.xls" target="_blank">Download the full list of indicators</a>&nbsp;contained within the Indicator Portal</p>
+
+          <p>More information for users:</p>
+
+          <ul>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#background">Background</a></li>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#Indicators">What do the indicators cover?</a></li>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#Access">Access to the Compendium</a></li>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#Archive">How can I access the archive?</a></li>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#Classification">Classification and Search features</a></li>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#User">User Engagement and changes to functionality</a></li>
+           <li>&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=http%3A%2F%2Fts-d-app-513.dev.green.net%3A80%2Fobj%2FfCatalog%2FCatalog2#Future">Future Developments</a></li>
+          </ul>
+
+          <p><strong>Background</strong></p>
+
+          <p>In October 2011 this collection of indicators brought together information that was previously available on two different websites; the Compendium of Clinical and Health Indicators and the Local Basket of Inequalities Indicators.</p>
+
+          <p>If you previously used the Compendium of Clinical and Health Indicators website (also known as NCHOD) then please be aware that the Directory of Clinical Databases (DoCDat) and Patient Reported Outcome Measures Group resources are now located on other websites.</p>
+
+          <p>For information about the contents of the Local Basket of Indicators please select the appropriate link from the list on the left.</p>
+
+          <p><strong>What do the indicators cover?</strong></p>
+
+          <p>There are over 1,000 indicators in this collection. They cover the following areas of interest:</p>
+
+          <ul>
+           <li>Population and demography</li>
+           <li>Births, conceptions, fertility, abortions</li>
+           <li>Deaths, mortality, infant mortality and life expectancy</li>
+           <li>Cancer screening, incidence, survival and death rates</li>
+           <li>Circulatory and heart diseases</li>
+           <li>Respiratory diseases</li>
+           <li>Diabetes and other long term conditions</li>
+           <li>Infectious diseases and immunisation</li>
+           <li>Health status</li>
+           <li>Lifestyle e.g. nutrition, smoking, alcohol consumption and physical activity</li>
+           <li>Health interventions and Primary Care</li>
+           <li>Hospital care</li>
+           <li>Home and Community support</li>
+           <li>Socio-economic factors influencing health
+           <ul>
+            <li>Employment, poverty, homelessness, deprivation, crime</li>
+            <li>Education</li>
+           </ul>
+           </li>
+          </ul>
+
+          <p>&nbsp;</p>
+
+          <p>The indicators can be viewed on a national basis and at a number of different regional and local levels including Strategic Health Authority, Primary Care Trust/Organisation, Region and Local Authority. Please note that not all indicators can be viewed at every level.</p>
+
+          <p>&nbsp;</p>
+
+          <p><strong>Access to the Compendium</strong></p>
+
+          <p>This website (<a href="https://indicators.hscic.gov.uk/" target="_blank">https://indicators.hscic.gov.uk</a>) is available for any user.</p>
+
+          <p>If you are having difficulty finding what you need please contact us via&nbsp;<a href="mailto:enquiries@nhsdigital.nhs.uk?subject=Indicator%20Portal">enquiries@nhsdigital.nhs.uk</a>&nbsp;for help with your data requirement.</p>
+
+          <p>&nbsp;</p>
+
+          <p><strong>How can I access the archive?</strong></p>
+
+          <p>We have an archive of older Compendium files (going back very many years) which are available on request.</p>
+
+          <p>Please use the "contact us" button on the top right and specify which indicator files you are interested in, and for which time periods. We will do our best to assist.</p>
+
+          <p>&nbsp;</p>
+
+          <p><strong>Classification and Search features</strong></p>
+
+          <p>The Indicator Portal is hosting a number of indicators in addition to the Compendium e.g. SHMI. Users will be able to search across the entire portal and access all indicators for a subject.</p>
+
+          <p>The indicators have been classified according to subject rather than type of indicator e.g. mortality / prevalence / incidence. This ensures that all indicators are classified in a consistent manner and a user browsing around a subject grouping will have access to other types of indicators outside of the Compendium.</p>
+
+          <p>Further indicators will be added to the portal which may not necessarily be of a specific indicator type and designing the taxonomy around subject included them all.&nbsp; The portal enables keyword searching to support the user who is interested in specific attributes, for example indicator type. A user can therefore enter a search on 'mortality' and a list of all the mortality indicators will be returned, likewise a search on 'prevalence' would bring up all the prevalence indicators. Searches can be refined by adding key words e.g. "vaccination MMR".</p>
+
+          <p>However, if you continue to experience difficulty finding what you need please&nbsp;<a href="mailto:enquiries@nhsdigital.nhs.uk?subject=Indicator%20Portal">contact us</a>&nbsp;for help with your data requirement.</p>
+
+          <p>&nbsp;</p>
+
+          <p><strong>User Engagement and changes to functionality</strong></p>
+
+          <p>Through the Compendium Advisory Group, that has representation from the NHS and DH, we have kept stakeholders involved in changes to the Compendium.</p>
+
+          <p>The indicators have not been significantly reviewed for over six years and NHS Digital conducted an initial 6 month review on the Compendium in early 2012. The aim was to help shape strategy and direct the work in NHS Digital in developing the Compendium of Public Health Indicators products and services to meet changing customer demand. Through an online survey and telephone interviews, stakeholders and users were asked about their experience of using the Compendium and views on future data requirements.</p>
+
+          <p>In response to users' comments a number of initial changes have been made:</p>
+
+          <p><strong>• Improved keywords</strong></p>
+
+          <p>The content of the current keyword database has been extensively reviewed. The aim was to improve the search function by increasing the number of keywords tagged. This should improve indicator access and reduce navigation time.</p>
+
+          <p><strong>• Indicator List</strong></p>
+
+          <p>To aid users in finding indicators there is a full indicator list, which can be downloaded, on the Indicator Portal homepage and on the Compendium homepage. This covers all indicators and not just those on the Compendium.</p>
+
+          <p>From this list, users can filter on:-</p>
+
+          <ul>
+           <li>Indicator Portal code</li>
+           <li>Indicator group (e.g. Compendium)</li>
+           <li>Level 1 (e.g. Hospital care)</li>
+           <li>Level 2 (e.g. Admissions)</li>
+           <li>Indicator name</li>
+           <li>Release date</li>
+           <li>Next update expected</li>
+          </ul>
+
+          <p>&nbsp;</p>
+
+          <p>This indicator list has also been added to the section called 'Site Updates' on the Indicator Portal homepage, under the heading 'Indicator Portal news' which provides the release history of indicators- date, title and description.&nbsp;<a href="https://indicators.hscic.gov.uk/webview/velocity?mode=documentation&amp;submode=catalog&amp;catalog=https%3A%2F%2F192.168.228.51%3A443%2Fobj%2FfCatalog%2FCatalog9" target="_blank">Site Updates</a></p>
+
+          <p>&nbsp;</p>
+
+          <p><strong>Extra Guidance</strong></p>
+
+          <p>&nbsp;</p>
+
+          <p>Extra guidance for users on how to filter the indicator list and search is provided through the screenshot guide on the main page of the Indicator Portal.</p>
+
+          <p><a href="https://indicators.hscic.gov.uk/download/Indicator_Portal_userguide.pdf" target="_blank">http://indicators.hscic.gov.uk/download/Indicator_Portal_userguide.pdf</a></p>
+
+          <p>User feedback will be used to prioritise other developments over the next 12 months and we continue to seek such feedback on the recent changes to the Indicator Portal.</p>
+
+          <p>Users are also advised to utilise the following sections:</p>
+
+          <ul>
+           <li>Additional reading</li>
+           <li>Statistical methods and disclosure control</li>
+           <li>Terms and conditions</li>
+          </ul>
+
+          <p><strong>Future Developments</strong>&nbsp;</p>
+
+          <p>We are in the process of updating the NHS Digital website in line with our new responsibilities under the proposed Health Act which will lead to improved access and functionality for the user. We will keep users informed about how these changes will affect the Compendium and the Indicator Portal as developments occur.</p>
+        jcr:primaryType: hippostd:html
+      common:searchable: true
+      hippo:availability:
+      - live
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T20:44:47.257Z
+      hippostdpubwf:lastModificationDate: 2018-01-24T23:22:12.752Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2018-01-24T23:22:15.671Z
+      hippotranslation:id: 2a333557-f3dd-4e4b-92b3-e2c05d26e4d9
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:cilanding
+      jcr:uuid: cc541dbd-d831-43dd-ac16-bb060b6c4851
+      publicationsystem:title: Compendium of Population Health Indicators
+    hippo:name: Compendium Indicators
+    jcr:mixinTypes:
+    - hippo:named
+    - mix:referenceable
+    jcr:primaryType: hippo:handle
+    jcr:uuid: 2877ffb8-5ea8-4a4f-b0d2-d6cec1506f24
+  /main-sections:
+    /main-sections[1]:
+      /publicationsystem:cihublink[1]:
+        /publicationsystem:pagelink:
+          hippo:docbase: a35c56f4-1a16-46d8-a76e-97afcff09afa
+          jcr:primaryType: hippo:mirror
+        jcr:primaryType: publicationsystem:cihublink
+        publicationsystem:summary: The CCG Outcomes Indicator Set (CCG OIS) is an
+          integral part of NHS England’s systematic approach to quality improvement.
+        publicationsystem:title: Clinical Commissioning Group Outcomes Indicator Set
+      /publicationsystem:cihublink[2]:
+        /publicationsystem:pagelink:
+          hippo:docbase: 2877ffb8-5ea8-4a4f-b0d2-d6cec1506f24
+          jcr:primaryType: hippo:mirror
+        jcr:primaryType: publicationsystem:cihublink
+        publicationsystem:summary: A wide-ranging collection of over 1,000 indicators
+          designed to provide a comprehensive overview of population health at a national,
+          regional and local level. These indicators were previously available on
+          the Clinical and Health Outcomes Knowledge Base website (also known as NCHOD).
+        publicationsystem:title: Compendium of Population Health Indicators
+      /publicationsystem:cihublink[3]:
+        /publicationsystem:pagelink:
+          hippo:docbase: a6ac8e34-e305-41a1-adc6-36027dc3dff2
+          jcr:primaryType: hippo:mirror
+        jcr:primaryType: publicationsystem:cihublink
+        publicationsystem:summary: The latest figures for the Adult Social Care Outcomes
+          Framework (ASCOF) for 2015-16 were released in October 2016. In total, there
+          are 22 measures which are designed to enable users to compare the effectiveness
+          of care delivered by councils responsible for adult social care services
+          in England.
+        publicationsystem:title: Social Care
+      /publicationsystem:cihublink[4]:
+        /publicationsystem:pagelink:
+          hippo:docbase: 08f3157a-b3c4-4496-a6e5-0855c43301bd
+          jcr:primaryType: hippo:mirror
+        jcr:primaryType: publicationsystem:cihublink
+        publicationsystem:summary: The CCG Outcomes Indicator Set (CCG OIS) is an
+          integral part of NHS England’s systematic approach to quality improvement.
+        publicationsystem:title: NHS Outcomes Framework
+      /publicationsystem:cihublink[5]:
+        /publicationsystem:pagelink:
+          hippo:docbase: 2b6ca5d1-61e4-4d01-a05e-d209d309c15c
+          jcr:primaryType: hippo:mirror
+        jcr:primaryType: publicationsystem:cihublink
+        publicationsystem:summary: A wide-ranging collection of over 1,000 indicators
+          designed to provide a comprehensive overview of population health at a national,
+          regional and local level. These indicators were previously available on
+          the Clinical and Health Outcomes Knowledge Base website (also known as NCHOD).
+        publicationsystem:title: Summary Hospital-level Mortality Indicator (SHMI)
+      /publicationsystem:cihublink[6]:
+        /publicationsystem:pagelink:
+          hippo:docbase: bf0cccd0-840b-4d7b-b71f-03b25454deba
+          jcr:primaryType: hippo:mirror
+        jcr:primaryType: publicationsystem:cihublink
+        publicationsystem:summary: 'NOTE: This will launch digital.nhs.uk/GP-data-hub
+          Inc copy..'
+        publicationsystem:title: Patient Online Management Information (POMI)
+      common:searchable: true
+      hippo:availability: []
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T20:43:17.900Z
+      hippostdpubwf:lastModificationDate: 2018-01-25T11:03:34.949Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 1fd89de7-8dba-47ac-9565-dc86bfa2892b
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:cihub
+      jcr:uuid: 97d59a08-00e6-4086-980c-172d761017ee
+      publicationsystem:summary: "This is a collection of over a thousand datasets\
+        \ that we publish. The information is for clinical staff, commissioners, researchers,\
+        \ and others needing data and evidence to help with decision-making in health\
+        \ and care.\r\n\r\nA wide variety of subjects are covered, ranging from quality\
+        \ through to population health and the outcome of treatments."
+      publicationsystem:title: Clinical Indicators
+    /main-sections[2]:
+      /publicationsystem:cihublink[1]:
+        /publicationsystem:pagelink:
+          hippo:docbase: a35c56f4-1a16-46d8-a76e-97afcff09afa
+          jcr:primaryType: hippo:mirror
+        jcr:primaryType: publicationsystem:cihublink
+        publicationsystem:summary: The CCG Outcomes Indicator Set (CCG OIS) is an
+          integral part of NHS England’s systematic approach to quality improvement.
+        publicationsystem:title: Clinical Commissioning Group Outcomes Indicator Set
+      /publicationsystem:cihublink[2]:
+        /publicationsystem:pagelink:
+          hippo:docbase: 2877ffb8-5ea8-4a4f-b0d2-d6cec1506f24
+          jcr:primaryType: hippo:mirror
+        jcr:primaryType: publicationsystem:cihublink
+        publicationsystem:summary: A wide-ranging collection of over 1,000 indicators
+          designed to provide a comprehensive overview of population health at a national,
+          regional and local level. These indicators were previously available on
+          the Clinical and Health Outcomes Knowledge Base website (also known as NCHOD).
+        publicationsystem:title: Compendium of Population Health Indicators
+      /publicationsystem:cihublink[3]:
+        /publicationsystem:pagelink:
+          hippo:docbase: a6ac8e34-e305-41a1-adc6-36027dc3dff2
+          jcr:primaryType: hippo:mirror
+        jcr:primaryType: publicationsystem:cihublink
+        publicationsystem:summary: The latest figures for the Adult Social Care Outcomes
+          Framework (ASCOF) for 2015-16 were released in October 2016. In total, there
+          are 22 measures which are designed to enable users to compare the effectiveness
+          of care delivered by councils responsible for adult social care services
+          in England.
+        publicationsystem:title: Social Care
+      /publicationsystem:cihublink[4]:
+        /publicationsystem:pagelink:
+          hippo:docbase: 08f3157a-b3c4-4496-a6e5-0855c43301bd
+          jcr:primaryType: hippo:mirror
+        jcr:primaryType: publicationsystem:cihublink
+        publicationsystem:summary: The CCG Outcomes Indicator Set (CCG OIS) is an
+          integral part of NHS England’s systematic approach to quality improvement.
+        publicationsystem:title: NHS Outcomes Framework
+      /publicationsystem:cihublink[5]:
+        /publicationsystem:pagelink:
+          hippo:docbase: 2b6ca5d1-61e4-4d01-a05e-d209d309c15c
+          jcr:primaryType: hippo:mirror
+        jcr:primaryType: publicationsystem:cihublink
+        publicationsystem:summary: A wide-ranging collection of over 1,000 indicators
+          designed to provide a comprehensive overview of population health at a national,
+          regional and local level. These indicators were previously available on
+          the Clinical and Health Outcomes Knowledge Base website (also known as NCHOD).
+        publicationsystem:title: Summary Hospital-level Mortality Indicator (SHMI)
+      /publicationsystem:cihublink[6]:
+        /publicationsystem:pagelink:
+          hippo:docbase: bf0cccd0-840b-4d7b-b71f-03b25454deba
+          jcr:primaryType: hippo:mirror
+        jcr:primaryType: publicationsystem:cihublink
+        publicationsystem:summary: 'NOTE: This will launch digital.nhs.uk/GP-data-hub
+          Inc copy..'
+        publicationsystem:title: Patient Online Management Information (POMI)
+      common:searchable: true
+      hippo:availability:
+      - preview
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T20:43:17.900Z
+      hippostdpubwf:lastModificationDate: 2018-01-25T11:04:11.104Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 1fd89de7-8dba-47ac-9565-dc86bfa2892b
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      - mix:versionable
+      jcr:primaryType: publicationsystem:cihub
+      jcr:uuid: e6383c92-d5c8-40f7-8c42-2cd17f0e1224
+      publicationsystem:summary: "This is a collection of over a thousand datasets\
+        \ that we publish. The information is for clinical staff, commissioners, researchers,\
+        \ and others needing data and evidence to help with decision-making in health\
+        \ and care.\r\n\r\nA wide variety of subjects are covered, ranging from quality\
+        \ through to population health and the outcome of treatments."
+      publicationsystem:title: Clinical Indicators
+    /main-sections[3]:
+      /publicationsystem:cihublink[1]:
+        /publicationsystem:pagelink:
+          hippo:docbase: a35c56f4-1a16-46d8-a76e-97afcff09afa
+          jcr:primaryType: hippo:mirror
+        jcr:primaryType: publicationsystem:cihublink
+        publicationsystem:summary: The CCG Outcomes Indicator Set (CCG OIS) is an
+          integral part of NHS England’s systematic approach to quality improvement.
+        publicationsystem:title: Clinical Commissioning Group Outcomes Indicator Set
+      /publicationsystem:cihublink[2]:
+        /publicationsystem:pagelink:
+          hippo:docbase: 2877ffb8-5ea8-4a4f-b0d2-d6cec1506f24
+          jcr:primaryType: hippo:mirror
+        jcr:primaryType: publicationsystem:cihublink
+        publicationsystem:summary: A wide-ranging collection of over 1,000 indicators
+          designed to provide a comprehensive overview of population health at a national,
+          regional and local level. These indicators were previously available on
+          the Clinical and Health Outcomes Knowledge Base website (also known as NCHOD).
+        publicationsystem:title: Compendium of Population Health Indicators
+      /publicationsystem:cihublink[3]:
+        /publicationsystem:pagelink:
+          hippo:docbase: a6ac8e34-e305-41a1-adc6-36027dc3dff2
+          jcr:primaryType: hippo:mirror
+        jcr:primaryType: publicationsystem:cihublink
+        publicationsystem:summary: The latest figures for the Adult Social Care Outcomes
+          Framework (ASCOF) for 2015-16 were released in October 2016. In total, there
+          are 22 measures which are designed to enable users to compare the effectiveness
+          of care delivered by councils responsible for adult social care services
+          in England.
+        publicationsystem:title: Social Care
+      /publicationsystem:cihublink[4]:
+        /publicationsystem:pagelink:
+          hippo:docbase: 08f3157a-b3c4-4496-a6e5-0855c43301bd
+          jcr:primaryType: hippo:mirror
+        jcr:primaryType: publicationsystem:cihublink
+        publicationsystem:summary: The CCG Outcomes Indicator Set (CCG OIS) is an
+          integral part of NHS England’s systematic approach to quality improvement.
+        publicationsystem:title: NHS Outcomes Framework
+      /publicationsystem:cihublink[5]:
+        /publicationsystem:pagelink:
+          hippo:docbase: 2b6ca5d1-61e4-4d01-a05e-d209d309c15c
+          jcr:primaryType: hippo:mirror
+        jcr:primaryType: publicationsystem:cihublink
+        publicationsystem:summary: A wide-ranging collection of over 1,000 indicators
+          designed to provide a comprehensive overview of population health at a national,
+          regional and local level. These indicators were previously available on
+          the Clinical and Health Outcomes Knowledge Base website (also known as NCHOD).
+        publicationsystem:title: Summary Hospital-level Mortality Indicator (SHMI)
+      /publicationsystem:cihublink[6]:
+        /publicationsystem:pagelink:
+          hippo:docbase: bf0cccd0-840b-4d7b-b71f-03b25454deba
+          jcr:primaryType: hippo:mirror
+        jcr:primaryType: publicationsystem:cihublink
+        publicationsystem:summary: 'NOTE: This will launch digital.nhs.uk/GP-data-hub
+          Inc copy..'
+        publicationsystem:title: Patient Online Management Information (POMI)
+      common:searchable: true
+      hippo:availability:
+      - live
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T20:43:17.900Z
+      hippostdpubwf:lastModificationDate: 2018-01-25T11:04:11.104Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2018-01-25T11:04:15.437Z
+      hippotranslation:id: 1fd89de7-8dba-47ac-9565-dc86bfa2892b
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:cihub
+      jcr:uuid: 06081220-19b1-4f3b-957b-a9d4365229fe
+      publicationsystem:summary: "This is a collection of over a thousand datasets\
+        \ that we publish. The information is for clinical staff, commissioners, researchers,\
+        \ and others needing data and evidence to help with decision-making in health\
+        \ and care.\r\n\r\nA wide variety of subjects are covered, ranging from quality\
+        \ through to population health and the outcome of treatments."
+      publicationsystem:title: Clinical Indicators
+    hippo:name: Main Sections
+    jcr:mixinTypes:
+    - hippo:named
+    - mix:referenceable
+    jcr:primaryType: hippo:handle
+    jcr:uuid: 1e0afe8d-4fb2-4528-83f7-98713d9215d4
+  /nhs-outcomes-framework:
+    /nhs-outcomes-framework[1]:
+      /publicationsystem:content:
+        hippostd:content: |-
+          <p>The NHS Outcomes Framework provides national level accountability for the outcomes the NHS delivers; it drives transparency, quality improvement and outcome measurement throughout the NHS.</p>
+
+          <p>It also sets out the national outcome goals that the Secretary of State uses to monitor the progress of NHS England. It does not set out how these outcomes should be delivered, it is for NHS England to determine how best to deliver improvements by working with Clinical Commissioning Groups to make use of the tools at their disposal.</p>
+
+          <p>The NHS Outcomes Framework uses the ONS mid-year population estimates for England as its subject population, and where standardisation is required the European Standard Population is generally used. All indicators are reported at England level, and are broken down, where possible, by a combination of Age, Lower tier local authority, Upper tier local authority, Region, Religion, Ethnicity, Deprivation decile, Sexual orientation, Gender and Condition.</p>
+
+          <p>The CCG Outcomes Indicator Set uses the registered patient population of England as its subject population, and where standardisation is required, the Office for National Statistics mid-year population estimates for England. All indicators are reported at CCG and National level, where 'National' represents the sum total of patients registered with a GP in England.</p>
+
+          <p><strong>Framework structure</strong></p>
+
+          <p>The framework is structured around five high level outcome domains.</p>
+
+          <ul>
+           <li><strong>Domain 1 - Preventing people from dying prematurely</strong><br />
+           This domain captures how successful the NHS is in reducing the number of avoidable deaths.</li>
+           <li><strong>Domain 2 - Enhancing quality of life for people with long-term conditions</strong><br />
+           This domain captures how successfully the NHS is supporting people with long-term conditions to live as normal a life as possible.</li>
+           <li><strong>Domain 3 - Helping people to recover from episodes of ill health or following injury</strong><br />
+           This domain captures how people recover from ill health or injury and wherever possible how it can be prevented.</li>
+           <li><strong>Domain 4 - Ensuring that people have a positive experience of care</strong><br />
+           This domain looks at the importance of providing a positive experience of care for patients, service users and carers.</li>
+           <li><strong>Domain 5 - Treating and caring for people in a safe environment and protecting them from avoidable harm</strong><br />
+           This domain explores patient safety and its importance in terms of quality of care to deliver better health outcomes.</li>
+          </ul>
+
+          <p><strong>List of all indicators</strong></p>
+
+          <p><a href="https://indicators.hscic.gov.uk/download/Indicator%20Portal%20indicators.xls" target="_blank">Download the full list of indicators</a>&nbsp;contained within the Indicator Portal. Filter column B on the NHS Outcomes Framework indicators to see this work stream's list of indicators.</p>
+        jcr:primaryType: hippostd:html
+      common:searchable: true
+      hippo:availability: []
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T20:52:43.733Z
+      hippostdpubwf:lastModificationDate: 2018-01-24T23:23:54.945Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 889f3118-fcea-44d1-87a0-fb72c4cd1052
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:cilanding
+      jcr:uuid: 55ee0230-2460-402f-8bb8-8cbe88b55023
+      publicationsystem:title: NHS Outcomes Framework
+    /nhs-outcomes-framework[2]:
+      /publicationsystem:content:
+        hippostd:content: |-
+          <p>The NHS Outcomes Framework provides national level accountability for the outcomes the NHS delivers; it drives transparency, quality improvement and outcome measurement throughout the NHS.</p>
+
+          <p>It also sets out the national outcome goals that the Secretary of State uses to monitor the progress of NHS England. It does not set out how these outcomes should be delivered, it is for NHS England to determine how best to deliver improvements by working with Clinical Commissioning Groups to make use of the tools at their disposal.</p>
+
+          <p>The NHS Outcomes Framework uses the ONS mid-year population estimates for England as its subject population, and where standardisation is required the European Standard Population is generally used. All indicators are reported at England level, and are broken down, where possible, by a combination of Age, Lower tier local authority, Upper tier local authority, Region, Religion, Ethnicity, Deprivation decile, Sexual orientation, Gender and Condition.</p>
+
+          <p>The CCG Outcomes Indicator Set uses the registered patient population of England as its subject population, and where standardisation is required, the Office for National Statistics mid-year population estimates for England. All indicators are reported at CCG and National level, where 'National' represents the sum total of patients registered with a GP in England.</p>
+
+          <p><strong>Framework structure</strong></p>
+
+          <p>The framework is structured around five high level outcome domains.</p>
+
+          <ul>
+           <li><strong>Domain 1 - Preventing people from dying prematurely</strong><br />
+           This domain captures how successful the NHS is in reducing the number of avoidable deaths.</li>
+           <li><strong>Domain 2 - Enhancing quality of life for people with long-term conditions</strong><br />
+           This domain captures how successfully the NHS is supporting people with long-term conditions to live as normal a life as possible.</li>
+           <li><strong>Domain 3 - Helping people to recover from episodes of ill health or following injury</strong><br />
+           This domain captures how people recover from ill health or injury and wherever possible how it can be prevented.</li>
+           <li><strong>Domain 4 - Ensuring that people have a positive experience of care</strong><br />
+           This domain looks at the importance of providing a positive experience of care for patients, service users and carers.</li>
+           <li><strong>Domain 5 - Treating and caring for people in a safe environment and protecting them from avoidable harm</strong><br />
+           This domain explores patient safety and its importance in terms of quality of care to deliver better health outcomes.</li>
+          </ul>
+
+          <p><strong>List of all indicators</strong></p>
+
+          <p><a href="https://indicators.hscic.gov.uk/download/Indicator%20Portal%20indicators.xls" target="_blank">Download the full list of indicators</a>&nbsp;contained within the Indicator Portal. Filter column B on the NHS Outcomes Framework indicators to see this work stream's list of indicators.</p>
+        jcr:primaryType: hippostd:html
+      common:searchable: true
+      hippo:availability:
+      - preview
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T20:52:43.733Z
+      hippostdpubwf:lastModificationDate: 2018-01-24T23:24:28.846Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 889f3118-fcea-44d1-87a0-fb72c4cd1052
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      - mix:versionable
+      jcr:primaryType: publicationsystem:cilanding
+      jcr:uuid: 78d665f3-0a25-439a-b18b-1cc79416f6b0
+      publicationsystem:title: NHS Outcomes Framework
+    /nhs-outcomes-framework[3]:
+      /publicationsystem:content:
+        hippostd:content: |-
+          <p>The NHS Outcomes Framework provides national level accountability for the outcomes the NHS delivers; it drives transparency, quality improvement and outcome measurement throughout the NHS.</p>
+
+          <p>It also sets out the national outcome goals that the Secretary of State uses to monitor the progress of NHS England. It does not set out how these outcomes should be delivered, it is for NHS England to determine how best to deliver improvements by working with Clinical Commissioning Groups to make use of the tools at their disposal.</p>
+
+          <p>The NHS Outcomes Framework uses the ONS mid-year population estimates for England as its subject population, and where standardisation is required the European Standard Population is generally used. All indicators are reported at England level, and are broken down, where possible, by a combination of Age, Lower tier local authority, Upper tier local authority, Region, Religion, Ethnicity, Deprivation decile, Sexual orientation, Gender and Condition.</p>
+
+          <p>The CCG Outcomes Indicator Set uses the registered patient population of England as its subject population, and where standardisation is required, the Office for National Statistics mid-year population estimates for England. All indicators are reported at CCG and National level, where 'National' represents the sum total of patients registered with a GP in England.</p>
+
+          <p><strong>Framework structure</strong></p>
+
+          <p>The framework is structured around five high level outcome domains.</p>
+
+          <ul>
+           <li><strong>Domain 1 - Preventing people from dying prematurely</strong><br />
+           This domain captures how successful the NHS is in reducing the number of avoidable deaths.</li>
+           <li><strong>Domain 2 - Enhancing quality of life for people with long-term conditions</strong><br />
+           This domain captures how successfully the NHS is supporting people with long-term conditions to live as normal a life as possible.</li>
+           <li><strong>Domain 3 - Helping people to recover from episodes of ill health or following injury</strong><br />
+           This domain captures how people recover from ill health or injury and wherever possible how it can be prevented.</li>
+           <li><strong>Domain 4 - Ensuring that people have a positive experience of care</strong><br />
+           This domain looks at the importance of providing a positive experience of care for patients, service users and carers.</li>
+           <li><strong>Domain 5 - Treating and caring for people in a safe environment and protecting them from avoidable harm</strong><br />
+           This domain explores patient safety and its importance in terms of quality of care to deliver better health outcomes.</li>
+          </ul>
+
+          <p><strong>List of all indicators</strong></p>
+
+          <p><a href="https://indicators.hscic.gov.uk/download/Indicator%20Portal%20indicators.xls" target="_blank">Download the full list of indicators</a>&nbsp;contained within the Indicator Portal. Filter column B on the NHS Outcomes Framework indicators to see this work stream's list of indicators.</p>
+        jcr:primaryType: hippostd:html
+      common:searchable: true
+      hippo:availability:
+      - live
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T20:52:43.733Z
+      hippostdpubwf:lastModificationDate: 2018-01-24T23:24:28.846Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2018-01-24T23:24:31.673Z
+      hippotranslation:id: 889f3118-fcea-44d1-87a0-fb72c4cd1052
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:cilanding
+      jcr:uuid: d4945d29-bc87-48d4-bff1-4081b3e10cb6
+      publicationsystem:title: NHS Outcomes Framework
+    hippo:name: NHS Outcomes Framework
+    jcr:mixinTypes:
+    - hippo:named
+    - mix:referenceable
+    jcr:primaryType: hippo:handle
+    jcr:uuid: 08f3157a-b3c4-4496-a6e5-0855c43301bd
+  /patient-online-management-information-pomi:
+    /patient-online-management-information-pomi[1]:
+      /publicationsystem:content:
+        hippostd:content: |-
+          <p>The Patient Online services indicator set was commissioned by NHS England to monitor progress against a government ambition for all patients who wish it to have online access to services in general practices by the end of March 2015.</p>
+
+          <p>This information was made available via the PHF10 return that collected information on a quarterly basis from system suppliers on the availability at GP practice level of online appointment booking, ordering of repeat prescriptions and access to medical records, test results, GP letters and summary information (allergies, adverse reactions and medications). This data was collected via the NHS Digital Data Depot secure file transfer system.</p>
+
+          <p>During the 2014/15 financial year (Q2 to Q4) the introduction of data requirements for the NHS Digital's GP System of Choice (GPSoC) team was combined with the PHF10 return and piloted to run monthly reporting in an attempt to make this ‘online availability data’ more frequently accessible and relevant.</p>
+
+          <p>Following the successful pilot of the monthly reporting, GPSoC and NHS England agreed to develop the metrics for this indicator set. As a result, from April 2015 the Patient Online Management Information (POMI) indicator set was introduced, replacing the old PHF10 return. The new POMI return continues to collect information on the availability to patients of electronic access to their test results, GP letters, prescriptions and online appointment booking facilities at the GP Practice level.</p>
+
+          <p>The subset and full medical records viewing services are being redefined to align with the requirements in the 2015/16 GMS/PMS regulations and the two previous indicators have been decommissioned from April 2015. This review will also consider other elements within the indicator set and how these align with the redefined indicators.</p>
+
+          <p>The new indicator to provide information on the availability to patients to access their detailed coded record (DCR) was introduced from February 2016, and the previous indicators for test results and letters decommissioned from April 2016. Work is ongoing between the NHS Digital and NHS England to review existing and, where required, develop further indicators for this data set.</p>
+
+          <p>From April 2017 the Patient Online Management Information data will no longer be published via the Indicator Portal. The data will be made available via the&nbsp;<a href="https://www.digital.nhs.uk/GP-Data-Hub" target="_blank">NHS Digital GP Data Hub</a>.</p>
+
+          <p>The data will continue to be refreshed on a monthly basis, and will be presented in an interactive dashboard in addition to an accessible .csv file, which can be accessed at&nbsp;<a href="http://content.digital.nhs.uk/pomipublications" target="_blank">http://content.digital.nhs.uk/pomipublications</a>. The time lag between the end of a reporting month and release of the data will be decreased to less than a month (e.g. data for the month of June will be made available before the end of July).</p>
+
+          <p>An overview of the available indicators for both the PHF10 and the POMI returns can be viewed below.</p>
+
+          <p>Patient Online Management Information (POMI) - Monthly Reporting (from February 2016)</p>
+
+          <ul>
+           <li>GP System Functionality for Patients to Book or Cancel Appointments Electronically</li>
+           <li>GP System Functionality for Patients to Order Repeat Prescriptions Electronically</li>
+           <li>GP System Functionality for Patients to View Detailed Coded Records (DCR) Electronically</li>
+          </ul>
+
+          <p>Patient Online Management Information (POMI) - Monthly Reporting (from April 2015)</p>
+
+          <ul>
+           <li>GP System Functionality for Patients to Book or Cancel Appointments Electronically</li>
+           <li>GP System Functionality for Patients to Order Repeat Prescriptions Electronically</li>
+           <li>GP System Functionality for Patients to View GP Letters Electronically</li>
+           <li>GP System Functionality for Patients to View Test Results Electronically</li>
+          </ul>
+
+          <p>PHF10 - Quarterly Reporting (to March 2015)</p>
+
+          <ul>
+           <li>GP System Functionality for Patients to Book or Cancel Appointments Electronically</li>
+           <li>GP System Functionality for Patients to View or Order Repeat Prescriptions Electronically</li>
+           <li>GP System Functionality for Patients to View GP Letters Electronically</li>
+           <li>GP System Functionality for Patients to View Test Results Electronically</li>
+           <li>GP System Functionality for Patients to View a Subset of Medical Records Electronically</li>
+           <li>GP System Functionality for Patients to View Full Medical Records Electronically</li>
+          </ul>
+
+          <p>Other useful links</p>
+
+          <p>NHS England<br />
+          <a href="http://www.england.nhs.uk/ourwork/pe/patient-online//" target="_blank">http://www.england.nhs.uk/ourwork/pe/patient-online/</a></p>
+
+          <p>GP System of Choice (GPSoC)<br />
+          <a href="http://systems.hscic.gov.uk/gpsoc" target="_blank">http://systems.hscic.gov.uk/gpsoc</a></p>
+
+          <p>Department of Health - the Government’s initial plan (white paper) for the period November 2012 - March 2015 (the government term)<br />
+          <a href="http://www.dh.gov.uk/en/Publicationsandstatistics/Publications/PublicationsPolicyAndGuidance/DH_117353" target="_blank">http://www.dh.gov.uk/en/Publicationsandstatistics/Publications/PublicationsPolicyAndGuidance/DH_117353</a></p>
+        jcr:primaryType: hippostd:html
+      common:searchable: true
+      hippo:availability: []
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T20:53:46.749Z
+      hippostdpubwf:lastModificationDate: 2018-01-24T23:26:47.773Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 5015f06a-b8c2-4299-8555-ab385dd3f0f3
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:cilanding
+      jcr:uuid: 25845371-c33b-4db9-a97a-ad154c0a11e1
+      publicationsystem:title: Patient Online Management Information (POMI)
+    /patient-online-management-information-pomi[2]:
+      /publicationsystem:content:
+        hippostd:content: |-
+          <p>The Patient Online services indicator set was commissioned by NHS England to monitor progress against a government ambition for all patients who wish it to have online access to services in general practices by the end of March 2015.</p>
+
+          <p>This information was made available via the PHF10 return that collected information on a quarterly basis from system suppliers on the availability at GP practice level of online appointment booking, ordering of repeat prescriptions and access to medical records, test results, GP letters and summary information (allergies, adverse reactions and medications). This data was collected via the NHS Digital Data Depot secure file transfer system.</p>
+
+          <p>During the 2014/15 financial year (Q2 to Q4) the introduction of data requirements for the NHS Digital's GP System of Choice (GPSoC) team was combined with the PHF10 return and piloted to run monthly reporting in an attempt to make this ‘online availability data’ more frequently accessible and relevant.</p>
+
+          <p>Following the successful pilot of the monthly reporting, GPSoC and NHS England agreed to develop the metrics for this indicator set. As a result, from April 2015 the Patient Online Management Information (POMI) indicator set was introduced, replacing the old PHF10 return. The new POMI return continues to collect information on the availability to patients of electronic access to their test results, GP letters, prescriptions and online appointment booking facilities at the GP Practice level.</p>
+
+          <p>The subset and full medical records viewing services are being redefined to align with the requirements in the 2015/16 GMS/PMS regulations and the two previous indicators have been decommissioned from April 2015. This review will also consider other elements within the indicator set and how these align with the redefined indicators.</p>
+
+          <p>The new indicator to provide information on the availability to patients to access their detailed coded record (DCR) was introduced from February 2016, and the previous indicators for test results and letters decommissioned from April 2016. Work is ongoing between the NHS Digital and NHS England to review existing and, where required, develop further indicators for this data set.</p>
+
+          <p>From April 2017 the Patient Online Management Information data will no longer be published via the Indicator Portal. The data will be made available via the&nbsp;<a href="https://www.digital.nhs.uk/GP-Data-Hub" target="_blank">NHS Digital GP Data Hub</a>.</p>
+
+          <p>The data will continue to be refreshed on a monthly basis, and will be presented in an interactive dashboard in addition to an accessible .csv file, which can be accessed at&nbsp;<a href="http://content.digital.nhs.uk/pomipublications" target="_blank">http://content.digital.nhs.uk/pomipublications</a>. The time lag between the end of a reporting month and release of the data will be decreased to less than a month (e.g. data for the month of June will be made available before the end of July).</p>
+
+          <p>An overview of the available indicators for both the PHF10 and the POMI returns can be viewed below.</p>
+
+          <p>Patient Online Management Information (POMI) - Monthly Reporting (from February 2016)</p>
+
+          <ul>
+           <li>GP System Functionality for Patients to Book or Cancel Appointments Electronically</li>
+           <li>GP System Functionality for Patients to Order Repeat Prescriptions Electronically</li>
+           <li>GP System Functionality for Patients to View Detailed Coded Records (DCR) Electronically</li>
+          </ul>
+
+          <p>Patient Online Management Information (POMI) - Monthly Reporting (from April 2015)</p>
+
+          <ul>
+           <li>GP System Functionality for Patients to Book or Cancel Appointments Electronically</li>
+           <li>GP System Functionality for Patients to Order Repeat Prescriptions Electronically</li>
+           <li>GP System Functionality for Patients to View GP Letters Electronically</li>
+           <li>GP System Functionality for Patients to View Test Results Electronically</li>
+          </ul>
+
+          <p>PHF10 - Quarterly Reporting (to March 2015)</p>
+
+          <ul>
+           <li>GP System Functionality for Patients to Book or Cancel Appointments Electronically</li>
+           <li>GP System Functionality for Patients to View or Order Repeat Prescriptions Electronically</li>
+           <li>GP System Functionality for Patients to View GP Letters Electronically</li>
+           <li>GP System Functionality for Patients to View Test Results Electronically</li>
+           <li>GP System Functionality for Patients to View a Subset of Medical Records Electronically</li>
+           <li>GP System Functionality for Patients to View Full Medical Records Electronically</li>
+          </ul>
+
+          <p>Other useful links</p>
+
+          <p>NHS England<br />
+          <a href="http://www.england.nhs.uk/ourwork/pe/patient-online//" target="_blank">http://www.england.nhs.uk/ourwork/pe/patient-online/</a></p>
+
+          <p>GP System of Choice (GPSoC)<br />
+          <a href="http://systems.hscic.gov.uk/gpsoc" target="_blank">http://systems.hscic.gov.uk/gpsoc</a></p>
+
+          <p>Department of Health - the Government’s initial plan (white paper) for the period November 2012 - March 2015 (the government term)<br />
+          <a href="http://www.dh.gov.uk/en/Publicationsandstatistics/Publications/PublicationsPolicyAndGuidance/DH_117353" target="_blank">http://www.dh.gov.uk/en/Publicationsandstatistics/Publications/PublicationsPolicyAndGuidance/DH_117353</a></p>
+        jcr:primaryType: hippostd:html
+      common:searchable: true
+      hippo:availability:
+      - preview
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T20:53:46.749Z
+      hippostdpubwf:lastModificationDate: 2018-01-24T23:26:51.031Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 5015f06a-b8c2-4299-8555-ab385dd3f0f3
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      - mix:versionable
+      jcr:primaryType: publicationsystem:cilanding
+      jcr:uuid: 7f6fd48f-a20a-4cb2-a3cc-39218709552d
+      publicationsystem:title: Patient Online Management Information (POMI)
+    /patient-online-management-information-pomi[3]:
+      /publicationsystem:content:
+        hippostd:content: |-
+          <p>The Patient Online services indicator set was commissioned by NHS England to monitor progress against a government ambition for all patients who wish it to have online access to services in general practices by the end of March 2015.</p>
+
+          <p>This information was made available via the PHF10 return that collected information on a quarterly basis from system suppliers on the availability at GP practice level of online appointment booking, ordering of repeat prescriptions and access to medical records, test results, GP letters and summary information (allergies, adverse reactions and medications). This data was collected via the NHS Digital Data Depot secure file transfer system.</p>
+
+          <p>During the 2014/15 financial year (Q2 to Q4) the introduction of data requirements for the NHS Digital's GP System of Choice (GPSoC) team was combined with the PHF10 return and piloted to run monthly reporting in an attempt to make this ‘online availability data’ more frequently accessible and relevant.</p>
+
+          <p>Following the successful pilot of the monthly reporting, GPSoC and NHS England agreed to develop the metrics for this indicator set. As a result, from April 2015 the Patient Online Management Information (POMI) indicator set was introduced, replacing the old PHF10 return. The new POMI return continues to collect information on the availability to patients of electronic access to their test results, GP letters, prescriptions and online appointment booking facilities at the GP Practice level.</p>
+
+          <p>The subset and full medical records viewing services are being redefined to align with the requirements in the 2015/16 GMS/PMS regulations and the two previous indicators have been decommissioned from April 2015. This review will also consider other elements within the indicator set and how these align with the redefined indicators.</p>
+
+          <p>The new indicator to provide information on the availability to patients to access their detailed coded record (DCR) was introduced from February 2016, and the previous indicators for test results and letters decommissioned from April 2016. Work is ongoing between the NHS Digital and NHS England to review existing and, where required, develop further indicators for this data set.</p>
+
+          <p>From April 2017 the Patient Online Management Information data will no longer be published via the Indicator Portal. The data will be made available via the&nbsp;<a href="https://www.digital.nhs.uk/GP-Data-Hub" target="_blank">NHS Digital GP Data Hub</a>.</p>
+
+          <p>The data will continue to be refreshed on a monthly basis, and will be presented in an interactive dashboard in addition to an accessible .csv file, which can be accessed at&nbsp;<a href="http://content.digital.nhs.uk/pomipublications" target="_blank">http://content.digital.nhs.uk/pomipublications</a>. The time lag between the end of a reporting month and release of the data will be decreased to less than a month (e.g. data for the month of June will be made available before the end of July).</p>
+
+          <p>An overview of the available indicators for both the PHF10 and the POMI returns can be viewed below.</p>
+
+          <p>Patient Online Management Information (POMI) - Monthly Reporting (from February 2016)</p>
+
+          <ul>
+           <li>GP System Functionality for Patients to Book or Cancel Appointments Electronically</li>
+           <li>GP System Functionality for Patients to Order Repeat Prescriptions Electronically</li>
+           <li>GP System Functionality for Patients to View Detailed Coded Records (DCR) Electronically</li>
+          </ul>
+
+          <p>Patient Online Management Information (POMI) - Monthly Reporting (from April 2015)</p>
+
+          <ul>
+           <li>GP System Functionality for Patients to Book or Cancel Appointments Electronically</li>
+           <li>GP System Functionality for Patients to Order Repeat Prescriptions Electronically</li>
+           <li>GP System Functionality for Patients to View GP Letters Electronically</li>
+           <li>GP System Functionality for Patients to View Test Results Electronically</li>
+          </ul>
+
+          <p>PHF10 - Quarterly Reporting (to March 2015)</p>
+
+          <ul>
+           <li>GP System Functionality for Patients to Book or Cancel Appointments Electronically</li>
+           <li>GP System Functionality for Patients to View or Order Repeat Prescriptions Electronically</li>
+           <li>GP System Functionality for Patients to View GP Letters Electronically</li>
+           <li>GP System Functionality for Patients to View Test Results Electronically</li>
+           <li>GP System Functionality for Patients to View a Subset of Medical Records Electronically</li>
+           <li>GP System Functionality for Patients to View Full Medical Records Electronically</li>
+          </ul>
+
+          <p>Other useful links</p>
+
+          <p>NHS England<br />
+          <a href="http://www.england.nhs.uk/ourwork/pe/patient-online//" target="_blank">http://www.england.nhs.uk/ourwork/pe/patient-online/</a></p>
+
+          <p>GP System of Choice (GPSoC)<br />
+          <a href="http://systems.hscic.gov.uk/gpsoc" target="_blank">http://systems.hscic.gov.uk/gpsoc</a></p>
+
+          <p>Department of Health - the Government’s initial plan (white paper) for the period November 2012 - March 2015 (the government term)<br />
+          <a href="http://www.dh.gov.uk/en/Publicationsandstatistics/Publications/PublicationsPolicyAndGuidance/DH_117353" target="_blank">http://www.dh.gov.uk/en/Publicationsandstatistics/Publications/PublicationsPolicyAndGuidance/DH_117353</a></p>
+        jcr:primaryType: hippostd:html
+      common:searchable: true
+      hippo:availability:
+      - live
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T20:53:46.749Z
+      hippostdpubwf:lastModificationDate: 2018-01-24T23:26:51.031Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2018-01-24T23:26:53.281Z
+      hippotranslation:id: 5015f06a-b8c2-4299-8555-ab385dd3f0f3
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:cilanding
+      jcr:uuid: cc969736-adcc-4fc0-9e07-3fdb50745153
+      publicationsystem:title: Patient Online Management Information (POMI)
+    hippo:name: Patient Online Management Information (POMI)
+    jcr:mixinTypes:
+    - hippo:named
+    - mix:referenceable
+    jcr:primaryType: hippo:handle
+    jcr:uuid: bf0cccd0-840b-4d7b-b71f-03b25454deba
+  /social-care:
+    /social-care[1]:
+      /publicationsystem:content:
+        hippostd:content: |-
+          <p>The Adult Social Care Outcomes Framework measures how well care and support services achieve the outcomes that matter most to people. The ASCOF is used both locally and nationally to set priorities for care and support, measure progress and strengthen transparency and accountability.</p>
+
+          <p>The measures are split across four domains:</p>
+
+          <ol>
+           <li>Enhancing quality of life for people with care and support needs</li>
+           <li>Delaying and reducing the need for care and support</li>
+           <li>Ensuring that people have a positive experience of care and support</li>
+           <li>Safeguarding adults whose circumstances make them vulnerable and protecting from avoidable harm</li>
+          </ol>
+
+          <p>This section provides data on the ASCOF outcomes for the 2016-17 reporting year. Data are provided at council, regional and national level for each outcome.&nbsp;</p>
+
+          <p>Data for the measures are sourced from:&nbsp;</p>
+
+          <ul>
+           <li>Personal Social Services Adult Social Care Survey (ASCS)</li>
+           <li>Personal Social Services Survey of Adult Carers in England (SACE)</li>
+           <li>Hospital Episode Statistics (HES)</li>
+           <li>Delayed Transfers of Care (DToC)</li>
+           <li>Office for National Statistics (ONS) 2016 mid-year population estimates</li>
+           <li>Short and Long-term (SALT) return</li>
+          </ul>
+
+          <p>The ASCOF Handbook of Definitions provides full methodologies, rationales and worked examples for each outcome. Users who are unfamiliar with these indicators would benefit from reading this document before making any conclusions on the outcomes. It is available via the following link:<br />
+          <a href="https://www.gov.uk/government/publications/adult-social-care-outcomes-framework-handbook-of-definitions" target="_blank">https://www.gov.uk/government/publications/adult-social-care-outcomes-framework-handbook-of-definitions</a></p>
+
+          <p>&nbsp;</p>
+
+          <p>The 2016-17 ASCOF written report and associated annexes (including disaggregated data in both Excel and .csv formats, relevant tables and charts, monthly data for measures based on data from HES and the Mental Health Services Dataset, and a time-series of aggregated measures) were published on 25 October 2017, and are available on the publication webpage at:<br />
+          <a href="http://www.content.digital.nhs.uk/catalogue/PUB30122" target="_blank">http://www.digital.nhs.uk/catalogue/PUB30122</a></p>
+
+          <p>The ASCOF measures 1F and 1H which are based on the Mental Health data set have been suspended in 2016-17 due to the quality and completeness of the data and so are not included in the Indicator Portal. The 1F and 1H outcomes have also not been included in the 2016-17 report, csv, disaggregated annex and time series annex file. The CASSR 1F and 1H scores have been made available in a separate annex file to enable CASSRs to see what their 2016-17 scores would have been, this is available on the publication page at:<br />
+          <a href="http://www.content.digital.nhs.uk/catalogue/PUB30122" target="_blank">http://www.digital.nhs.uk/catalogue/PUB30122</a></p>
+        jcr:primaryType: hippostd:html
+      common:searchable: true
+      hippo:availability: []
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T20:51:55.391Z
+      hippostdpubwf:lastModificationDate: 2018-01-24T23:27:09.530Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 3306448a-ac36-4c04-b397-8ce288b28d68
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:cilanding
+      jcr:uuid: d27bbef8-d67a-465b-8d6b-05d9bd665f7f
+      publicationsystem:title: Social Care
+    /social-care[2]:
+      /publicationsystem:content:
+        hippostd:content: |-
+          <p>The Adult Social Care Outcomes Framework measures how well care and support services achieve the outcomes that matter most to people. The ASCOF is used both locally and nationally to set priorities for care and support, measure progress and strengthen transparency and accountability.</p>
+
+          <p>The measures are split across four domains:</p>
+
+          <ol>
+           <li>Enhancing quality of life for people with care and support needs</li>
+           <li>Delaying and reducing the need for care and support</li>
+           <li>Ensuring that people have a positive experience of care and support</li>
+           <li>Safeguarding adults whose circumstances make them vulnerable and protecting from avoidable harm</li>
+          </ol>
+
+          <p>This section provides data on the ASCOF outcomes for the 2016-17 reporting year. Data are provided at council, regional and national level for each outcome.&nbsp;</p>
+
+          <p>Data for the measures are sourced from:&nbsp;</p>
+
+          <ul>
+           <li>Personal Social Services Adult Social Care Survey (ASCS)</li>
+           <li>Personal Social Services Survey of Adult Carers in England (SACE)</li>
+           <li>Hospital Episode Statistics (HES)</li>
+           <li>Delayed Transfers of Care (DToC)</li>
+           <li>Office for National Statistics (ONS) 2016 mid-year population estimates</li>
+           <li>Short and Long-term (SALT) return</li>
+          </ul>
+
+          <p>The ASCOF Handbook of Definitions provides full methodologies, rationales and worked examples for each outcome. Users who are unfamiliar with these indicators would benefit from reading this document before making any conclusions on the outcomes. It is available via the following link:<br />
+          <a href="https://www.gov.uk/government/publications/adult-social-care-outcomes-framework-handbook-of-definitions" target="_blank">https://www.gov.uk/government/publications/adult-social-care-outcomes-framework-handbook-of-definitions</a></p>
+
+          <p>&nbsp;</p>
+
+          <p>The 2016-17 ASCOF written report and associated annexes (including disaggregated data in both Excel and .csv formats, relevant tables and charts, monthly data for measures based on data from HES and the Mental Health Services Dataset, and a time-series of aggregated measures) were published on 25 October 2017, and are available on the publication webpage at:<br />
+          <a href="http://www.content.digital.nhs.uk/catalogue/PUB30122" target="_blank">http://www.digital.nhs.uk/catalogue/PUB30122</a></p>
+
+          <p>The ASCOF measures 1F and 1H which are based on the Mental Health data set have been suspended in 2016-17 due to the quality and completeness of the data and so are not included in the Indicator Portal. The 1F and 1H outcomes have also not been included in the 2016-17 report, csv, disaggregated annex and time series annex file. The CASSR 1F and 1H scores have been made available in a separate annex file to enable CASSRs to see what their 2016-17 scores would have been, this is available on the publication page at:<br />
+          <a href="http://www.content.digital.nhs.uk/catalogue/PUB30122" target="_blank">http://www.digital.nhs.uk/catalogue/PUB30122</a></p>
+        jcr:primaryType: hippostd:html
+      common:searchable: true
+      hippo:availability:
+      - preview
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T20:51:55.391Z
+      hippostdpubwf:lastModificationDate: 2018-01-24T23:27:12.020Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 3306448a-ac36-4c04-b397-8ce288b28d68
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      - mix:versionable
+      jcr:primaryType: publicationsystem:cilanding
+      jcr:uuid: da0dbcf9-ca8d-4d49-8af1-5f9b54ea0281
+      publicationsystem:title: Social Care
+    /social-care[3]:
+      /publicationsystem:content:
+        hippostd:content: |-
+          <p>The Adult Social Care Outcomes Framework measures how well care and support services achieve the outcomes that matter most to people. The ASCOF is used both locally and nationally to set priorities for care and support, measure progress and strengthen transparency and accountability.</p>
+
+          <p>The measures are split across four domains:</p>
+
+          <ol>
+           <li>Enhancing quality of life for people with care and support needs</li>
+           <li>Delaying and reducing the need for care and support</li>
+           <li>Ensuring that people have a positive experience of care and support</li>
+           <li>Safeguarding adults whose circumstances make them vulnerable and protecting from avoidable harm</li>
+          </ol>
+
+          <p>This section provides data on the ASCOF outcomes for the 2016-17 reporting year. Data are provided at council, regional and national level for each outcome.&nbsp;</p>
+
+          <p>Data for the measures are sourced from:&nbsp;</p>
+
+          <ul>
+           <li>Personal Social Services Adult Social Care Survey (ASCS)</li>
+           <li>Personal Social Services Survey of Adult Carers in England (SACE)</li>
+           <li>Hospital Episode Statistics (HES)</li>
+           <li>Delayed Transfers of Care (DToC)</li>
+           <li>Office for National Statistics (ONS) 2016 mid-year population estimates</li>
+           <li>Short and Long-term (SALT) return</li>
+          </ul>
+
+          <p>The ASCOF Handbook of Definitions provides full methodologies, rationales and worked examples for each outcome. Users who are unfamiliar with these indicators would benefit from reading this document before making any conclusions on the outcomes. It is available via the following link:<br />
+          <a href="https://www.gov.uk/government/publications/adult-social-care-outcomes-framework-handbook-of-definitions" target="_blank">https://www.gov.uk/government/publications/adult-social-care-outcomes-framework-handbook-of-definitions</a></p>
+
+          <p>&nbsp;</p>
+
+          <p>The 2016-17 ASCOF written report and associated annexes (including disaggregated data in both Excel and .csv formats, relevant tables and charts, monthly data for measures based on data from HES and the Mental Health Services Dataset, and a time-series of aggregated measures) were published on 25 October 2017, and are available on the publication webpage at:<br />
+          <a href="http://www.content.digital.nhs.uk/catalogue/PUB30122" target="_blank">http://www.digital.nhs.uk/catalogue/PUB30122</a></p>
+
+          <p>The ASCOF measures 1F and 1H which are based on the Mental Health data set have been suspended in 2016-17 due to the quality and completeness of the data and so are not included in the Indicator Portal. The 1F and 1H outcomes have also not been included in the 2016-17 report, csv, disaggregated annex and time series annex file. The CASSR 1F and 1H scores have been made available in a separate annex file to enable CASSRs to see what their 2016-17 scores would have been, this is available on the publication page at:<br />
+          <a href="http://www.content.digital.nhs.uk/catalogue/PUB30122" target="_blank">http://www.digital.nhs.uk/catalogue/PUB30122</a></p>
+        jcr:primaryType: hippostd:html
+      common:searchable: true
+      hippo:availability:
+      - live
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T20:51:55.391Z
+      hippostdpubwf:lastModificationDate: 2018-01-24T23:27:12.020Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2018-01-24T23:27:14.092Z
+      hippotranslation:id: 3306448a-ac36-4c04-b397-8ce288b28d68
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:cilanding
+      jcr:uuid: 04cd307c-8e7e-4faf-8458-71d456fd64b9
+      publicationsystem:title: Social Care
+    hippo:name: Social Care
+    jcr:mixinTypes:
+    - hippo:named
+    - mix:referenceable
+    jcr:primaryType: hippo:handle
+    jcr:uuid: a6ac8e34-e305-41a1-adc6-36027dc3dff2
+  /summary-hospital-level-mortality-indicator-shmi:
+    /summary-hospital-level-mortality-indicator-shmi[1]:
+      /publicationsystem:content:
+        hippostd:content: |-
+          <p>The Summary Hospital-level Mortality Indicator (SHMI) reports on mortality at trust level across the NHS in England. This indicator is produced and published quarterly as a National Statistic by NHS Digital.&nbsp;</p>
+
+          <p>The SHMI is the ratio between the actual number of patients who die following hospitalisation at the trust and the number that would be expected to die on the basis of average England figures, given the characteristics of the patients treated there.</p>
+
+          <p>It covers all deaths reported of patients who were admitted to non-specialist acute NHS trusts in England and either died while in hospital or within 30 days of discharge. The expected number of deaths is calculated from statistical models derived to estimate the risk of mortality based on the characteristics of the patients (including the condition the patient is in hospital for, other underlying conditions the patient suffers from, age, gender and method of admission to hospital).</p>
+
+          <p>The data used to produce the SHMI are generated from data the trusts submit to the Secondary Uses Service (SUS). The data are processed by NHS Digital to create Hospital Episode Statistics (HES) data, which are then linked with death registrations data from the Office for National Statistics (ONS) to allow deaths which occurred outside of hospital to be captured. A combination of finalised and provisional HES data is used in the calculation of the SHMI to ensure that the indicator is as timely as possible.</p>
+
+          <p>Further information and related documents can be accessed from the SHMI support and guidance page at&nbsp;<a href="http://www.digital.nhs.uk/SHMI" target="_blank">http://www.digital.nhs.uk/SHMI</a>.</p>
+
+          <p>Downloads for the five most recent SHMI releases are available from the 'Recent SHMI Publications' page on this Indicator Portal. Downloads for earlier SHMI publications are available from the 'Historic SHMI Publications' page on this Indicator Portal.</p>
+
+          <h2>How to use the SHMI</h2>
+
+          <p>The SHMI for each trust is published along with a banding indicating whether a trust's SHMI is 'higher than expected', 'as expected' or 'lower than expected'. For any given number of expected deaths, a range of observed deaths is considered to be 'as expected'. If the observed number of deaths falls outside of this range, the trust in question is considered to have a higher or lower SHMI than expected.</p>
+
+          <p>The methodology used to calculate the expected number of deaths for a particular trust takes into account the number of patients treated and their characteristics (including the condition the patient is in hospital for, other underlying conditions the patient suffers from, age, gender and method of admission to hospital) and so these factors should not influence a trust's SHMI. There are many other factors which have the potential to affect a trust's SHMI including (but not limited to) the quality of the data upon which the SHMI is based, other patient characteristics not listed above, the organisation of services and availability of resources e.g. staff, and quality of care.</p>
+
+          <p>This means that, unlike some other official statistics, it is not possible to give specific reasons for a trust having a 'higher than expected' or 'lower than expected' SHMI because many of the factors which can affect this and can be identified in the underlying data have already been adjusted for. Therefore, a 'higher than expected' SHMI should not immediately be interpreted as indicating bad performance and instead should be viewed as a 'smoke alarm' which requires further investigation by the trust. Further information on how trusts should investigate a 'higher than expected' SHMI is available in the 'SHMI guidance for trusts' document which is available to download from&nbsp;<a href="http://www.digital.nhs.uk/SHMI" target="_blank">http://www.digital.nhs.uk/SHMI</a>.</p>
+
+          <p>Similarly, an 'as expected' or 'lower than expected' SHMI should not immediately be interpreted as indicating satisfactory or good performance. The SHMI requires careful interpretation and should be used in conjunction with other indicators and information from other sources (e.g. patient feedback, staff surveys and other similar material) that together form a holistic view of trust outcomes.</p>
+
+          <p>The SHMI is not designed to measure changes in mortality over time. Instead, its purpose is to compare mortality outcomes for hospital trusts to the England average at a fixed point in time. The SHMI can be used by hospital trusts to compare their mortality outcomes to this national baseline. Regulators (for example, the Care Quality Commission) and commissioning organisations can also use the SHMI to investigate outcomes for trusts.&nbsp;<strong>However, it cannot be used to directly compare mortality outcomes between trusts and it is inappropriate to rank trusts according to their SHMI.</strong></p>
+
+          <p>Where a trust has an 'as expected' SHMI, it is inappropriate to conclude that their SHMI is lower or higher than the national baseline, even if the number of observed deaths is smaller or larger than the number of expected deaths. This is because the trust has been placed in the 'as expected' range because any variation from the number of expected deaths is not statistically significant.</p>
+
+          <p>The difference between the number of observed deaths and the number of expected deaths cannot be interpreted as the number of avoidable deaths for the trust. Whether or not a death could have been prevented can only be investigated by a detailed case-note review. The SHMI is not a direct measure of quality of care.</p>
+
+          <p>The expected number of deaths for each trust is not an actual count of patients, but is a statistical construct which estimates the number of deaths that may be expected at the trust on the basis of average England figures and the characteristics of the patients treated there.</p>
+
+          <p>Further information on how to accurately describe and interpret the SHMI is available in the document 'SHMI interpretation guidance', which is available to download from&nbsp;<a href="http://www.digital.nhs.uk/SHMI" target="_blank">http://www.digital.nhs.uk/SHMI</a>.</p>
+
+          <h2>Revisions procedure</h2>
+
+          <p>Any revisions and/or corrections relating to the SHMI publication will comply with NHS Digital's Revisions Procedure which is available on the NHS Digital website at&nbsp;<a href="http://www.digital.nhs.uk/pubs/calendar" target="_blank">http://www.digital.nhs.uk/pubs/calendar</a>.</p>
+        jcr:primaryType: hippostd:html
+      common:searchable: true
+      hippo:availability: []
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T20:53:22.404Z
+      hippostdpubwf:lastModificationDate: 2018-01-24T23:25:54.935Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 5ee1c6c1-8692-4a15-a04a-bb721e0c7874
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:cilanding
+      jcr:uuid: b1d1acfe-a84c-41ee-8b75-176cdbc00527
+      publicationsystem:title: Summary Hospital-level Mortality Indicator (SHMI)
+    /summary-hospital-level-mortality-indicator-shmi[2]:
+      /publicationsystem:content:
+        hippostd:content: |-
+          <p>The Summary Hospital-level Mortality Indicator (SHMI) reports on mortality at trust level across the NHS in England. This indicator is produced and published quarterly as a National Statistic by NHS Digital.&nbsp;</p>
+
+          <p>The SHMI is the ratio between the actual number of patients who die following hospitalisation at the trust and the number that would be expected to die on the basis of average England figures, given the characteristics of the patients treated there.</p>
+
+          <p>It covers all deaths reported of patients who were admitted to non-specialist acute NHS trusts in England and either died while in hospital or within 30 days of discharge. The expected number of deaths is calculated from statistical models derived to estimate the risk of mortality based on the characteristics of the patients (including the condition the patient is in hospital for, other underlying conditions the patient suffers from, age, gender and method of admission to hospital).</p>
+
+          <p>The data used to produce the SHMI are generated from data the trusts submit to the Secondary Uses Service (SUS). The data are processed by NHS Digital to create Hospital Episode Statistics (HES) data, which are then linked with death registrations data from the Office for National Statistics (ONS) to allow deaths which occurred outside of hospital to be captured. A combination of finalised and provisional HES data is used in the calculation of the SHMI to ensure that the indicator is as timely as possible.</p>
+
+          <p>Further information and related documents can be accessed from the SHMI support and guidance page at&nbsp;<a href="http://www.digital.nhs.uk/SHMI" target="_blank">http://www.digital.nhs.uk/SHMI</a>.</p>
+
+          <p>Downloads for the five most recent SHMI releases are available from the 'Recent SHMI Publications' page on this Indicator Portal. Downloads for earlier SHMI publications are available from the 'Historic SHMI Publications' page on this Indicator Portal.</p>
+
+          <h2>How to use the SHMI</h2>
+
+          <p>The SHMI for each trust is published along with a banding indicating whether a trust's SHMI is 'higher than expected', 'as expected' or 'lower than expected'. For any given number of expected deaths, a range of observed deaths is considered to be 'as expected'. If the observed number of deaths falls outside of this range, the trust in question is considered to have a higher or lower SHMI than expected.</p>
+
+          <p>The methodology used to calculate the expected number of deaths for a particular trust takes into account the number of patients treated and their characteristics (including the condition the patient is in hospital for, other underlying conditions the patient suffers from, age, gender and method of admission to hospital) and so these factors should not influence a trust's SHMI. There are many other factors which have the potential to affect a trust's SHMI including (but not limited to) the quality of the data upon which the SHMI is based, other patient characteristics not listed above, the organisation of services and availability of resources e.g. staff, and quality of care.</p>
+
+          <p>This means that, unlike some other official statistics, it is not possible to give specific reasons for a trust having a 'higher than expected' or 'lower than expected' SHMI because many of the factors which can affect this and can be identified in the underlying data have already been adjusted for. Therefore, a 'higher than expected' SHMI should not immediately be interpreted as indicating bad performance and instead should be viewed as a 'smoke alarm' which requires further investigation by the trust. Further information on how trusts should investigate a 'higher than expected' SHMI is available in the 'SHMI guidance for trusts' document which is available to download from&nbsp;<a href="http://www.digital.nhs.uk/SHMI" target="_blank">http://www.digital.nhs.uk/SHMI</a>.</p>
+
+          <p>Similarly, an 'as expected' or 'lower than expected' SHMI should not immediately be interpreted as indicating satisfactory or good performance. The SHMI requires careful interpretation and should be used in conjunction with other indicators and information from other sources (e.g. patient feedback, staff surveys and other similar material) that together form a holistic view of trust outcomes.</p>
+
+          <p>The SHMI is not designed to measure changes in mortality over time. Instead, its purpose is to compare mortality outcomes for hospital trusts to the England average at a fixed point in time. The SHMI can be used by hospital trusts to compare their mortality outcomes to this national baseline. Regulators (for example, the Care Quality Commission) and commissioning organisations can also use the SHMI to investigate outcomes for trusts.&nbsp;<strong>However, it cannot be used to directly compare mortality outcomes between trusts and it is inappropriate to rank trusts according to their SHMI.</strong></p>
+
+          <p>Where a trust has an 'as expected' SHMI, it is inappropriate to conclude that their SHMI is lower or higher than the national baseline, even if the number of observed deaths is smaller or larger than the number of expected deaths. This is because the trust has been placed in the 'as expected' range because any variation from the number of expected deaths is not statistically significant.</p>
+
+          <p>The difference between the number of observed deaths and the number of expected deaths cannot be interpreted as the number of avoidable deaths for the trust. Whether or not a death could have been prevented can only be investigated by a detailed case-note review. The SHMI is not a direct measure of quality of care.</p>
+
+          <p>The expected number of deaths for each trust is not an actual count of patients, but is a statistical construct which estimates the number of deaths that may be expected at the trust on the basis of average England figures and the characteristics of the patients treated there.</p>
+
+          <p>Further information on how to accurately describe and interpret the SHMI is available in the document 'SHMI interpretation guidance', which is available to download from&nbsp;<a href="http://www.digital.nhs.uk/SHMI" target="_blank">http://www.digital.nhs.uk/SHMI</a>.</p>
+
+          <h2>Revisions procedure</h2>
+
+          <p>Any revisions and/or corrections relating to the SHMI publication will comply with NHS Digital's Revisions Procedure which is available on the NHS Digital website at&nbsp;<a href="http://www.digital.nhs.uk/pubs/calendar" target="_blank">http://www.digital.nhs.uk/pubs/calendar</a>.</p>
+        jcr:primaryType: hippostd:html
+      common:searchable: true
+      hippo:availability:
+      - preview
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T20:53:22.404Z
+      hippostdpubwf:lastModificationDate: 2018-01-24T23:26:12.384Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 5ee1c6c1-8692-4a15-a04a-bb721e0c7874
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      - mix:versionable
+      jcr:primaryType: publicationsystem:cilanding
+      jcr:uuid: 5a58f566-3c35-43ee-a94b-61d27d0b7cbd
+      publicationsystem:title: Summary Hospital-level Mortality Indicator (SHMI)
+    /summary-hospital-level-mortality-indicator-shmi[3]:
+      /publicationsystem:content:
+        hippostd:content: |-
+          <p>The Summary Hospital-level Mortality Indicator (SHMI) reports on mortality at trust level across the NHS in England. This indicator is produced and published quarterly as a National Statistic by NHS Digital.&nbsp;</p>
+
+          <p>The SHMI is the ratio between the actual number of patients who die following hospitalisation at the trust and the number that would be expected to die on the basis of average England figures, given the characteristics of the patients treated there.</p>
+
+          <p>It covers all deaths reported of patients who were admitted to non-specialist acute NHS trusts in England and either died while in hospital or within 30 days of discharge. The expected number of deaths is calculated from statistical models derived to estimate the risk of mortality based on the characteristics of the patients (including the condition the patient is in hospital for, other underlying conditions the patient suffers from, age, gender and method of admission to hospital).</p>
+
+          <p>The data used to produce the SHMI are generated from data the trusts submit to the Secondary Uses Service (SUS). The data are processed by NHS Digital to create Hospital Episode Statistics (HES) data, which are then linked with death registrations data from the Office for National Statistics (ONS) to allow deaths which occurred outside of hospital to be captured. A combination of finalised and provisional HES data is used in the calculation of the SHMI to ensure that the indicator is as timely as possible.</p>
+
+          <p>Further information and related documents can be accessed from the SHMI support and guidance page at&nbsp;<a href="http://www.digital.nhs.uk/SHMI" target="_blank">http://www.digital.nhs.uk/SHMI</a>.</p>
+
+          <p>Downloads for the five most recent SHMI releases are available from the 'Recent SHMI Publications' page on this Indicator Portal. Downloads for earlier SHMI publications are available from the 'Historic SHMI Publications' page on this Indicator Portal.</p>
+
+          <h2>How to use the SHMI</h2>
+
+          <p>The SHMI for each trust is published along with a banding indicating whether a trust's SHMI is 'higher than expected', 'as expected' or 'lower than expected'. For any given number of expected deaths, a range of observed deaths is considered to be 'as expected'. If the observed number of deaths falls outside of this range, the trust in question is considered to have a higher or lower SHMI than expected.</p>
+
+          <p>The methodology used to calculate the expected number of deaths for a particular trust takes into account the number of patients treated and their characteristics (including the condition the patient is in hospital for, other underlying conditions the patient suffers from, age, gender and method of admission to hospital) and so these factors should not influence a trust's SHMI. There are many other factors which have the potential to affect a trust's SHMI including (but not limited to) the quality of the data upon which the SHMI is based, other patient characteristics not listed above, the organisation of services and availability of resources e.g. staff, and quality of care.</p>
+
+          <p>This means that, unlike some other official statistics, it is not possible to give specific reasons for a trust having a 'higher than expected' or 'lower than expected' SHMI because many of the factors which can affect this and can be identified in the underlying data have already been adjusted for. Therefore, a 'higher than expected' SHMI should not immediately be interpreted as indicating bad performance and instead should be viewed as a 'smoke alarm' which requires further investigation by the trust. Further information on how trusts should investigate a 'higher than expected' SHMI is available in the 'SHMI guidance for trusts' document which is available to download from&nbsp;<a href="http://www.digital.nhs.uk/SHMI" target="_blank">http://www.digital.nhs.uk/SHMI</a>.</p>
+
+          <p>Similarly, an 'as expected' or 'lower than expected' SHMI should not immediately be interpreted as indicating satisfactory or good performance. The SHMI requires careful interpretation and should be used in conjunction with other indicators and information from other sources (e.g. patient feedback, staff surveys and other similar material) that together form a holistic view of trust outcomes.</p>
+
+          <p>The SHMI is not designed to measure changes in mortality over time. Instead, its purpose is to compare mortality outcomes for hospital trusts to the England average at a fixed point in time. The SHMI can be used by hospital trusts to compare their mortality outcomes to this national baseline. Regulators (for example, the Care Quality Commission) and commissioning organisations can also use the SHMI to investigate outcomes for trusts.&nbsp;<strong>However, it cannot be used to directly compare mortality outcomes between trusts and it is inappropriate to rank trusts according to their SHMI.</strong></p>
+
+          <p>Where a trust has an 'as expected' SHMI, it is inappropriate to conclude that their SHMI is lower or higher than the national baseline, even if the number of observed deaths is smaller or larger than the number of expected deaths. This is because the trust has been placed in the 'as expected' range because any variation from the number of expected deaths is not statistically significant.</p>
+
+          <p>The difference between the number of observed deaths and the number of expected deaths cannot be interpreted as the number of avoidable deaths for the trust. Whether or not a death could have been prevented can only be investigated by a detailed case-note review. The SHMI is not a direct measure of quality of care.</p>
+
+          <p>The expected number of deaths for each trust is not an actual count of patients, but is a statistical construct which estimates the number of deaths that may be expected at the trust on the basis of average England figures and the characteristics of the patients treated there.</p>
+
+          <p>Further information on how to accurately describe and interpret the SHMI is available in the document 'SHMI interpretation guidance', which is available to download from&nbsp;<a href="http://www.digital.nhs.uk/SHMI" target="_blank">http://www.digital.nhs.uk/SHMI</a>.</p>
+
+          <h2>Revisions procedure</h2>
+
+          <p>Any revisions and/or corrections relating to the SHMI publication will comply with NHS Digital's Revisions Procedure which is available on the NHS Digital website at&nbsp;<a href="http://www.digital.nhs.uk/pubs/calendar" target="_blank">http://www.digital.nhs.uk/pubs/calendar</a>.</p>
+        jcr:primaryType: hippostd:html
+      common:searchable: true
+      hippo:availability:
+      - live
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-23T20:53:22.404Z
+      hippostdpubwf:lastModificationDate: 2018-01-24T23:26:12.384Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2018-01-24T23:26:14.695Z
+      hippotranslation:id: 5ee1c6c1-8692-4a15-a04a-bb721e0c7874
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:cilanding
+      jcr:uuid: a9156f18-a794-41bb-841c-9e357b31de01
+      publicationsystem:title: Summary Hospital-level Mortality Indicator (SHMI)
+    hippo:name: Summary Hospital-level Mortality Indicator (SHMI)
+    jcr:mixinTypes:
+    - hippo:named
+    - mix:referenceable
+    jcr:primaryType: hippo:handle
+    jcr:uuid: 2b6ca5d1-61e4-4d01-a05e-d209d309c15c
+  hippo:name: CI hub
+  hippostd:foldertype:
+  - new-translated-folder
+  - new-document
+  hippotranslation:id: 00000000-0000-0000-0000-000000000000
+  hippotranslation:locale: en
+  jcr:mixinTypes:
+  - hippo:named
+  - hippotranslation:translated
+  - mix:versionable
+  jcr:primaryType: hippostd:folder
+  jcr:uuid: 5d447649-674d-4e3f-881a-257c15cc7f7c

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/about/terms-and-conditions.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/about/terms-and-conditions.yaml
@@ -13,7 +13,7 @@
 
         <p>&nbsp;</p>
 
-        <p>1.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; References in these terms and conditions to “NHS Digital”, “we”, “our” and “us” are references to the Health and Social Care Information Centre, a non-departmental public body established under primary legislation and known as NHS Digital. The entire contents of this website, and the individual articles, items, media files and assets published are owned by NHS Digital, unless otherwise indicated.</p>
+        <p>1.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; References in these terms and conditions to "NHS Digital", "we", "our" and "us” are references to the Health and Social Care Information Centre, a non-departmental public body established under primary legislation and known as NHS Digital. The entire contents of this website, and the individual articles, items, media files and assets published are owned by NHS Digital, unless otherwise indicated.</p>
 
         <p>&nbsp;</p>
 
@@ -133,7 +133,7 @@
 
         <p><strong>&nbsp;</strong></p>
 
-        <p>7.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The material on this website includes information, data, text, images, videos, Information Standards, interactive services, link to products and apps and other works (“<strong>NHS Digital Content</strong>”).&nbsp; You acknowledge that all rights in copyright, patents, design rights, trade marks and other intellectual property rights (whether registered, capable of registration or otherwise) throughout the world, in this website and all NHS Digital Content are owned by, or licensed to NHS Digital, unless otherwise indicated. Some NHS Digital Content includes identifiable third-party content for which we will have sought permission for its inclusion.</p>
+        <p>7.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The material on this website includes information, data, text, images, videos, Information Standards, interactive services, link to products and apps and other works ("<strong>NHS Digital Content</strong>”).&nbsp; You acknowledge that all rights in copyright, patents, design rights, trade marks and other intellectual property rights (whether registered, capable of registration or otherwise) throughout the world, in this website and all NHS Digital Content are owned by, or licensed to NHS Digital, unless otherwise indicated. Some NHS Digital Content includes identifiable third-party content for which we will have sought permission for its inclusion.</p>
 
         <p><strong>&nbsp;</strong></p>
 
@@ -149,7 +149,7 @@
 
         <p>&nbsp;</p>
 
-        <p>8.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Copyright and database rights in the NHS Digital Content are released free-of-charge under the current version of the&nbsp;<a rel="nofollow" href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence</a>&nbsp;(“<strong>OGL</strong>”), except where specified, either in these terms and conditions, elsewhere on this website or in the OGL terms.&nbsp; This licence does not extend to any other intellectual property rights, including but not limited to patents, design rights and trade marks. If there is any conflict between the OGL terms and these terms and conditions these terms and conditions shall take precedence.&nbsp;</p>
+        <p>8.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Copyright and database rights in the NHS Digital Content are released free-of-charge under the current version of the&nbsp;<a rel="nofollow" href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence</a>&nbsp;("<strong>OGL</strong>”), except where specified, either in these terms and conditions, elsewhere on this website or in the OGL terms.&nbsp; This licence does not extend to any other intellectual property rights, including but not limited to patents, design rights and trade marks. If there is any conflict between the OGL terms and these terms and conditions these terms and conditions shall take precedence.&nbsp;</p>
 
         <p>&nbsp;</p>
 
@@ -199,13 +199,13 @@
 
         <p>8.4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; If you do use any NHS Digital Content you must attribute it with the following statement:</p>
 
-        <p>“<strong>Information from NHS Digital, licenced under the current version of the Open Government Licence</strong>”.</p>
+        <p>"<strong>Information from NHS Digital, licenced under the current version of the Open Government Licence</strong>”.</p>
 
         <ul>
          <li>or in cases where the NHS Digital Content is combined, adapted, or otherwise modified in line with these terms and conditions:</li>
         </ul>
 
-        <p>“<strong>Contains information from NHS Digital, licenced under the current version of the Open Government Licence</strong>”.</p>
+        <p>"<strong>Contains information from NHS Digital, licenced under the current version of the Open Government Licence</strong>”.</p>
 
         <p>8.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; By using any NHS Digital Content you accept and agree to the following terms:</p>
 
@@ -261,7 +261,7 @@
 
         <p><strong>&nbsp;</strong></p>
 
-        <p>9.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Comments posted should relate to your personal experience or that of someone close to you. You should not name any individuals (other than yourself) or include information through which someone else could identify an individual about whom you are writing. If you want to comment on someone else’s experience, (e.g. a relative or someone you care for) then you may do so if you ensure that you are not named in the posting and you state how the other person is connected to you (e.g. “my father”). You warrant that all statements of fact in any comment you submit are true, and that any expression of opinion is your honestly held opinion on those facts, or that of the person on whose behalf you are writing.</p>
+        <p>9.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Comments posted should relate to your personal experience or that of someone close to you. You should not name any individuals (other than yourself) or include information through which someone else could identify an individual about whom you are writing. If you want to comment on someone else’s experience, (e.g. a relative or someone you care for) then you may do so if you ensure that you are not named in the posting and you state how the other person is connected to you (e.g. "my father”). You warrant that all statements of fact in any comment you submit are true, and that any expression of opinion is your honestly held opinion on those facts, or that of the person on whose behalf you are writing.</p>
 
         <p><strong>&nbsp;</strong></p>
 
@@ -296,7 +296,7 @@
 
         <p><strong>&nbsp;</strong></p>
 
-        <p>10.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Our RSS feeds can be used as part of your website; however, we do require that proper format and attribution are used. The attribution text should read “<strong>NHS Digital</strong><strong>&nbsp;</strong><strong>RSS feeds</strong>”. We reserve the right from time to time to restrict the distribution of NHS Digital RSS feed content and do not accept any liability for these feeds.</p>
+        <p>10.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Our RSS feeds can be used as part of your website; however, we do require that proper format and attribution are used. The attribution text should read "<strong>NHS Digital</strong><strong>&nbsp;</strong><strong>RSS feeds</strong>”. We reserve the right from time to time to restrict the distribution of NHS Digital RSS feed content and do not accept any liability for these feeds.</p>
 
         <p><strong>&nbsp;</strong></p>
 
@@ -399,7 +399,7 @@
 
         <p>&nbsp;</p>
 
-        <p>1.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; References in these terms and conditions to “NHS Digital”, “we”, “our” and “us” are references to the Health and Social Care Information Centre, a non-departmental public body established under primary legislation and known as NHS Digital. The entire contents of this website, and the individual articles, items, media files and assets published are owned by NHS Digital, unless otherwise indicated.</p>
+        <p>1.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; References in these terms and conditions to "NHS Digital”, "we”, "our” and "us” are references to the Health and Social Care Information Centre, a non-departmental public body established under primary legislation and known as NHS Digital. The entire contents of this website, and the individual articles, items, media files and assets published are owned by NHS Digital, unless otherwise indicated.</p>
 
         <p>&nbsp;</p>
 
@@ -519,7 +519,7 @@
 
         <p><strong>&nbsp;</strong></p>
 
-        <p>7.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The material on this website includes information, data, text, images, videos, Information Standards, interactive services, link to products and apps and other works (“<strong>NHS Digital Content</strong>”).&nbsp; You acknowledge that all rights in copyright, patents, design rights, trade marks and other intellectual property rights (whether registered, capable of registration or otherwise) throughout the world, in this website and all NHS Digital Content are owned by, or licensed to NHS Digital, unless otherwise indicated. Some NHS Digital Content includes identifiable third-party content for which we will have sought permission for its inclusion.</p>
+        <p>7.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The material on this website includes information, data, text, images, videos, Information Standards, interactive services, link to products and apps and other works ("<strong>NHS Digital Content</strong>”).&nbsp; You acknowledge that all rights in copyright, patents, design rights, trade marks and other intellectual property rights (whether registered, capable of registration or otherwise) throughout the world, in this website and all NHS Digital Content are owned by, or licensed to NHS Digital, unless otherwise indicated. Some NHS Digital Content includes identifiable third-party content for which we will have sought permission for its inclusion.</p>
 
         <p><strong>&nbsp;</strong></p>
 
@@ -535,7 +535,7 @@
 
         <p>&nbsp;</p>
 
-        <p>8.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Copyright and database rights in the NHS Digital Content are released free-of-charge under the current version of the&nbsp;<a rel="nofollow" href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence</a>&nbsp;(“<strong>OGL</strong>”), except where specified, either in these terms and conditions, elsewhere on this website or in the OGL terms.&nbsp; This licence does not extend to any other intellectual property rights, including but not limited to patents, design rights and trade marks. If there is any conflict between the OGL terms and these terms and conditions these terms and conditions shall take precedence.&nbsp;</p>
+        <p>8.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Copyright and database rights in the NHS Digital Content are released free-of-charge under the current version of the&nbsp;<a rel="nofollow" href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence</a>&nbsp;("<strong>OGL</strong>”), except where specified, either in these terms and conditions, elsewhere on this website or in the OGL terms.&nbsp; This licence does not extend to any other intellectual property rights, including but not limited to patents, design rights and trade marks. If there is any conflict between the OGL terms and these terms and conditions these terms and conditions shall take precedence.&nbsp;</p>
 
         <p>&nbsp;</p>
 
@@ -585,13 +585,13 @@
 
         <p>8.4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; If you do use any NHS Digital Content you must attribute it with the following statement:</p>
 
-        <p>“<strong>Information from NHS Digital, licenced under the current version of the Open Government Licence</strong>”.</p>
+        <p>"<strong>Information from NHS Digital, licenced under the current version of the Open Government Licence</strong>”.</p>
 
         <ul>
          <li>or in cases where the NHS Digital Content is combined, adapted, or otherwise modified in line with these terms and conditions:</li>
         </ul>
 
-        <p>“<strong>Contains information from NHS Digital, licenced under the current version of the Open Government Licence</strong>”.</p>
+        <p>"<strong>Contains information from NHS Digital, licenced under the current version of the Open Government Licence</strong>”.</p>
 
         <p>8.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; By using any NHS Digital Content you accept and agree to the following terms:</p>
 
@@ -647,7 +647,7 @@
 
         <p><strong>&nbsp;</strong></p>
 
-        <p>9.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Comments posted should relate to your personal experience or that of someone close to you. You should not name any individuals (other than yourself) or include information through which someone else could identify an individual about whom you are writing. If you want to comment on someone else’s experience, (e.g. a relative or someone you care for) then you may do so if you ensure that you are not named in the posting and you state how the other person is connected to you (e.g. “my father”). You warrant that all statements of fact in any comment you submit are true, and that any expression of opinion is your honestly held opinion on those facts, or that of the person on whose behalf you are writing.</p>
+        <p>9.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Comments posted should relate to your personal experience or that of someone close to you. You should not name any individuals (other than yourself) or include information through which someone else could identify an individual about whom you are writing. If you want to comment on someone else’s experience, (e.g. a relative or someone you care for) then you may do so if you ensure that you are not named in the posting and you state how the other person is connected to you (e.g. "my father”). You warrant that all statements of fact in any comment you submit are true, and that any expression of opinion is your honestly held opinion on those facts, or that of the person on whose behalf you are writing.</p>
 
         <p><strong>&nbsp;</strong></p>
 
@@ -682,7 +682,7 @@
 
         <p><strong>&nbsp;</strong></p>
 
-        <p>10.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Our RSS feeds can be used as part of your website; however, we do require that proper format and attribution are used. The attribution text should read “<strong>NHS Digital</strong><strong>&nbsp;</strong><strong>RSS feeds</strong>”. We reserve the right from time to time to restrict the distribution of NHS Digital RSS feed content and do not accept any liability for these feeds.</p>
+        <p>10.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Our RSS feeds can be used as part of your website; however, we do require that proper format and attribution are used. The attribution text should read "<strong>NHS Digital</strong><strong>&nbsp;</strong><strong>RSS feeds</strong>”. We reserve the right from time to time to restrict the distribution of NHS Digital RSS feed content and do not accept any liability for these feeds.</p>
 
         <p><strong>&nbsp;</strong></p>
 
@@ -787,7 +787,7 @@
 
         <p>&nbsp;</p>
 
-        <p>1.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; References in these terms and conditions to “NHS Digital”, “we”, “our” and “us” are references to the Health and Social Care Information Centre, a non-departmental public body established under primary legislation and known as NHS Digital. The entire contents of this website, and the individual articles, items, media files and assets published are owned by NHS Digital, unless otherwise indicated.</p>
+        <p>1.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; References in these terms and conditions to "NHS Digital”, "we”, "our” and "us” are references to the Health and Social Care Information Centre, a non-departmental public body established under primary legislation and known as NHS Digital. The entire contents of this website, and the individual articles, items, media files and assets published are owned by NHS Digital, unless otherwise indicated.</p>
 
         <p>&nbsp;</p>
 
@@ -907,7 +907,7 @@
 
         <p><strong>&nbsp;</strong></p>
 
-        <p>7.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The material on this website includes information, data, text, images, videos, Information Standards, interactive services, link to products and apps and other works (“<strong>NHS Digital Content</strong>”).&nbsp; You acknowledge that all rights in copyright, patents, design rights, trade marks and other intellectual property rights (whether registered, capable of registration or otherwise) throughout the world, in this website and all NHS Digital Content are owned by, or licensed to NHS Digital, unless otherwise indicated. Some NHS Digital Content includes identifiable third-party content for which we will have sought permission for its inclusion.</p>
+        <p>7.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; The material on this website includes information, data, text, images, videos, Information Standards, interactive services, link to products and apps and other works ("<strong>NHS Digital Content</strong>”).&nbsp; You acknowledge that all rights in copyright, patents, design rights, trade marks and other intellectual property rights (whether registered, capable of registration or otherwise) throughout the world, in this website and all NHS Digital Content are owned by, or licensed to NHS Digital, unless otherwise indicated. Some NHS Digital Content includes identifiable third-party content for which we will have sought permission for its inclusion.</p>
 
         <p><strong>&nbsp;</strong></p>
 
@@ -923,7 +923,7 @@
 
         <p>&nbsp;</p>
 
-        <p>8.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Copyright and database rights in the NHS Digital Content are released free-of-charge under the current version of the&nbsp;<a rel="nofollow" href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence</a>&nbsp;(“<strong>OGL</strong>”), except where specified, either in these terms and conditions, elsewhere on this website or in the OGL terms.&nbsp; This licence does not extend to any other intellectual property rights, including but not limited to patents, design rights and trade marks. If there is any conflict between the OGL terms and these terms and conditions these terms and conditions shall take precedence.&nbsp;</p>
+        <p>8.1&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Copyright and database rights in the NHS Digital Content are released free-of-charge under the current version of the&nbsp;<a rel="nofollow" href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/">Open Government Licence</a>&nbsp;("<strong>OGL</strong>”), except where specified, either in these terms and conditions, elsewhere on this website or in the OGL terms.&nbsp; This licence does not extend to any other intellectual property rights, including but not limited to patents, design rights and trade marks. If there is any conflict between the OGL terms and these terms and conditions these terms and conditions shall take precedence.&nbsp;</p>
 
         <p>&nbsp;</p>
 
@@ -973,13 +973,13 @@
 
         <p>8.4&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; If you do use any NHS Digital Content you must attribute it with the following statement:</p>
 
-        <p>“<strong>Information from NHS Digital, licenced under the current version of the Open Government Licence</strong>”.</p>
+        <p>"<strong>Information from NHS Digital, licenced under the current version of the Open Government Licence</strong>”.</p>
 
         <ul>
          <li>or in cases where the NHS Digital Content is combined, adapted, or otherwise modified in line with these terms and conditions:</li>
         </ul>
 
-        <p>“<strong>Contains information from NHS Digital, licenced under the current version of the Open Government Licence</strong>”.</p>
+        <p>"<strong>Contains information from NHS Digital, licenced under the current version of the Open Government Licence</strong>”.</p>
 
         <p>8.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; By using any NHS Digital Content you accept and agree to the following terms:</p>
 
@@ -1035,7 +1035,7 @@
 
         <p><strong>&nbsp;</strong></p>
 
-        <p>9.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Comments posted should relate to your personal experience or that of someone close to you. You should not name any individuals (other than yourself) or include information through which someone else could identify an individual about whom you are writing. If you want to comment on someone else’s experience, (e.g. a relative or someone you care for) then you may do so if you ensure that you are not named in the posting and you state how the other person is connected to you (e.g. “my father”). You warrant that all statements of fact in any comment you submit are true, and that any expression of opinion is your honestly held opinion on those facts, or that of the person on whose behalf you are writing.</p>
+        <p>9.5&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Comments posted should relate to your personal experience or that of someone close to you. You should not name any individuals (other than yourself) or include information through which someone else could identify an individual about whom you are writing. If you want to comment on someone else’s experience, (e.g. a relative or someone you care for) then you may do so if you ensure that you are not named in the posting and you state how the other person is connected to you (e.g. "my father”). You warrant that all statements of fact in any comment you submit are true, and that any expression of opinion is your honestly held opinion on those facts, or that of the person on whose behalf you are writing.</p>
 
         <p><strong>&nbsp;</strong></p>
 
@@ -1070,7 +1070,7 @@
 
         <p><strong>&nbsp;</strong></p>
 
-        <p>10.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Our RSS feeds can be used as part of your website; however, we do require that proper format and attribution are used. The attribution text should read “<strong>NHS Digital</strong><strong>&nbsp;</strong><strong>RSS feeds</strong>”. We reserve the right from time to time to restrict the distribution of NHS Digital RSS feed content and do not accept any liability for these feeds.</p>
+        <p>10.3&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Our RSS feeds can be used as part of your website; however, we do require that proper format and attribution are used. The attribution text should read "<strong>NHS Digital</strong><strong>&nbsp;</strong><strong>RSS feeds</strong>”. We reserve the right from time to time to restrict the distribution of NHS Digital RSS feed content and do not accept any liability for these feeds.</p>
 
         <p><strong>&nbsp;</strong></p>
 

--- a/repository-data/development/src/main/script/YamlFormatter.groovy
+++ b/repository-data/development/src/main/script/YamlFormatter.groovy
@@ -20,8 +20,11 @@ rootDir.eachFileRecurse(FileType.DIRECTORIES) { dir ->
         String text = file.getText()
         LinkedHashMap map = parser.load(text)
 
-        // Don't remove the UUID for this file, it's referenced in the facet configuration
-        boolean removeUuid = !file.getName().equals("corporate-website.yaml")
+        // Don't remove the UUID for corporate-website, it's referenced in the facet configuration
+        // Same for ci-hub and cihublink, since referenced for page links
+        boolean removeUuid = !file.getName().equals("corporate-website.yaml") &&
+            !file.getName().equals("ci-hub.yaml") &&
+            !file.getName().equals("cihublink.yaml")
         map = format(map, removeUuid, true)
 
         // Write out the formatted yaml

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/cihub.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/cihub.ftl
@@ -1,0 +1,23 @@
+<#ftl output_format="HTML">
+<#include "../include/imports.ftl">
+<#include "./macro/structured-text.ftl">
+<@hst.setBundle basename="publicationsystem.headers"/>
+<section class="document-content">
+    <#if document??>
+        <h1 data-uipath="ps.document.title">${document.title}</h1>
+        <p data-uipath="ps.document.content">
+            <@structuredText item=document.summary uipath="ps.document.summary" />
+        </p>
+        <h2 class="push--bottom"><@fmt.message key="headers.ci-hub-overview"/></h2>
+
+        <div class="layout layout--large">
+            <#list document.ciHubLink as link><!--
+                --><div class="layout__item layout-1-3">
+                    <@hst.link var="landingPageLink" hippobean=link.pageLink />
+                    <h3><a href="${landingPageLink}" title="${link.title}">${link.title}</a></h3>
+                    <p class="zeta">${link.summary}</p>
+                </div><!--
+            --></#list>
+        </div>
+    </#if>
+</section>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/cilanding.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/cilanding.ftl
@@ -1,0 +1,34 @@
+<#ftl output_format="HTML">
+<#include "../include/imports.ftl">
+<@hst.setBundle basename="publicationsystem.headers"/>
+<section class="document-content">
+    <#if document??>
+        <h1 data-uipath="ps.document.title">${document.title}</h1>
+        <div class="layout layout--large">
+            <div class="layout__item layout-2-3">
+                <@hst.html hippohtml=document.content />
+            </div><!--
+        --><div class="layout__item layout-1-3">
+                <div class="panel panel--grey push-half--bottom">
+                    <h3><@fmt.message key="headers.ci-landing-actions"/></h3>
+                    <ul>
+                        <@hst.link var="backlink" mount="common-context" path="/" />
+                        <li><a href="${backlink}" title="Back to Clinical Indicators">Back to Clinical Indicators</a></li>
+                    </ul>
+                </div>
+            <#if document.resourceLinks?has_content>
+                <div class="panel panel--grey push-half--bottom">
+                    <h3><@fmt.message key="headers.ci-landing-resources"/></h3>
+                    <ul data-uipath="ps.publication.resources">
+                        <#list document.resourceLinks as link>
+                            <li>
+                                <a href="${link.linkUrl}" target="_blank">${link.linkText}</a>
+                            </li>
+                        </#list>
+                    </ul>
+                </div>
+            </#if>
+            </div>
+        </div>
+    </#if>
+</section>

--- a/repository-data/webfiles/src/main/resources/site/less/style.less
+++ b/repository-data/webfiles/src/main/resources/site/less/style.less
@@ -173,15 +173,18 @@ a {
   background-color: @color-secondary;
 }
 .common-search__inner {
-  width: @max-width;
+  max-width: @max-width;
   margin: 0px auto;
   padding-top: 20px;
   padding-bottom: 20px;
+  padding-left: 20px;
+  padding-right: 20px;
 }
 /* Add icon to input */
 .common-search__input {
   display: inline-block;
   position: relative;
+  width: calc(~"100% - 155px");
 }
 .common-search__input::after {
   position: absolute;
@@ -197,7 +200,7 @@ a {
 }
 
 .common-search__input__field {
-  width: 1009px;
+  width:100%;
   border-radius: 0px;
   padding: 16px 16px 16px 45px;
   margin-right: 6px;

--- a/site/src/main/java/uk/nhs/digital/ps/beans/CiHub.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/CiHub.java
@@ -1,0 +1,28 @@
+package uk.nhs.digital.ps.beans;
+
+import org.hippoecm.hst.content.beans.Node;
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+import uk.nhs.digital.ps.beans.structuredText.StructuredText;
+
+import java.util.List;
+
+@HippoEssentialsGenerated(internalName = "publicationsystem:cihub")
+@Node(jcrType = "publicationsystem:cihub")
+public class CiHub extends BaseDocument {
+
+    @HippoEssentialsGenerated(internalName = "publicationsystem:title")
+    public String getTitle() {
+        return getProperty("publicationsystem:title");
+    }
+
+    @HippoEssentialsGenerated(internalName = "publicationsystem:summary")
+    public StructuredText getSummary() {
+        return new StructuredText(getProperty("publicationsystem:summary", ""));
+    }
+
+    @HippoEssentialsGenerated(internalName = "publicationsystem:cihublink")
+    public List<CiHubLink> getCiHubLink() {
+        return getChildBeansByName("publicationsystem:cihublink",
+                CiHubLink.class);
+    }
+}

--- a/site/src/main/java/uk/nhs/digital/ps/beans/CiHubLink.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/CiHubLink.java
@@ -1,0 +1,25 @@
+package uk.nhs.digital.ps.beans;
+
+import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
+import org.hippoecm.hst.content.beans.standard.HippoCompound;
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+
+@HippoEssentialsGenerated(internalName = "publicationsystem:cihublink")
+@Node(jcrType = "publicationsystem:cihublink")
+public class CiHubLink extends HippoCompound {
+    @HippoEssentialsGenerated(internalName = "publicationsystem:title")
+    public String getTitle() {
+        return getProperty("publicationsystem:title");
+    }
+
+    @HippoEssentialsGenerated(internalName = "publicationsystem:summary")
+    public String getSummary() {
+        return getProperty("publicationsystem:summary");
+    }
+
+    @HippoEssentialsGenerated(internalName = "publicationsystem:pagelink")
+    public HippoBean getPageLink() {
+        return getLinkedBean("publicationsystem:pagelink", HippoBean.class);
+    }
+}

--- a/site/src/main/java/uk/nhs/digital/ps/beans/CiLanding.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/CiLanding.java
@@ -1,0 +1,27 @@
+package uk.nhs.digital.ps.beans;
+
+import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoHtml;
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+
+import java.util.List;
+
+@HippoEssentialsGenerated(internalName = "publicationsystem:cilanding")
+@Node(jcrType = "publicationsystem:cilanding")
+public class CiLanding extends BaseDocument {
+    @HippoEssentialsGenerated(internalName = "publicationsystem:title")
+    public String getTitle() {
+        return getProperty("publicationsystem:title");
+    }
+
+    @HippoEssentialsGenerated(internalName = "publicationsystem:content")
+    public HippoHtml getContent() {
+        return getHippoHtml("publicationsystem:content");
+    }
+
+    @HippoEssentialsGenerated(internalName = "publicationsystem:resourceLinks")
+    public List<Relatedlink> getResourceLinks() {
+        return getChildBeansByName("publicationsystem:resourceLinks",
+                Relatedlink.class);
+    }
+}

--- a/site/src/main/java/uk/nhs/digital/ps/components/CiHubComponent.java
+++ b/site/src/main/java/uk/nhs/digital/ps/components/CiHubComponent.java
@@ -1,0 +1,18 @@
+package uk.nhs.digital.ps.components;
+
+import org.hippoecm.hst.component.support.bean.BaseHstComponent;
+import org.hippoecm.hst.core.component.HstComponentException;
+import org.hippoecm.hst.core.component.HstRequest;
+import org.hippoecm.hst.core.component.HstResponse;
+import org.hippoecm.hst.core.request.HstRequestContext;
+
+public class CiHubComponent extends BaseHstComponent {
+
+    @Override
+    public void doBeforeRender(final HstRequest request, final HstResponse response) throws HstComponentException {
+        super.doBeforeRender(request, response);
+        final HstRequestContext ctx = request.getRequestContext();
+
+        request.setAttribute("document", ctx.getContentBean());
+    }
+}

--- a/site/src/main/java/uk/nhs/digital/ps/components/CiLandingComponent.java
+++ b/site/src/main/java/uk/nhs/digital/ps/components/CiLandingComponent.java
@@ -1,0 +1,18 @@
+package uk.nhs.digital.ps.components;
+
+import org.hippoecm.hst.component.support.bean.BaseHstComponent;
+import org.hippoecm.hst.core.component.HstComponentException;
+import org.hippoecm.hst.core.component.HstRequest;
+import org.hippoecm.hst.core.component.HstResponse;
+import org.hippoecm.hst.core.request.HstRequestContext;
+
+public class CiLandingComponent extends BaseHstComponent {
+
+    @Override
+    public void doBeforeRender(final HstRequest request, final HstResponse response) throws HstComponentException {
+        super.doBeforeRender(request, response);
+        final HstRequestContext ctx = request.getRequestContext();
+
+        request.setAttribute("document", ctx.getContentBean());
+    }
+}

--- a/styleguide/ci-hub.html
+++ b/styleguide/ci-hub.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en" class="">
+<head>
+
+  <title>NHS - Replacement Publication System - Dataset</title>
+
+  <meta charset="UTF-8" />
+  <meta name="title" content="NHS - Replacement Publication System" />
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0" />
+  <link rel="stylesheet" href="css/style.css" />
+  <!-- <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'> -->
+
+</head>
+<body class="">
+
+  <header class="top-header">
+    <div class="top-header__col1">
+      <img class="top-header__logo" src="https://digital.nhs.uk/media/89/NHSDigital/variant1/NHS-Digital-logo_WEB_LEFT-100x855" alt="NHS Digital">
+    </div><!--
+    --><div class="top-header__col2">
+      <div class="top-header__nav">
+        <ul class="top-header__nav__list">
+          <li class="top-header__nav__list__item"><a href="#">Data and information</a></li>
+          <li class="top-header__nav__list__item"><a href="#">Systems and services</a></li>
+          <li class="top-header__nav__list__item"><a href="#">News and events</a></li>
+          <li class="top-header__nav__list__item"><a href="#">About NHS Digital</a></li>
+        </ul>
+      </div>
+    </div>
+  </header>
+
+
+
+
+
+
+
+  <section class="document-content">
+
+      <h1>Clinical Indicators</h1>
+
+      <section class="common-search">
+        <div class="common-search__inner">
+            <span class="common-search__input">
+            <input class="common-search__input__field" id="query" name="query" placeholder="What are you looking for today?" type="text" value="">
+          </span>
+          <input class="common-search__submit" id="btnSearch" type="submit" value="Search">
+        </div>
+      </section>
+
+      <p>This is a collection of over a thousand data sets that we publish. The information is for clinical staff, commissioners, researchers, and others needing data and evidence to help with decision-making in health and care.</p>
+      <p>A wide variety of subjects are covered, ranging from quality through to population health and the outcomes of treatments.</p>
+
+      <h2 class="push--bottom">Overview</h2>
+
+      <div class="layout layout--large">
+        <div class="layout__item layout-1-3">
+            <h3><a href="#">Clinical Commissioning Group Outcomes Indicator Set</a></h3>
+            <p class="zeta">The CCG Outcomes Indicator Set (CCG OIS) is an integral part of NHS England’s systematic approach to quality improvement.</p>
+        </div><!--
+        --><div class="layout__item layout-1-3">
+            <h3><a href="#">Compendium of Population Health Indicators</a></h3>
+            <p class="zeta">A wide-ranging collection of over 1,000 indicators designed to provide a comprehensive overview of population health at a national, regional and local level. These indicators were previously available on the Clinical and Health Outcomes Knowledge Base website (also known as NCHOD).</p>
+        </div><!--
+        --><div class="layout__item layout-1-3">
+            <h3><a href="#">Social Care</a></h3>
+            <p class="zeta">The latest figures for the Adult Social Care Outcomes Framework (ASCOF) for 2015-16 were released in October 2016. In total, there are 22 measures which are designed to enable users to compare the effectiveness of care delivered by councils responsible for adult social care services in England.</p>
+        </div><!--
+        --><div class="layout__item layout-1-3">
+            <h3><a href="#">NHS Outcomes Framework</a></h3>
+            <p class="zeta">The CCG Outcomes Indicator Set (CCG OIS) is an integral part of NHS England’s systematic approach to quality improvement.</p>
+        </div><!--
+        --><div class="layout__item layout-1-3">
+            <h3><a href="#">Summary Hospital-level Mortality Indicator (SHMI) </a></h3>
+            <p class="zeta">A wide-ranging collection of over 1,000 indicators designed to provide a comprehensive overview of population health at a national, regional and local level. These indicators were previously available on the Clinical and Health Outcomes Knowledge Base website (also known as NCHOD).</p>
+        </div><!--
+        --><div class="layout__item layout-1-3">
+            <h3><a href="#">Patient Online Management Information (POMI)</a></h3>
+            <p class="zeta">NOTE: This will launch digital.nhs.uk/GP-data-hub Inc copy..</p>
+        </div>
+
+      </div>
+
+
+
+
+  </section>
+
+
+  <footer class="footer">
+    <div class="footer__inner">
+      FOOTER
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/styleguide/ci-landing-page.html
+++ b/styleguide/ci-landing-page.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en" class="">
+<head>
+
+  <title>NHS - Replacement Publication System - Dataset</title>
+
+  <meta charset="UTF-8" />
+  <meta name="title" content="NHS - Replacement Publication System" />
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0" />
+  <link rel="stylesheet" href="css/style.css" />
+  <!-- <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'> -->
+
+</head>
+<body class="">
+
+  <header class="top-header">
+    <div class="top-header__col1">
+      <img class="top-header__logo" src="https://digital.nhs.uk/media/89/NHSDigital/variant1/NHS-Digital-logo_WEB_LEFT-100x855" alt="NHS Digital">
+    </div><!--
+    --><div class="top-header__col2">
+      <div class="top-header__nav">
+        <ul class="top-header__nav__list">
+          <li class="top-header__nav__list__item"><a href="#">Data and information</a></li>
+          <li class="top-header__nav__list__item"><a href="#">Systems and services</a></li>
+          <li class="top-header__nav__list__item"><a href="#">News and events</a></li>
+          <li class="top-header__nav__list__item"><a href="#">About NHS Digital</a></li>
+        </ul>
+      </div>
+    </div>
+  </header>
+
+
+
+
+
+
+
+  <section class="document-content">
+
+    <p>&#8249;&nbsp; <a href="#">Back to Clinical Indictors</a></p>
+    <h1>CCG Outcomes - Indicator Set</h1>
+
+    <div class="layout layout--large">
+        <div class="layout__item layout-2-3">
+            <p>
+                The Clinical Commissioning Group Outcomes Indicator Set (CCG OIS) is an integral part of NHS England’s systematic approach to quality improvement. Its primary aim is to support and enable CCGs and health and wellbeing partners to plan for health improvement by providing information for measuring and benchmarking outcomes of services commissioned by CCGs. It is also intended to provide clear, comparative information for patients and the public about the quality of health services commissioned by CCGs and the associated health outcomes.
+            </p>
+            <p>The CCG Outcomes Indicator Set uses the registered patient population of England as its subject population, and where standardisation is required, the Office for National Statistics mid-year population estimates for England. All indicators are reported at CCG and National level, where ‘National’ represents the sum total of patients registered with a GP in England.</p>
+            <p>The NHS Outcomes Framework uses the ONS mid-year population estimates for England as its subject population, and where standardisation is required the European Standard Population is generally used. All indicators are reported at England level, and are broken down, where possible, by a combination of Age, Lower tier local authority, Upper tier local authority, Region, Religion, Ethnicity, Deprivation decile, Sexual orientation, Gender and Condition.</p>
+            <p>The indicators are structured around the five NHS Outcomes Framework domains.</p>
+            <p>
+                <strong>Domain 1</strong>, Preventing people from dying prematurely <br>
+                This domain captures how successful the NHS is in reducing the number of avoidable deaths.
+            </p>
+            <p>
+                <strong>Domain 2</strong>, Enhancing quality of life for people with long-term conditions <br>
+                This domain captures how successfully the NHS is supporting people with long-term conditions to live as normal a life as possible.
+            </p>
+            <p>
+                <strong>Domain 3</strong>, Helping people to recover from episodes of ill health or following injury  <br>
+                This domain captures how people recover from ill health or injury and wherever possible how it can be prevented.
+            </p>
+            <p>
+                <strong>Domain 4</strong>, Ensuring that people have a positive experience of care  <br>
+                This domain looks at the importance of providing a positive experience of care for patients, service users and carers.
+            </p>
+            <p>
+                <strong>Domain 5</strong>, Treating and caring for people in a safe environment and protecting them from avoidable harm  <br>
+                This domain explores patient safety and its importance in terms of quality of care to deliver better health outcomes.
+            </p>
+            <h3>Further information</h3>
+            <p>CCG Outcomes Indicator Set on the NHS England website:</p>
+        </div><!--
+
+        --><div class="layout__item layout-1-3">
+
+            <div class="panel panel--grey push-half--bottom">
+                <h3>Actions</h3>
+                <ul>
+                    <li><a href="#">Browse CCG Outcomes</a></li>
+                    <li><a href="#">Back to Clinical Indicators</a></li>
+                </ul>
+            </div>
+
+            <div class="panel panel--grey push-half--bottom">
+                <h3>Resources</h3>
+                <ul data-uipath="ps.publication.resources">
+                    <li>
+                        <a href="/site/publications/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/series-publication-with-datasets-dataset" title="series-publication-with-datasets Dataset">series-publication-with-datasets Dataset</a>
+                    </li>
+                </ul>
+            </div>
+
+        </div>
+    </div>
+
+
+
+  </section>
+
+
+  <footer class="footer">
+    <div class="footer__inner">
+      FOOTER
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/styleguide/css/style.css
+++ b/styleguide/css/style.css
@@ -1,0 +1,869 @@
+/*! normalize.css v3.0.2 | MIT License | git.io/normalize */
+/**
+ * 1. Set default font family to sans-serif.
+ * 2. Prevent iOS text size adjust after orientation change, without disabling
+ *    user zoom.
+ */
+html {
+  font-family: sans-serif;
+  /* 1 */
+  -ms-text-size-adjust: 100%;
+  /* 2 */
+  -webkit-text-size-adjust: 100%;
+  /* 2 */
+  height: 100%;
+}
+/**
+ * Remove default margin.
+ */
+body {
+  margin: 0;
+  height: 100%;
+  padding: 0;
+}
+/* apply a natural box layout model to all elements, but allowing components to change */
+html {
+  box-sizing: border-box;
+}
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+/* HTML5 display definitions
+   ========================================================================== */
+/**
+ * Correct `block` display not defined for any HTML5 element in IE 8/9.
+ * Correct `block` display not defined for `details` or `summary` in IE 10/11
+ * and Firefox.
+ * Correct `block` display not defined for `main` in IE 11.
+ */
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+main,
+menu,
+nav,
+section,
+summary {
+  display: block;
+}
+/**
+ * 1. Correct `inline-block` display not defined in IE 8/9.
+ * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
+ */
+audio,
+canvas,
+progress,
+video {
+  display: inline-block;
+  /* 1 */
+  vertical-align: baseline;
+  /* 2 */
+}
+/**
+ * Prevent modern browsers from displaying `audio` without controls.
+ * Remove excess height in iOS 5 devices.
+ */
+audio:not([controls]) {
+  display: none;
+  height: 0;
+}
+/**
+ * Address `[hidden]` styling not present in IE 8/9/10.
+ * Hide the `template` element in IE 8/9/11, Safari, and Firefox < 22.
+ */
+[hidden],
+template {
+  display: none;
+}
+/* Links
+   ========================================================================== */
+/**
+ * Remove the gray background color from active links in IE 10.
+ */
+a {
+  background-color: transparent;
+}
+/**
+ * Improve readability when focused and also mouse hovered in all browsers.
+ */
+a:active,
+a:hover {
+  outline: 0;
+}
+/* Text-level semantics
+   ========================================================================== */
+/**
+ * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
+ */
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+/**
+ * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
+ */
+b,
+strong {
+  font-weight: bold;
+}
+/**
+ * Address styling not present in Safari and Chrome.
+ */
+dfn {
+  font-style: italic;
+}
+/**
+ * Address variable `h1` font-size and margin within `section` and `article`
+ * contexts in Firefox 4+, Safari, and Chrome.
+ */
+h1 {
+  font-size: 2em;
+  margin: 0.67em 0;
+}
+/**
+ * Address styling not present in IE 8/9.
+ */
+mark {
+  background: #ff0;
+  color: #000;
+}
+/**
+ * Address inconsistent and variable font size in all browsers.
+ */
+small {
+  font-size: 80%;
+}
+/**
+ * Prevent `sub` and `sup` affecting `line-height` in all browsers.
+ */
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+sup {
+  top: -0.5em;
+}
+sub {
+  bottom: -0.25em;
+}
+/* Embedded content
+   ========================================================================== */
+/**
+ * Remove border when inside `a` element in IE 8/9/10.
+ */
+img {
+  border: 0;
+}
+/**
+ * Correct overflow not hidden in IE 9/10/11.
+ */
+svg:not(:root) {
+  overflow: hidden;
+}
+/* Grouping content
+   ========================================================================== */
+/**
+ * Address margin not present in IE 8/9 and Safari.
+ */
+figure {
+  margin: 1em 40px;
+}
+/**
+ * Address differences between Firefox and other browsers.
+ */
+hr {
+  -moz-box-sizing: content-box;
+  box-sizing: content-box;
+  height: 0;
+}
+/**
+ * Contain overflow in all browsers.
+ */
+pre {
+  overflow: auto;
+}
+/**
+ * Address odd `em`-unit font size rendering in all browsers.
+ */
+code,
+kbd,
+pre,
+samp {
+  font-family: monospace, monospace;
+  font-size: 1em;
+}
+/* Forms
+   ========================================================================== */
+/**
+ * Known limitation: by default, Chrome and Safari on OS X allow very limited
+ * styling of `select`, unless a `border` property is set.
+ */
+/**
+ * 1. Correct color not being inherited.
+ *    Known issue: affects color of disabled elements.
+ * 2. Correct font properties not being inherited.
+ * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
+ */
+button,
+input,
+optgroup,
+select,
+textarea {
+  color: inherit;
+  /* 1 */
+  font: inherit;
+  /* 2 */
+  margin: 0;
+  /* 3 */
+}
+/**
+ * Address `overflow` set to `hidden` in IE 8/9/10/11.
+ */
+button {
+  overflow: visible;
+}
+/**
+ * Address inconsistent `text-transform` inheritance for `button` and `select`.
+ * All other form control elements do not inherit `text-transform` values.
+ * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
+ * Correct `select` style inheritance in Firefox.
+ */
+button,
+select {
+  text-transform: none;
+}
+/**
+ * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
+ *    and `video` controls.
+ * 2. Correct inability to style clickable `input` types in iOS.
+ * 3. Improve usability and consistency of cursor style between image-type
+ *    `input` and others.
+ */
+button,
+html input[type="button"],
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button;
+  /* 2 */
+  cursor: pointer;
+  /* 3 */
+}
+/**
+ * Re-set default cursor for disabled elements.
+ */
+button[disabled],
+html input[disabled] {
+  cursor: default;
+}
+/**
+ * Remove inner padding and border in Firefox 4+.
+ */
+button::-moz-focus-inner,
+input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+/**
+ * Address Firefox 4+ setting `line-height` on `input` using `!important` in
+ * the UA stylesheet.
+ */
+input {
+  line-height: normal;
+}
+/**
+ * It's recommended that you don't attempt to style these elements.
+ * Firefox's implementation doesn't respect box-sizing, padding, or width.
+ *
+ * 1. Address box sizing set to `content-box` in IE 8/9/10.
+ * 2. Remove excess padding in IE 8/9/10.
+ */
+input[type="checkbox"],
+input[type="radio"] {
+  box-sizing: border-box;
+  /* 1 */
+  padding: 0;
+  /* 2 */
+}
+/**
+ * Fix the cursor style for Chrome's increment/decrement buttons. For certain
+ * `font-size` values of the `input`, it causes the cursor style of the
+ * decrement button to change from `default` to `text`.
+ */
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
+/**
+ * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
+ * 2. Address `box-sizing` set to `border-box` in Safari and Chrome
+ *    (include `-moz` to future-proof).
+ */
+/**
+ * Remove inner padding and search cancel button in Safari and Chrome on OS X.
+ * Safari (but not Chrome) clips the cancel button when the search input has
+ * padding (and `textfield` appearance).
+ */
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+/**
+ * Define consistent border, margin, and padding.
+ */
+fieldset {
+  border: 1px solid #c0c0c0;
+  margin: 0 2px;
+  padding: 0.35em 0.625em 0.75em;
+}
+/**
+ * 1. Correct `color` not being inherited in IE 8/9/10/11.
+ * 2. Remove padding so people aren't caught out if they zero out fieldsets.
+ */
+legend {
+  border: 0;
+  /* 1 */
+  padding: 0;
+  /* 2 */
+}
+/**
+ * Remove default vertical scrollbar in IE 8/9/10/11.
+ */
+textarea {
+  overflow: auto;
+}
+/**
+ * Don't inherit the `font-weight` (applied by a rule above).
+ * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
+ */
+optgroup {
+  font-weight: bold;
+}
+/* Tables
+   ========================================================================== */
+/**
+ * Remove most spacing between table cells.
+ */
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+td,
+th {
+  padding: 0;
+}
+/* FONTS */
+/* ########################################################## */
+/*
+@font-face{
+font-family:"FrutigerLTW01-76BlackItalic";
+src:url("fonts/FrutigerLTW01-76BlackItalic.eot?#iefix");
+src:url("fonts/FrutigerLTW01-76BlackItalic.eot?#iefix") format("eot"),url("fonts/FrutigerLTW01-76BlackItalic.woff2") format("woff2"),url("fonts/FrutigerLTW01-76BlackItalic.woff") format("woff"),url("fonts/FrutigerLTW01-76BlackItalic.ttf") format("truetype"),url("fonts/FrutigerLTW01-76BlackItalic.svg#24df08f2-b418-49de-8eca-745947092d72") format("svg");
+}
+*/
+@font-face {
+  font-family: "FrutigerLTW01-65Bold";
+  src: url("fonts/FrutigerLTW01-65Bold.eot?#iefix");
+  src: url("fonts/FrutigerLTW01-65Bold.eot?#iefix") format("eot"), url("fonts/FrutigerLTW01-65Bold.woff2") format("woff2"), url("fonts/FrutigerLTW01-65Bold.woff") format("woff"), url("fonts/FrutigerLTW01-65Bold.ttf") format("truetype"), url("fonts/FrutigerLTW01-65Bold.svg#eae74276-dd78-47e4-9b27-dac81c3411ca") format("svg");
+}
+/*
+@font-face{
+font-family:"FrutigerLTW01-45Light";
+src:url("fonts/FrutigerLTW01-45Light.eot?#iefix");
+src:url("fonts/FrutigerLTW01-45Light.eot?#iefix") format("eot"),url("fonts/FrutigerLTW01-45Light.woff2") format("woff2"),url("fonts/FrutigerLTW01-45Light.woff") format("woff"),url("fonts/FrutigerLTW01-45Light.ttf") format("truetype"),url("fonts/FrutigerLTW01-45Light.svg#29f3ff8a-1719-4e25-a757-53ee1a1114a5") format("svg");
+}
+@font-face{
+font-family:"FrutigerLTW01-66BoldItalic";
+src:url("fonts/FrutigerLTW01-66BoldItalic.eot?#iefix");
+src:url("fonts/FrutigerLTW01-66BoldItalic.eot?#iefix") format("eot"),url("fonts/FrutigerLTW01-66BoldItalic.woff2") format("woff2"),url("fonts/FrutigerLTW01-66BoldItalic.woff") format("woff"),url("fonts/FrutigerLTW01-66BoldItalic.ttf") format("truetype"),url("fonts/FrutigerLTW01-66BoldItalic.svg#8ad009ab-a7e5-4acb-8ca5-326d2a759924") format("svg");
+}
+*/
+@font-face {
+  font-family: "FrutigerLTW01-55Roman";
+  src: url("fonts/FrutigerLTW01-55Roman.eot?#iefix");
+  src: url("fonts/FrutigerLTW01-55Roman.eot?#iefix") format("eot"), url("fonts/FrutigerLTW01-55Roman.woff2") format("woff2"), url("fonts/FrutigerLTW01-55Roman.woff") format("woff"), url("fonts/FrutigerLTW01-55Roman.ttf") format("truetype"), url("fonts/FrutigerLTW01-55Roman.svg#7def0e34-f28d-434f-b2ec-472bde847115") format("svg");
+}
+/*
+@font-face{
+font-family:"FrutigerLTW01-95UltraBlack";
+src:url("fonts/FrutigerLTW01-95UltraBlack.eot?#iefix");
+src:url("fonts/FrutigerLTW01-95UltraBlack.eot?#iefix") format("eot"),url("fonts/FrutigerLTW01-95UltraBlack.woff2") format("woff2"),url("fonts/FrutigerLTW01-95UltraBlack.woff") format("woff"),url("fonts/FrutigerLTW01-95UltraBlack.ttf") format("truetype"),url("fonts/FrutigerLTW01-95UltraBlack.svg#3b96d0b6-5de6-4fb0-9884-b645e55d01c4") format("svg");
+}
+@font-face{
+font-family:"FrutigerLTW01-56Italic";
+src:url("fonts/FrutigerLTW01-56Italic.eot?#iefix");
+src:url("fonts/FrutigerLTW01-56Italic.eot?#iefix") format("eot"),url("fonts/FrutigerLTW01-56Italic.woff2") format("woff2"),url("fonts/FrutigerLTW01-56Italic.woff") format("woff"),url("fonts/FrutigerLTW01-56Italic.ttf") format("truetype"),url("fonts/FrutigerLTW01-56Italic.svg#141c0322-57c4-48ca-abb4-31688d659f7d") format("svg");
+}
+@font-face{
+font-family:"FrutigerLTW01-75Black";
+src:url("fonts/FrutigerLTW01-75Black.eot?#iefix");
+src:url("fonts/FrutigerLTW01-75Black.eot?#iefix") format("eot"),url("fonts/FrutigerLTW01-75Black.woff2") format("woff2"),url("fonts/FrutigerLTW01-75Black.woff") format("woff"),url("fonts/FrutigerLTW01-75Black.ttf") format("truetype"),url("fonts/FrutigerLTW01-75Black.svg#1c437efb-925e-4bc5-96d0-c706bb400696") format("svg");
+}
+@font-face{
+font-family:"FrutigerLTW01-46LightItalic";
+src:url("fonts/FrutigerLTW01-46LightItalic.eot?#iefix");
+src:url("fonts/FrutigerLTW01-46LightItalic.eot?#iefix") format("eot"),url("fonts/FrutigerLTW01-46LightItalic.woff2") format("woff2"),url("fonts/FrutigerLTW01-46LightItalic.woff") format("woff"),url("fonts/FrutigerLTW01-46LightItalic.ttf") format("truetype"),url("fonts/FrutigerLTW01-46LightItalic.svg#cd75c3e3-c5b7-4a25-9498-cabe4e8a9076") format("svg");
+}
+*/
+/* VARS */
+/* ########################################################## */
+.document-content {
+  width: 1170px;
+  margin-top: 40px;
+  margin-right: auto;
+  margin-left: auto;
+  margin-bottom: 40px;
+}
+/* TEXT */
+/* ########################################################## */
+body {
+  font-family: "FrutigerLTW01-55Roman", Arial;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin-top: 0;
+  margin-bottom: 10px;
+  line-height: 1.3;
+  color: #3E4F59;
+  font-family: "FrutigerLTW01-55Roman", Arial;
+  font-weight: 100;
+}
+h1 {
+  font-size: 36px;
+}
+h2 {
+  font-size: 33px;
+  font-family: "FrutigerLTW01-65Bold", Arial;
+}
+p {
+  font-size: 18px;
+  color: #3E4F59;
+  line-height: 1.5;
+  margin-bottom: 30px;
+}
+ul,
+li {
+  font-size: 18px;
+  color: #3E4F59;
+  line-height: 1.5;
+}
+a {
+  color: inherit;
+  color: #005EB8;
+}
+.zeta {
+  font-size: 16px;
+}
+/* SPACING */
+/* ########################################################## */
+.flush {
+  margin: 0px;
+}
+.flush--top {
+  margin-top: 0px;
+}
+.flush--bottom {
+  margin-bottom: 0px;
+}
+.flush--left {
+  margin-left: 0px;
+}
+.flush--right {
+  margin-right: 0px;
+}
+.push--top {
+  margin-top: 20px;
+}
+.push-double--top {
+  margin-top: 40px;
+}
+.push-half--top {
+  margin-top: 10px;
+}
+.push--bottom {
+  margin-bottom: 20px;
+}
+.push-double--bottom {
+  margin-bottom: 40px;
+}
+.push-half--bottom {
+  margin-bottom: 10px;
+}
+/* TOP HEADER */
+/* ########################################################## */
+.top-header {
+  width: 1170px;
+  margin: 0px auto;
+  padding-top: 20px;
+  padding-bottom: 3px;
+}
+.top-header__col1 {
+  display: inline-block;
+  width: 20%;
+}
+.top-header__col2 {
+  display: inline-block;
+  width: 80%;
+  vertical-align: bottom;
+  text-align: right;
+}
+.top-header__logo {
+  width: 80px;
+}
+.top-header__nav__list {
+  margin: 0px;
+  padding: 0px;
+}
+.top-header__nav__list__item {
+  display: inline-block;
+}
+.top-header__nav__list__item a {
+  display: inline-block;
+  background-image: url(img/icon-chevron-down.svg);
+  background-repeat: no-repeat;
+  background-position: 100% 58%;
+  color: #005eb8;
+  background-size: 20px 20px;
+  padding: 10px 30px 10px 4px;
+  margin-right: 27px;
+  font-size: 16px;
+  text-decoration: none;
+}
+/* COMMON SEARCH */
+/* ########################################################## */
+.common-search {
+  background-color: #00376D;
+}
+.common-search__inner {
+  max-width: 1170px;
+  margin: 0px auto;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  padding-left: 20px;
+  padding-right: 20px;
+}
+/* Add icon to input */
+.common-search__input {
+  display: inline-block;
+  position: relative;
+  width: calc(100% - 155px);
+}
+.common-search__input::after {
+  position: absolute;
+  content: "";
+  background-image: url(img/icon-search.svg);
+  background-position: 0px 0px;
+  background-repeat: no-repeat;
+  top: 50%;
+  left: 10px;
+  width: 26px;
+  height: 26px;
+  margin-top: -12px;
+}
+.common-search__input__field {
+  width: 100%;
+  border-radius: 0px;
+  padding: 16px 16px 16px 45px;
+  margin-right: 6px;
+  font-size: 20px;
+  border: 0;
+}
+.common-search__submit {
+  background-color: #005EB8;
+  color: #FFF;
+  width: 145px;
+  border-radius: 0px;
+  padding-top: 14px;
+  padding-bottom: 14px;
+  font-size: 22px;
+  border: 1px solid #005EB8;
+}
+/* HERO */
+/* ########################################################## */
+.document-header {
+  background-color: #005EB8;
+  padding: 40px 0px 20px;
+}
+.document-header__inner {
+  width: 1170px;
+  margin: 0px auto;
+}
+.document-header__inner h1,
+.document-header__inner h2,
+.document-header__inner h3,
+.document-header__inner h4,
+.document-header__inner h5,
+.document-header__inner a,
+.document-header__inner p,
+.document-header__inner dl,
+.document-header__inner dd,
+.document-header__inner dt {
+  color: #FFF;
+}
+.document-header__inner dt {
+  font-size: 16px;
+  margin-top: 6px;
+}
+.document-header__inner dd {
+  margin: 0px;
+}
+/* MEDIA FLEX */
+/* ########################################################## */
+.media {
+  display: flex;
+  align-items: flex-start;
+}
+.media__figure {
+  margin-right: 1em;
+}
+.media__body {
+  flex: 1;
+  margin: 0px 0px 0px 20px;
+  line-height: 1.4;
+}
+.media__icon {
+  width: 52px;
+  height: 52px;
+}
+.media__icon--calendar {
+  background-image: url(img/icon-calendar.svg);
+  background-position: 0px 0px;
+  background-repeat: no-repeat;
+  background-size: 52px;
+}
+.media__icon--granularity {
+  background-image: url(img/icon-granularity.svg);
+  background-position: 0px 0px;
+  background-repeat: no-repeat;
+  background-size: 52px;
+}
+.media__icon--geographic-coverage {
+  background-image: url(img/icon-geographic-coverage.svg);
+  background-position: 0px 0px;
+  background-repeat: no-repeat;
+  background-size: 52px;
+}
+.media__icon--date-range {
+  background-image: url(img/icon-date-range.svg);
+  background-position: 0px 0px;
+  background-repeat: no-repeat;
+  background-size: 52px;
+}
+/* PANELS */
+/* ########################################################## */
+.panel {
+  display: block;
+  padding: 20px;
+  /*
+    @media #{map-get($base-breakpoints, 'desk')} {
+        padding: $base-spacing-unit;
+    }
+    */
+  background: #fff;
+}
+.panel:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+/*  =PANEL SIZE VARIATIONS (Matches _layout.scss sizing units)
+--------------------------------------------------------------------*/
+.panel--flush {
+  padding: 0;
+}
+.panel--tiny {
+  padding: 5px;
+}
+.panel--small {
+  padding: 10px;
+}
+.panel--large {
+  padding: 20px;
+}
+/*  =Style variations
+--------------------------------------------------------------------*/
+.panel--grey {
+  background-color: #F1F2F4;
+}
+/* FILTER LIST */
+/* ########################################################## */
+.filter-list {
+  list-style: none;
+  margin: 0px 0px 20px 0px;
+  padding: 0px;
+}
+.filter-list__item {
+  margin-bottom: 5px;
+}
+.filter-list__item__link {
+  border-radius: 5px;
+  background-color: #DEE2E5;
+  color: #3E4F59;
+  text-decoration: none;
+  font-size: 14px;
+  padding: 5px;
+}
+/* BASIC LAYOUT */
+/* ########################################################## */
+.layout {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  margin-left: -15px;
+}
+.layout--large {
+  margin-left: -60px;
+}
+.layout--large > .layout__item {
+  padding-left: 60px;
+}
+.layout__item {
+  display: inline-block;
+  padding-left: 15px;
+  vertical-align: top;
+  text-align: left;
+  width: 100%;
+}
+.layout-1-2 {
+  width: 50%;
+}
+.layout-1-3 {
+  width: 33.33333%;
+}
+.layout-2-3 {
+  width: 66.666666%;
+}
+.layout-1-4 {
+  width: 25%;
+}
+.layout-2-4 {
+  width: 50%;
+}
+.layout-3-4 {
+  width: 75%;
+}
+.layout-1-5 {
+  width: 20%;
+}
+.layout-2-5 {
+  width: 40%;
+}
+.layout-3-5 {
+  width: 60%;
+}
+.layout-4-5 {
+  width: 80%;
+}
+.layout-1-6 {
+  width: 16.666666666%;
+}
+.layout-2-6 {
+  width: 33.333333333%;
+}
+.layout-3-6 {
+  width: 50%;
+}
+.layout-4-6 {
+  width: 66.666666666%;
+}
+.layout-5-6 {
+  width: 83.3333333333%;
+}
+.layout-6-6 {
+  width: 100%;
+}
+/* FLEX LAYOUT */
+/* ########################################################## */
+.flex {
+  display: flex;
+}
+.flex__item {
+  flex: 1;
+}
+/* FOOTER */
+/* ########################################################## */
+.footer {
+  background-color: #425563;
+  font-size: 16px;
+  margin-top: 20px;
+  padding-top: 20px;
+  padding-bottom: 20px;
+}
+.footer p {
+  color: #FFF;
+  font-size: 16px;
+}
+.footer__inner {
+  width: 1170px;
+  margin: 0 auto;
+}
+.footer__inner__list {
+  list-style: none;
+  padding-left: 0px;
+  margin-bottom: 10px;
+}
+.footer__inner__list__item {
+  display: inline-block;
+  margin-right: 12px;
+  padding-right: 12px;
+  border-right: 1px solid #FFF;
+  line-height: 1;
+}
+.footer__inner__list__item:last-child {
+  border-right: 0px;
+}
+.footer__inner__list__item__link {
+  color: #FFF;
+  font-size: 16px;
+}
+.footer__inner__sharelist {
+  list-style: none;
+  padding-left: 0px;
+  text-align: right;
+  color: #FFF;
+}
+.footer__inner__sharelist__item {
+  display: inline-block;
+  vertical-align: middle;
+  font-size: 16px;
+  color: #FFF;
+}
+/* PAGINATIONS */
+/* ########################################################## */
+.pagination {
+  text-align: center;
+}
+.pagination a {
+  display: inline-block;
+  text-decoration: none;
+  padding: 10px 17px;
+}
+.pagination__list {
+  list-style: none;
+}
+.pagination__list__item {
+  display: inline-block;
+  border: 1px solid #D9DDDC;
+  border-radius: 5px;
+}
+.pagination__list__item--previous {
+  margin-right: 10px;
+}
+.pagination__list__item--current {
+  padding: 10px 17px;
+}
+.pagination__list__item--next {
+  margin-left: 10px;
+}

--- a/styleguide/index.html
+++ b/styleguide/index.html
@@ -25,6 +25,14 @@
 
 
   <div class="panel panel--grey push--bottom">
+    <h3>CI Hub page:</h3>
+    <ul>
+      <li><a href="">Example page</a>
+      <li><a href="../styleguide/ci-hub.html">Template</a></li>
+    </ul>
+  </div>
+
+  <div class="panel panel--grey push--bottom">
     <h3>Dataset:</h3>
     <ul>
       <li><a href="http://localhost:8080/publications/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/series-publication-with-datasets-dataset">Example page</a>


### PR DESCRIPTION
Add 2 new document types to cater for CI Hub and
CI Landing pages, the former with links to the latter.
The CI hub page is now the root document for site.
Replaced invalid double quote characters from Terms and
conditions document content.