### PR TITLE
[RPS-312] Import Initial Content

### DIFF
--- a/cms/src/main/java/uk/nhs/digital/ps/modules/FullTaxonomyModule.java
+++ b/cms/src/main/java/uk/nhs/digital/ps/modules/FullTaxonomyModule.java
@@ -15,7 +15,6 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
-import javax.jcr.Session;
 import javax.jcr.Value;
 
 public class FullTaxonomyModule extends AbstractDaemonModule {
@@ -25,15 +24,6 @@ public class FullTaxonomyModule extends AbstractDaemonModule {
     public static final String HIPPO_CLASSIFIABLE_PATH = "/hippo:namespaces/publicationsystem/publication/editor:templates/_default_/classifiable";
     public static final String TAXONOMY_NAME_PROPERTY = "essentials-taxonomy-name";
     public static final String FULL_TAXONOMY_PROPERTY = "common:FullTaxonomy";
-
-    private Node taxonomyTreeNode;
-
-    @Override
-    public void initialize(final Session session) {
-        super.initialize(session);
-
-        this.taxonomyTreeNode = getTaxonomyTreeNode();
-    }
 
     @Override
     protected void handleCommitEvent(HippoWorkflowEvent event) {
@@ -90,7 +80,7 @@ public class FullTaxonomyModule extends AbstractDaemonModule {
 
     private Stream<String> getTaxonomyList(String key) {
 
-        Optional<Node> taxonomyNodeOptional = getDescendantTaxonomyNodes(taxonomyTreeNode)
+        Optional<Node> taxonomyNodeOptional = getDescendantTaxonomyNodes(getTaxonomyTreeNode())
             .filter(node -> getTaxonomyKey(node).equals(key))
             .findAny();
 

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/TaxonomyMigrator.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/TaxonomyMigrator.java
@@ -32,7 +32,7 @@ public class TaxonomyMigrator {
     private static final String TAXONOMY_MAPPING_COLUMN_PREFIX = "Leaf";
     private static final String P_CODE_COLUMN = "P Code";
     private static final String TAXONOMY_DEFINITION_SHEET_NAME = "Taxonomy with structure";
-    private static final String TAXONOMY_MAPPING_SHEET_NAME = "Examples";
+    private static final String TAXONOMY_MAPPING_SHEET_NAME = "Taxonomy mapping";
 
     private MigrationReport migrationReport;
     private ExecutionParameters executionParameters;

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/report/DatasetMigrationImpact.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/report/DatasetMigrationImpact.java
@@ -5,6 +5,7 @@ public enum DatasetMigrationImpact {
     FIELD_MIGRATED_AS_IS("Field migrated as is"),
     FIELD_MIGRATED_MODIFIED("Modified value migrated"),
     FIELD_NOT_MIGRATED("Field not migrated"),
+    FIELD_MIGRATED_PARTIALLY("Field migrated partially"),
     DATASET_NOT_MIGRATED("Dataset not migrated"),
     ONE_DUPLICATE_DATASET_MIGRATED("Dataset migrated once");
 

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/report/IncidentType.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/report/IncidentType.java
@@ -134,10 +134,11 @@ public enum IncidentType {
         + "\nthe offending Dataset."
     ),
     TAXONOMY_MAPPING_INVALID(
-        FIELD_NOT_MIGRATED,
+        FIELD_MIGRATED_PARTIALLY,
         "Invalid Taxonomy mapping",
         "Provided Taxonomy values",
-        "Taxonomy mapping provided for the Dataset contained invalid values."
+        "Taxonomy mapping provided for the Dataset contained invalid values"
+        + "\n(ones absent from the Taxonomy definition)."
         + "\nValid values were migrated, invalid ones ignored."
         + "\n"
         + "\nProvided Taxonomy Mapping file needs reviewing in context of"

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/report/MigrationReport.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/report/MigrationReport.java
@@ -272,6 +272,14 @@ public class MigrationReport {
             "Compendium Mapping file used", executionParameters.getNesstarCompendiumMappingFile().getFileName()
         );
 
+        addMetaDataRow(labelCellStyle, valueCellStyle, metadataSheet, currentRowNumber.addAndGet(1),
+            "Taxonomy definition file used", executionParameters.getTaxonomyDefinitionImportPath().getFileName()
+        );
+
+        addMetaDataRow(labelCellStyle, valueCellStyle, metadataSheet, currentRowNumber.addAndGet(1),
+            "Taxonomy mapping file used", executionParameters.getTaxonomyMappingImportPath().getFileName()
+        );
+
         currentRowNumber.addAndGet(3);
 
         addMetaDataRow(labelCellStyle, valueCellStyle, metadataSheet, currentRowNumber.addAndGet(1),

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/CompendiumImportables.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/CompendiumImportables.java
@@ -31,14 +31,11 @@ import java.util.stream.Stream;
 
 import static java.text.MessageFormat.format;
 import static java.util.stream.StreamSupport.stream;
-import static org.slf4j.LoggerFactory.getLogger;
 import static uk.nhs.digital.ps.migrator.report.IncidentType.*;
 
 public class CompendiumImportables {
 
-    private final static Logger log = getLogger(CompendiumImportables.class);
-
-    private static final String P_CODE_MAPPING_SHEET_NAME = "Sheet2";
+    private static final String P_CODE_MAPPING_SHEET_NAME = "Mapping of P codes";
     private static final Pattern P_CODE_REGEX = Pattern.compile("P\\d+");
 
     private final ExecutionParameters executionParameters;

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/MigratorImporterScript.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/MigratorImporterScript.yaml
@@ -8,20 +8,25 @@ definitions:
         \ by the latter:\n- with each file containing definition of only one document\
         \ or folder,\n- with files being named in the way where when ordered ascendingly\
         \ by their names, files defining folders will be processed before those defining\
-        \ their content.\n\nKeep batch size set to 1 to ensure that folder files are\
+        \ their content.\
+        \ \n\nParameters:\
+        \ \n- sourceBaseFolderPath - points to the directory that contains EXIM
+        \ import JSON files.\
+        \ \n\nKeep batch size set to 1 to ensure that folder files are\
         \ correctly processed; the system appears to only commit changes between individual\
         \ batches and if parent and child folders are created in the same batch, the\
         \ parent cannot be found when the child is being created. Keeping batch size\
         \ set to 1 ensures that changes from each import file are committed before\
-        \ the next file is processed.\n\nNOTE that the expectation is that the script\
-        \ will only ever be executed once as it has no logic to deal with partial\
-        \ imports - if, say, a failure occurs and the script is re-run, duplicates\
-        \ or further errors can be expected. "
+        \ the next file is processed.\
+        \ \n\nNOTE that the expectation is that the script will only ever be
+        \ executed once as it has no logic to deal with partial imports - if, say,
+        \ a failure occurs and the script is re-run, duplicates or further errors\
+        \ can be expected."
       hipposys:dryrun: false
       hipposys:parameters: '{"sourceBaseFolderPath": "file:/tmp/migrator/exim-import/"}'
-      hipposys:path: /
+      hipposys:path: /content/documents/corporate-website/publication-system
       hipposys:script:
         resource: /configuration/update/MigratorImporterScript.groovy
         type: string
-      hipposys:throttle: 10
+      hipposys:throttle: 100
       jcr:primaryType: hipposys:updaterinfo


### PR DESCRIPTION
Fixed problem with Taxonomy population during import,
where the FullTaxonomyModule class would obtain an instance
of the Taxonomy document on system start and attempt to use it
during import. When the document was deleted in an early manual
step of the import process, the reference kept by the class would be
no longer valid, causing tagging of documents during import to fail.
The class has been modified to fetch fresh copy of the document
each time it's needed rather that story it as an internal state.

Modified the import script to:
* execute document creation and document publishing in separate
  batch units,
* increase gap between execution of batch units from 10ms to
  100ms to ensure

This was to ensure that one step is definitely finished before the
other commences as it's been observed that (probably with more
intensive processing introduced by event-driven Taxonomy tag
propagation?), the latter would start executing (and fail) while
the former was not entirely finished.