### PR TITLE
[RPS-322] Nominal date for migrated publications

### DIFF
--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/HippoImportableItem.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/HippoImportableItem.java
@@ -3,7 +3,11 @@ package uk.nhs.digital.ps.migrator.model.hippo;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import uk.nhs.digital.ps.migrator.misc.TextHelper;
 
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -13,6 +17,9 @@ import static java.util.stream.Collectors.joining;
 import static org.apache.commons.lang3.builder.ToStringStyle.SHORT_PREFIX_STYLE;
 
 public abstract class HippoImportableItem {
+
+    public static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+    public static final String EMPTY_DATE = "0001-01-01T12:00:00.000Z";
 
     private static final String ROOT_PATH_PREFIX = "/content/documents/corporate-website/publication-system";
 
@@ -107,6 +114,14 @@ public abstract class HippoImportableItem {
              currentParent = currentParent.parentFolder) {
 
             folderVisitor.accept(currentParent);
+        }
+    }
+
+    public static Date parseDate(String dateStr) {
+        try {
+            return DATE_FORMAT.parse(dateStr);
+        } catch (ParseException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/Publication.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/model/hippo/Publication.java
@@ -4,15 +4,17 @@ public class Publication extends HippoImportableItem {
 
     private final String title;
     private final String informationType;
+    private final String nominalDate;
 
     public Publication(final Folder parent,
                        final String name,
                        final String title,
-                       final String informationType
-    ) {
+                       final String informationType,
+                       final String nominalDate) {
         super(parent, name);
         this.title = title;
         this.informationType = informationType;
+        this.nominalDate = nominalDate;
     }
 
     public String getTitle() {
@@ -25,5 +27,9 @@ public class Publication extends HippoImportableItem {
 
     public String getInformationType() {
         return informationType;
+    }
+
+    public String getNominalDate() {
+        return nominalDate;
     }
 }

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/CcgImportables.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/CcgImportables.java
@@ -2,10 +2,7 @@ package uk.nhs.digital.ps.migrator.task.importables;
 
 import static java.util.stream.Collectors.toList;
 
-import uk.nhs.digital.ps.migrator.model.hippo.Folder;
-import uk.nhs.digital.ps.migrator.model.hippo.HippoImportableItem;
-import uk.nhs.digital.ps.migrator.model.hippo.Publication;
-import uk.nhs.digital.ps.migrator.model.hippo.Series;
+import uk.nhs.digital.ps.migrator.model.hippo.*;
 import uk.nhs.digital.ps.migrator.model.nesstar.Catalog;
 import uk.nhs.digital.ps.migrator.model.nesstar.CatalogStructure;
 import uk.nhs.digital.ps.migrator.task.NesstarImportableItemsFactory;
@@ -42,9 +39,6 @@ public class CcgImportables {
         // B)
         final Folder currentPublicationFolder = nesstarImportableItemsFactory.newFolder(ccgRootFolder, "Current");
 
-        // C)
-        final Publication currentPublication = nesstarImportableItemsFactory.newPublication(
-            currentPublicationFolder, "content", ccgRootFolder.getLocalizedName());
 
         // D)
         // There is only one level of Domains under CCG so it's enough to just iterate over them rather than walk a tree
@@ -63,6 +57,13 @@ public class CcgImportables {
                 );
 
             }).collect(toList());
+
+        // C)
+        final Publication currentPublication = nesstarImportableItemsFactory.newPublication(
+            currentPublicationFolder,
+            "content",
+            ccgRootFolder.getLocalizedName(),
+            domainsWithDatasets);
 
         // F)
         final Folder archiveFolder = nesstarImportableItemsFactory.newFolder(ccgRootFolder, "Archive");

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/CompendiumImportables.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/CompendiumImportables.java
@@ -10,10 +10,7 @@ import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import uk.nhs.digital.ps.migrator.config.ExecutionParameters;
-import uk.nhs.digital.ps.migrator.model.hippo.Folder;
-import uk.nhs.digital.ps.migrator.model.hippo.HippoImportableItem;
-import uk.nhs.digital.ps.migrator.model.hippo.Publication;
-import uk.nhs.digital.ps.migrator.model.hippo.Series;
+import uk.nhs.digital.ps.migrator.model.hippo.*;
 import uk.nhs.digital.ps.migrator.model.nesstar.DataSetRepository;
 import uk.nhs.digital.ps.migrator.model.nesstar.PublishingPackage;
 import uk.nhs.digital.ps.migrator.report.IncidentType;
@@ -100,24 +97,26 @@ public class CompendiumImportables {
                 final Folder publicationFolder = factory.newFolder(seriesCurrentFolder, publicationPrototype.getName());
                 importableItems.add(publicationFolder);
 
-                // F)
-                final Publication publication = factory.newPublication(
-                    publicationFolder,
-                    "content",
-                    publicationPrototype.getName()
-                );
-                importableItems.add(publication);
-
                 // G)
+                ArrayList<HippoImportableItem> datasets = new ArrayList<>();
                 publicationPrototype.getDatasetIds().forEach(datasetId -> {
                     final PublishingPackage publishingPackage = dataSetRepository.findById(datasetId);
                     if (publishingPackage == null) {
                         migrationReport.report(datasetId, IncidentType.DATASET_MISSING_IN_MAPPING, publicationPrototype.getName());
                     } else {
-                        importableItems.add(factory.toDataSet(publicationFolder, publishingPackage));
+                        datasets.add(factory.toDataSet(publicationFolder, publishingPackage));
                     }
                 });
 
+                // F)
+                final Publication publication = factory.newPublication(
+                    publicationFolder,
+                    "content",
+                    publicationPrototype.getName(),
+                    datasets);
+
+                importableItems.add(publication);
+                importableItems.addAll(datasets);
             });
 
             // H)

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/NhsOutcomesFrameworkImportables.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/NhsOutcomesFrameworkImportables.java
@@ -2,10 +2,7 @@ package uk.nhs.digital.ps.migrator.task.importables;
 
 import static java.util.stream.Collectors.toList;
 
-import uk.nhs.digital.ps.migrator.model.hippo.Folder;
-import uk.nhs.digital.ps.migrator.model.hippo.HippoImportableItem;
-import uk.nhs.digital.ps.migrator.model.hippo.Publication;
-import uk.nhs.digital.ps.migrator.model.hippo.Series;
+import uk.nhs.digital.ps.migrator.model.hippo.*;
 import uk.nhs.digital.ps.migrator.model.nesstar.Catalog;
 import uk.nhs.digital.ps.migrator.model.nesstar.CatalogStructure;
 import uk.nhs.digital.ps.migrator.task.NesstarImportableItemsFactory;
@@ -43,11 +40,6 @@ public class NhsOutcomesFrameworkImportables {
         // B)
         final Folder currentPublicationFolder = nesstarImportableItemsFactory.newFolder(nfoRootFolder, "Current");
 
-        // C)
-        final Publication currentPublication = nesstarImportableItemsFactory.newPublication(
-            currentPublicationFolder, "content", nfoRootFolder.getLocalizedName()
-        );
-
         // D)
         final List<HippoImportableItem> domainsWithDatasets = rootCatalog.getChildCatalogs()
             .stream()
@@ -61,6 +53,13 @@ public class NhsOutcomesFrameworkImportables {
                     getImportableDatasetsFromCatalog(domainCatalog, domainFolder)
                 );
             }).collect(toList());
+
+        // C)
+        final Publication currentPublication = nesstarImportableItemsFactory.newPublication(
+            currentPublicationFolder,
+            "content",
+            nfoRootFolder.getLocalizedName(),
+            domainsWithDatasets);
 
         // F)
         final Folder archiveFolder = nesstarImportableItemsFactory.newFolder(nfoRootFolder, "Archive");

--- a/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/SocialCareImportables.java
+++ b/migrator/src/main/java/uk/nhs/digital/ps/migrator/task/importables/SocialCareImportables.java
@@ -2,10 +2,7 @@ package uk.nhs.digital.ps.migrator.task.importables;
 
 import static java.util.stream.Collectors.toList;
 
-import uk.nhs.digital.ps.migrator.model.hippo.Folder;
-import uk.nhs.digital.ps.migrator.model.hippo.HippoImportableItem;
-import uk.nhs.digital.ps.migrator.model.hippo.Publication;
-import uk.nhs.digital.ps.migrator.model.hippo.Series;
+import uk.nhs.digital.ps.migrator.model.hippo.*;
 import uk.nhs.digital.ps.migrator.model.nesstar.Catalog;
 import uk.nhs.digital.ps.migrator.model.nesstar.CatalogStructure;
 import uk.nhs.digital.ps.migrator.task.NesstarImportableItemsFactory;
@@ -42,10 +39,6 @@ public class SocialCareImportables {
         // B)
         final Folder currentPublicationFolder = nesstarImportableItemsFactory.newFolder(rootFolder, "Current");
 
-        // C)
-        final Publication currentPublication = nesstarImportableItemsFactory.newPublication(
-            currentPublicationFolder, "content", rootFolder.getLocalizedName());
-
         // D)
         final List<Catalog> domainCatalogs = rootCatalog.getChildCatalogs();
 
@@ -62,6 +55,13 @@ public class SocialCareImportables {
                 );
 
             }).collect(toList());
