### PR TITLE
[RPS-324] CI migration set information type

### DIFF
--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/config/MigratorConfiguration.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/config/MigratorConfiguration.java
@@ -19,7 +19,7 @@ public class MigratorConfiguration {
 
     @Bean
     public List<MigrationTask> tasks(final ExecutionParameters executionParameters,
-                                     final ImportableItemsFactory importableItemsFactory,
+                                     final NesstarImportableItemsFactory nesstarImportableItemsFactory,
                                      final SocialCareImportables socialCareImportables,
                                      final CcgImportables ccgImportables,
                                      final NhsOutcomesFrameworkImportables nhsOutcomesFrameworkImportables,
@@ -32,7 +32,7 @@ public class MigratorConfiguration {
             new UnzipNesstarExportFileTask(executionParameters),
             new GenerateNesstarImportContentTask(
                 executionParameters,
-                importableItemsFactory,
+                nesstarImportableItemsFactory,
                 socialCareImportables,
                 ccgImportables,
                 nhsOutcomesFrameworkImportables,
@@ -61,11 +61,11 @@ public class MigratorConfiguration {
     }
 
     @Bean
-    public ImportableItemsFactory importableItemsFactory(final ExecutionParameters executionParameters,
-                                                         final MigrationReport migrationReport,
-                                                         final TaxonomyMigrator taxonomyMigrator)
+    public NesstarImportableItemsFactory importableItemsFactory(final ExecutionParameters executionParameters,
+                                                                final MigrationReport migrationReport,
+                                                                final TaxonomyMigrator taxonomyMigrator)
     {
-        return new ImportableItemsFactory(executionParameters, migrationReport, taxonomyMigrator);
+        return new NesstarImportableItemsFactory(executionParameters, migrationReport, taxonomyMigrator);
     }
 
     @Bean
@@ -74,26 +74,26 @@ public class MigratorConfiguration {
     }
 
     @Bean
-    public CcgImportables ccgImportables(final ImportableItemsFactory importableItemsFactory) {
-        return new CcgImportables(importableItemsFactory);
+    public CcgImportables ccgImportables(final NesstarImportableItemsFactory nesstarImportableItemsFactory) {
+        return new CcgImportables(nesstarImportableItemsFactory);
     }
 
     @Bean
-    public SocialCareImportables socialCareImportables(final ImportableItemsFactory importableItemsFactory) {
-        return new SocialCareImportables(importableItemsFactory);
+    public SocialCareImportables socialCareImportables(final NesstarImportableItemsFactory nesstarImportableItemsFactory) {
+        return new SocialCareImportables(nesstarImportableItemsFactory);
     }
 
     @Bean
-    public NhsOutcomesFrameworkImportables nhsOutcomesFrameworkImportables(final ImportableItemsFactory importableItemsFactory) {
-        return new NhsOutcomesFrameworkImportables(importableItemsFactory);
+    public NhsOutcomesFrameworkImportables nhsOutcomesFrameworkImportables(final NesstarImportableItemsFactory nesstarImportableItemsFactory) {
+        return new NhsOutcomesFrameworkImportables(nesstarImportableItemsFactory);
     }
 
     @Bean
     public CompendiumImportables compendiumImportables(final ExecutionParameters executionParameters,
-                                                       final ImportableItemsFactory importableItemsFactory,
+                                                       final NesstarImportableItemsFactory nesstarImportableItemsFactory,
                                                        final MigrationReport migrationReport
     ) {
-        return new CompendiumImportables(executionParameters, importableItemsFactory, migrationReport);
+        return new CompendiumImportables(executionParameters, nesstarImportableItemsFactory, migrationReport);
     }
 
     @Bean

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/Publication.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/Publication.java
@@ -3,13 +3,16 @@ package uk.nhs.digital.ps.migrator.model.hippo;
 public class Publication extends HippoImportableItem {
 
     private final String title;
+    private final String informationType;
 
     public Publication(final Folder parent,
                        final String name,
-                       final String title
+                       final String title,
+                       final String informationType
     ) {
         super(parent, name);
         this.title = title;
+        this.informationType = informationType;
     }
 
     public String getTitle() {
@@ -18,5 +21,9 @@ public class Publication extends HippoImportableItem {
 
     public String getSummary() {
         return title + " Summary";
+    }
+
+    public String getInformationType() {
+        return informationType;
     }
 }

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/GenerateNesstarImportContentTask.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/GenerateNesstarImportContentTask.java
@@ -40,7 +40,7 @@ public class GenerateNesstarImportContentTask implements MigrationTask {
 
     private final ExecutionParameters executionParameters;
 
-    private final ImportableItemsFactory importableItemsFactory;
+    private final NesstarImportableItemsFactory nesstarImportableItemsFactory;
     private final SocialCareImportables socialCareImportables;
     private final CcgImportables ccgImportables;
     private final NhsOutcomesFrameworkImportables nhsOutcomesFrameworkImportables;
@@ -51,7 +51,7 @@ public class GenerateNesstarImportContentTask implements MigrationTask {
 
 
     public GenerateNesstarImportContentTask(final ExecutionParameters executionParameters,
-                                            final ImportableItemsFactory importableItemsFactory,
+                                            final NesstarImportableItemsFactory nesstarImportableItemsFactory,
                                             final SocialCareImportables socialCareImportables,
                                             final CcgImportables ccgImportables,
                                             final NhsOutcomesFrameworkImportables nhsOutcomesFrameworkImportables,
@@ -61,7 +61,7 @@ public class GenerateNesstarImportContentTask implements MigrationTask {
                                             final TaxonomyMigrator taxonomyMigrator) {
 
         this.executionParameters = executionParameters;
-        this.importableItemsFactory = importableItemsFactory;
+        this.nesstarImportableItemsFactory = nesstarImportableItemsFactory;
         this.socialCareImportables = socialCareImportables;
         this.ccgImportables = ccgImportables;
         this.nhsOutcomesFrameworkImportables = nhsOutcomesFrameworkImportables;
@@ -176,7 +176,7 @@ public class GenerateNesstarImportContentTask implements MigrationTask {
         // separating them from Statistical Publications.
         // Expected CMS path: Corporate Website/Publications System/Clinical Indicators
 
-        final Folder rootClinicalIndicatorsFolder = importableItemsFactory.toFolder(
+        final Folder rootClinicalIndicatorsFolder = nesstarImportableItemsFactory.toFolder(
             null, catalogStructure.findCatalogByLabel(ROOT_CATALOG_LABEL)
         );
         rootClinicalIndicatorsFolder.setLocalizedName("Clinical Indicators");

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/NesstarImportableItemsFactory.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/NesstarImportableItemsFactory.java
@@ -23,20 +23,21 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
-public class ImportableItemsFactory {
+public class NesstarImportableItemsFactory {
 
-    private final static Logger log = getLogger(ImportableItemsFactory.class);
+    private final static Logger log = getLogger(NesstarImportableItemsFactory.class);
 
     private static final String DATE_FIELD_NOMINAL_DATE = "Nominal Date";
     private static final String DATE_FIELD_NEXT_PUBLICATION_DATE = "Next Publication Date";
+    private static final String PUBLICATION_INFORMATION_TYPE = "Open data";
 
     private final ExecutionParameters executionParameters;
     private final MigrationReport migrationReport;
     private final TaxonomyMigrator taxonomyMigrator;
 
-    public ImportableItemsFactory(final ExecutionParameters executionParameters,
-                                  final MigrationReport migrationReport,
-                                  final TaxonomyMigrator taxonomyMigrator) {
+    public NesstarImportableItemsFactory(final ExecutionParameters executionParameters,
+                                         final MigrationReport migrationReport,
+                                         final TaxonomyMigrator taxonomyMigrator) {
         this.executionParameters = executionParameters;
         this.migrationReport = migrationReport;
         this.taxonomyMigrator = taxonomyMigrator;
@@ -55,7 +56,8 @@ public class ImportableItemsFactory {
 
         return new Publication(
             parentFolder, "content",
-            catalog.getLabel()
+            catalog.getLabel(),
+            PUBLICATION_INFORMATION_TYPE
         );
     }
 
@@ -130,7 +132,8 @@ public class ImportableItemsFactory {
         return new Publication(
             parentFolder,
             name,
-            title
+            title,
+            PUBLICATION_INFORMATION_TYPE
         );
     }
 

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/CcgImportables.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/CcgImportables.java
@@ -6,7 +6,7 @@ import uk.nhs.digital.ps.migrator.model.hippo.Publication;
 import uk.nhs.digital.ps.migrator.model.hippo.Series;
 import uk.nhs.digital.ps.migrator.model.nesstar.Catalog;
 import uk.nhs.digital.ps.migrator.model.nesstar.CatalogStructure;
-import uk.nhs.digital.ps.migrator.task.ImportableItemsFactory;
+import uk.nhs.digital.ps.migrator.task.NesstarImportableItemsFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,10 +16,10 @@ import static java.util.stream.Collectors.toList;
 
 public class CcgImportables {
 
-    private final ImportableItemsFactory importableItemsFactory;
+    private final NesstarImportableItemsFactory nesstarImportableItemsFactory;
 
-    public CcgImportables(final ImportableItemsFactory importableItemsFactory) {
-        this.importableItemsFactory = importableItemsFactory;
+    public CcgImportables(final NesstarImportableItemsFactory nesstarImportableItemsFactory) {
+        this.nesstarImportableItemsFactory = nesstarImportableItemsFactory;
     }
 
     public List<HippoImportableItem> create(final CatalogStructure catalogStructure, final Folder ciRootFolder) {
@@ -37,13 +37,13 @@ public class CcgImportables {
 
         // A)
         final Catalog ccgRootCatalog = catalogStructure.findCatalogByLabel("CCG Outcomes Indicator Set");
-        final Folder ccgRootFolder = importableItemsFactory.toFolder(ciRootFolder, ccgRootCatalog);
+        final Folder ccgRootFolder = nesstarImportableItemsFactory.toFolder(ciRootFolder, ccgRootCatalog);
 
         // B)
-        final Folder currentPublicationFolder = importableItemsFactory.newFolder(ccgRootFolder, "Current");
+        final Folder currentPublicationFolder = nesstarImportableItemsFactory.newFolder(ccgRootFolder, "Current");
 
         // C)
-        final Publication currentPublication = importableItemsFactory.newPublication(
+        final Publication currentPublication = nesstarImportableItemsFactory.newPublication(
             currentPublicationFolder, "content", ccgRootFolder.getLocalizedName());
 
         // D)
@@ -52,23 +52,23 @@ public class CcgImportables {
 
         final List<HippoImportableItem> domainsWithDatasets = domainCatalogs.stream()
             .flatMap(domainCatalog -> {
-                final Folder domainFolder = importableItemsFactory.toFolder(currentPublicationFolder, domainCatalog);
+                final Folder domainFolder = nesstarImportableItemsFactory.toFolder(currentPublicationFolder, domainCatalog);
 
                 return Stream.concat(
                     Stream.of(domainFolder),
                     // E)
                     domainCatalog.findPublishingPackages().stream().map(domainPublishingPackage ->
-                        importableItemsFactory.toDataSet(domainFolder, domainPublishingPackage)
+                        nesstarImportableItemsFactory.toDataSet(domainFolder, domainPublishingPackage)
                     )
                 );
 
             }).collect(toList());
 
         // F)
-        final Folder archiveFolder = importableItemsFactory.newFolder(ccgRootFolder, "Archive");
+        final Folder archiveFolder = nesstarImportableItemsFactory.newFolder(ccgRootFolder, "Archive");
 
         // G
-        final Series series = importableItemsFactory.newSeries(archiveFolder, "Archived " + ccgRootFolder.getLocalizedName());
+        final Series series = nesstarImportableItemsFactory.newSeries(archiveFolder, "Archived " + ccgRootFolder.getLocalizedName());
 
         final List<HippoImportableItem> importableItems = new ArrayList<>();
         importableItems.add(ccgRootFolder);

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/CompendiumImportables.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/CompendiumImportables.java
@@ -15,7 +15,7 @@ import uk.nhs.digital.ps.migrator.model.hippo.Publication;
 import uk.nhs.digital.ps.migrator.model.hippo.Series;
 import uk.nhs.digital.ps.migrator.model.nesstar.DataSetRepository;
 import uk.nhs.digital.ps.migrator.model.nesstar.PublishingPackage;
-import uk.nhs.digital.ps.migrator.task.ImportableItemsFactory;
+import uk.nhs.digital.ps.migrator.task.NesstarImportableItemsFactory;
 
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -42,15 +42,15 @@ public class CompendiumImportables {
     private static final Pattern P_CODE_REGEX = Pattern.compile("P\\d+");
 
     private final ExecutionParameters executionParameters;
-    private final ImportableItemsFactory factory;
+    private final NesstarImportableItemsFactory factory;
     private final MigrationReport migrationReport;
 
     public CompendiumImportables(final ExecutionParameters executionParameters,
-                                 final ImportableItemsFactory importableItemsFactory,
+                                 final NesstarImportableItemsFactory nesstarImportableItemsFactory,
                                  final MigrationReport migrationReport) {
 
         this.executionParameters = executionParameters;
-        this.factory = importableItemsFactory;
+        this.factory = nesstarImportableItemsFactory;
         this.migrationReport = migrationReport;
     }
 

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/NhsOutcomesFrameworkImportables.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/NhsOutcomesFrameworkImportables.java
@@ -6,7 +6,7 @@ import uk.nhs.digital.ps.migrator.model.hippo.Publication;
 import uk.nhs.digital.ps.migrator.model.hippo.Series;
 import uk.nhs.digital.ps.migrator.model.nesstar.Catalog;
 import uk.nhs.digital.ps.migrator.model.nesstar.CatalogStructure;
-import uk.nhs.digital.ps.migrator.task.ImportableItemsFactory;
+import uk.nhs.digital.ps.migrator.task.NesstarImportableItemsFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,10 +16,10 @@ import static java.util.stream.Collectors.toList;
 
 public class NhsOutcomesFrameworkImportables {
 
-    private final ImportableItemsFactory importableItemsFactory;
+    private final NesstarImportableItemsFactory nesstarImportableItemsFactory;
 
-    public NhsOutcomesFrameworkImportables(final ImportableItemsFactory importableItemsFactory) {
-        this.importableItemsFactory = importableItemsFactory;
+    public NhsOutcomesFrameworkImportables(final NesstarImportableItemsFactory nesstarImportableItemsFactory) {
+        this.nesstarImportableItemsFactory = nesstarImportableItemsFactory;
     }
 
     public List<HippoImportableItem> create(final CatalogStructure catalogStructure, final Folder ciRootFolder) {
@@ -38,13 +38,13 @@ public class NhsOutcomesFrameworkImportables {
 
         // A)
         final Catalog rootCatalog = catalogStructure.findCatalogByLabel("NHS Outcomes Framework");
-        final Folder nfoRootFolder = importableItemsFactory.toFolder(ciRootFolder, rootCatalog);
+        final Folder nfoRootFolder = nesstarImportableItemsFactory.toFolder(ciRootFolder, rootCatalog);
 
         // B)
-        final Folder currentPublicationFolder = importableItemsFactory.newFolder(nfoRootFolder, "Current");
+        final Folder currentPublicationFolder = nesstarImportableItemsFactory.newFolder(nfoRootFolder, "Current");
 
         // C)
-        final Publication currentPublication = importableItemsFactory.newPublication(
+        final Publication currentPublication = nesstarImportableItemsFactory.newPublication(
             currentPublicationFolder, "content", nfoRootFolder.getLocalizedName()
         );
 
@@ -53,7 +53,7 @@ public class NhsOutcomesFrameworkImportables {
             .stream()
             .filter(domainCatalog -> !"NHS Outcomes Framework (NHS OF) summary dashboard and useful links".equals(domainCatalog.getLabel()))
             .flatMap(domainCatalog -> {
-                final Folder domainFolder = importableItemsFactory.toFolder(currentPublicationFolder, domainCatalog);
+                final Folder domainFolder = nesstarImportableItemsFactory.toFolder(currentPublicationFolder, domainCatalog);
 
                 return Stream.concat(
                     Stream.of(domainFolder),
@@ -63,10 +63,10 @@ public class NhsOutcomesFrameworkImportables {
             }).collect(toList());
 
         // F)
-        final Folder archiveFolder = importableItemsFactory.newFolder(nfoRootFolder, "Archive");
+        final Folder archiveFolder = nesstarImportableItemsFactory.newFolder(nfoRootFolder, "Archive");
 
         // G
-        final Series series = importableItemsFactory.newSeries(archiveFolder, "Archived " + nfoRootFolder.getLocalizedName());
+        final Series series = nesstarImportableItemsFactory.newSeries(archiveFolder, "Archived " + nfoRootFolder.getLocalizedName());
 
         importableItems.add(nfoRootFolder);
         importableItems.add(currentPublicationFolder);
@@ -83,7 +83,7 @@ public class NhsOutcomesFrameworkImportables {
 
         if (catalogs.isEmpty()) {
             return rootCatalog.findPublishingPackages().stream().map(domainPublishingPackage ->
-                importableItemsFactory.toDataSet(rootFolder, domainPublishingPackage)
+                nesstarImportableItemsFactory.toDataSet(rootFolder, domainPublishingPackage)
             );
         }
 

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/SocialCareImportables.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/SocialCareImportables.java
@@ -6,7 +6,7 @@ import uk.nhs.digital.ps.migrator.model.hippo.Publication;
 import uk.nhs.digital.ps.migrator.model.hippo.Series;
 import uk.nhs.digital.ps.migrator.model.nesstar.Catalog;
 import uk.nhs.digital.ps.migrator.model.nesstar.CatalogStructure;
-import uk.nhs.digital.ps.migrator.task.ImportableItemsFactory;
+import uk.nhs.digital.ps.migrator.task.NesstarImportableItemsFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -16,10 +16,10 @@ import static java.util.stream.Collectors.toList;
 
 public class SocialCareImportables {
 
-    private final ImportableItemsFactory importableItemsFactory;
+    private final NesstarImportableItemsFactory nesstarImportableItemsFactory;
 
-    public SocialCareImportables(final ImportableItemsFactory importableItemsFactory) {
-        this.importableItemsFactory = importableItemsFactory;
+    public SocialCareImportables(final NesstarImportableItemsFactory nesstarImportableItemsFactory) {
+        this.nesstarImportableItemsFactory = nesstarImportableItemsFactory;
     }
 
     public List<HippoImportableItem> create(final CatalogStructure catalogStructure, final Folder ciRootFolder) {
@@ -37,13 +37,13 @@ public class SocialCareImportables {
 
         // A)
         final Catalog rootCatalog = catalogStructure.findCatalogByLabel("Adult Social Care Outcomes Framework (ASCOF)");
-        final Folder rootFolder = importableItemsFactory.toFolder(ciRootFolder, rootCatalog);
+        final Folder rootFolder = nesstarImportableItemsFactory.toFolder(ciRootFolder, rootCatalog);
 
         // B)
-        final Folder currentPublicationFolder = importableItemsFactory.newFolder(rootFolder, "Current");
+        final Folder currentPublicationFolder = nesstarImportableItemsFactory.newFolder(rootFolder, "Current");
 
         // C)
-        final Publication currentPublication = importableItemsFactory.newPublication(
+        final Publication currentPublication = nesstarImportableItemsFactory.newPublication(
             currentPublicationFolder, "content", rootFolder.getLocalizedName());
 
         // D)
@@ -51,23 +51,23 @@ public class SocialCareImportables {
 
         final List<HippoImportableItem> domainsWithDatasets = domainCatalogs.stream()
             .flatMap(domainCatalog -> {
-                final Folder domainFolder = importableItemsFactory.toFolder(currentPublicationFolder, domainCatalog);
+                final Folder domainFolder = nesstarImportableItemsFactory.toFolder(currentPublicationFolder, domainCatalog);
 
                 return Stream.concat(
                     Stream.of(domainFolder),
                     // E)
                     domainCatalog.findPublishingPackages().stream().map(domainPublishingPackage ->
-                        importableItemsFactory.toDataSet(domainFolder, domainPublishingPackage)
+                        nesstarImportableItemsFactory.toDataSet(domainFolder, domainPublishingPackage)
                     )
                 );
 
             }).collect(toList());
 
         // F)
-        final Folder archiveFolder = importableItemsFactory.newFolder(rootFolder, "Archive");
+        final Folder archiveFolder = nesstarImportableItemsFactory.newFolder(rootFolder, "Archive");
 
         // G
-        final Series series = importableItemsFactory.newSeries(archiveFolder, "Archived " + rootFolder.getLocalizedName());
+        final Series series = nesstarImportableItemsFactory.newSeries(archiveFolder, "Archived " + rootFolder.getLocalizedName());
 
         final List<HippoImportableItem> importableItems = new ArrayList<>();
         importableItems.add(rootFolder);

--- a/migrator/src/main/resources/templates/publication.json.ftl
+++ b/migrator/src/main/resources/templates/publication.json.ftl
@@ -22,7 +22,7 @@
     "name" : "publicationsystem:InformationType",
     "type" : "STRING",
     "multiple" : true,
-    "values" : [ "Experimental statistics" ]
+    "values" : [ "${publication.informationType}" ]
   }, {
     "name" : "publicationsystem:Summary",
     "type" : "STRING",

--- a/migrator/src/test/java/uk/nhs/digital/ps/migrator/task/NesstarImportableItemsFactoryTest.java
+++ b/migrator/src/test/java/uk/nhs/digital/ps/migrator/task/NesstarImportableItemsFactoryTest.java
@@ -21,21 +21,21 @@ import java.util.Arrays;
 import java.util.List;
 
 @RunWith(DataProviderRunner.class)
-public class ImportableItemsFactoryTest {
+public class NesstarImportableItemsFactoryTest {
 
 
     @Mock ExecutionParameters executionParameters;
     @Mock MigrationReport migrationReport;
     @Mock TaxonomyMigrator taxonomyMigrator;
 
-    private ImportableItemsFactory importableItemsFactory;
+    private NesstarImportableItemsFactory nesstarImportableItemsFactory;
 
 
     @Before
     public void setUp() throws Exception {
         initMocks(this);
 
-        importableItemsFactory = new ImportableItemsFactory(executionParameters, migrationReport, taxonomyMigrator);
+        nesstarImportableItemsFactory = new NesstarImportableItemsFactory(executionParameters, migrationReport, taxonomyMigrator);
     }
 
     @Test
@@ -46,7 +46,7 @@ public class ImportableItemsFactoryTest {
         final String pCode = "aTestPCodeValue";
 
         // when
-        importableItemsFactory.formatDatasetSummary(summaryWithHtmlMarkup, null, pCode);
+        nesstarImportableItemsFactory.formatDatasetSummary(summaryWithHtmlMarkup, null, pCode);
 
         // then
         verify(migrationReport).report(pCode, IncidentType.HTML_IN_SUMMARY, summaryWithHtmlMarkup);
@@ -61,7 +61,7 @@ public class ImportableItemsFactoryTest {
         final String expectedSummary = testData[1];
 
         // when
-        final String actualSummary = importableItemsFactory.formatDatasetSummary(inputSummary, null, "aTestPCode");
+        final String actualSummary = nesstarImportableItemsFactory.formatDatasetSummary(inputSummary, null, "aTestPCode");
 
         // then
         assertThat("Summary is formatted correctly", actualSummary, startsWith(expectedSummary));


### PR DESCRIPTION
For the clinical indicator import process, information type
is now set to 'Open data' for the publication level content
document.  Also renamed ImportableItemsFactory to
NesstarImportableItemsFactory in order to make it more explicit
that the import is for Nesstar content.