+
+        // C)
+        final Publication currentPublication = nesstarImportableItemsFactory.newPublication(
+            currentPublicationFolder,
+            "content",
+            rootFolder.getLocalizedName(),
+            domainsWithDatasets);
 
         // F)
         final Folder archiveFolder = nesstarImportableItemsFactory.newFolder(rootFolder, "Archive");

--- a/migrator/src/main/resources/templates/publication.json.ftl
+++ b/migrator/src/main/resources/templates/publication.json.ftl
@@ -37,7 +37,7 @@
     "name" : "publicationsystem:NominalDate",
     "type" : "DATE",
     "multiple" : false,
-    "values" : [ "0001-01-01T12:00:00.000Z" ]
+    "values" : [ "${publication.nominalDate}" ]
   }, {
     "name" : "publicationsystem:KeyFacts",
     "type" : "STRING",

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/ci-hub.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/ci-hub.yaml
@@ -1,6 +1,5 @@
 ---
 /content/documents/corporate-website/publication-system/ci-hub:
-  .meta:order-before: acceptance-tests
   /ccg-outcomes:
     /ccg-outcomes[1]:
       /publicationsystem:content:


### PR DESCRIPTION
The nominal date is set on the publications from the
latest date of the child datasets.

Also made the field mapping case insensitive.