### PR TITLE
[RPS-350] Made Doc type facets consistent

### DIFF
--- a/acceptance-tests/src/test/resources/features/site/datasets.feature
+++ b/acceptance-tests/src/test/resources/features/site/datasets.feature
@@ -34,10 +34,11 @@ Feature: As a consumer I need to be able to navigate to publication data sets
     Scenario: Dataset label displayed for dataset document type
         Given I navigate to the "bare minimum dataset" page
         Then I should see headers:
-            | Data set                  |
+            | Data set            |
         And I should not see headers:
-            | Publication               |
-            | Series / Collection       |
+            | Publication         |
+            | Series / Collection |
+            | Archive             |
 
     Scenario: View resource links and download attachments from dataset
         Given I navigate to the "publication with datasets Dataset" data set page

--- a/acceptance-tests/src/test/resources/features/site/facets.feature
+++ b/acceptance-tests/src/test/resources/features/site/facets.feature
@@ -8,8 +8,8 @@ Feature: Faceted search
         Given I navigate to the "home" page
         When I search for "zzFacets_Testzz"
         Then I should see the "DOCUMENT TYPE" list containing:
-            | Statistical Publication (2) |
-            | Data Set (1)                |
+            | Publication (2) |
+            | Data set (1)    |
         And I should see the "CATEGORY" list containing:
             | Conditions (2)             |
             | Social care (2)            |
@@ -61,10 +61,10 @@ Feature: Faceted search
         Given I navigate to the "home" page
         When I search for "zzFacets_Testzz"
         Then I should see 3 search results
-        When I click on the "Statistical Publication" link
+        When I click on the "Publication" link
         Then I should see 2 search results
         And I should see the "DOCUMENT TYPE" list containing:
-            | Statistical Publication x |
+            | Publication x |
         And I should see the "CATEGORY" list containing:
             | Accidents and injuries (1) |
             | Conditions (1)             |
@@ -72,20 +72,20 @@ Feature: Faceted search
             | Social care (1)            |
         When I click on the "Cancer networks" link
         Then I should see 1 search results
-        When I can click on the "Statistical Publication" link
+        When I can click on the "Publication" link
         Then I should see 2 search results
 
 
     Scenario: Sticky facets when searching for new queries
         Given I navigate to the "home" page
         When I search for "zzFacets_Testzz"
-        And I click on the "Statistical Publication" link
+        And I click on the "Publication" link
         And I click on the "2018" link
         Then I should see 1 search results
         When I search for "WeightSearchTerm"
         Then I should see 3 search result
         And I should see the "DOCUMENT TYPE" list containing:
-            | Statistical Publication x |
+            | Publication x |
         And I should see the "YEAR" list containing:
             | 2018 x |
 

--- a/acceptance-tests/src/test/resources/features/site/publication.feature
+++ b/acceptance-tests/src/test/resources/features/site/publication.feature
@@ -53,10 +53,11 @@ Feature: Ensure publication page displays required fields.
     Scenario: Publication label displayed for publication document type
         Given I navigate to the "bare minimum publication" page
         Then I should see headers:
-            | Publication               |
+            | Publication |
         And I should not see headers:
-            | Series / Collection       |
-            | Data set                  |
+            | Series / Collection |
+            | Data set            |
+            | Archive             |
 
     Scenario: Display multiparagraph summary
         Given I navigate to "publication with datasets" page

--- a/acceptance-tests/src/test/resources/features/site/search.feature
+++ b/acceptance-tests/src/test/resources/features/site/search.feature
@@ -113,21 +113,30 @@ Feature: Basic search
         When I search for ""
         Then I should see the full search results page
         And I should see the "DOCUMENT TYPE" list including:
-            | Statistical Publication ( ... |
+            | Publication ( ...         |
+            | Data set ( ...            |
+            | Series / Collection ( ... |
+            | Archive ( ...             |
 
     Scenario: Navigating to the search page displays the results page with full, unfiltered result set
         Given I navigate to the "search" page
         Then I should see the full search results page
         And I should see the "DOCUMENT TYPE" list including:
-            | Statistical Publication ( ... |
+            | Publication ( ...         |
+            | Data set ( ...            |
+            | Series / Collection ( ... |
+            | Archive ( ...             |
 
     Scenario: Each document type label is correctly displayed in search results
         Given I navigate to the "home" page
         When I search for "Bare Minimum"
         Then I should see search results which also include:
-            | Data set              | Bare Minimum Dataset              |
-            | Publication           | Bare Minimum Publication          |
+            | Data set            | Bare Minimum Dataset          |
+            | Publication         | Bare Minimum Publication      |
         When I navigate to the "home" page
         When I search for "series"
         Then I should see search results which also include:
-            | Series / Collection   | Time Series Lorem Ipsum Dolor     |
+            | Series / Collection | Time Series Lorem Ipsum Dolor |
+        When I search for "archive"
+        Then I should see search results which also include:
+            | Archive             | Time Archive Lorem Ipsum Dolor |

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/document-types.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/document-types.yaml
@@ -22,10 +22,10 @@
     - publicationsystem:dataset
     - publicationsystem:publication
     resourcebundle:messages:
-    - Archive
-    - Series
-    - Data Set
-    - Statistical Publication
+    - labels.archive
+    - labels.series
+    - labels.dataset
+    - labels.publication
   /document-types[2]:
     hippo:availability:
     - preview
@@ -50,10 +50,10 @@
     - publicationsystem:dataset
     - publicationsystem:publication
     resourcebundle:messages:
-    - Archive
-    - Series
-    - Data Set
-    - Statistical Publication
+    - labels.archive
+    - labels.series
+    - labels.dataset
+    - labels.publication
   /document-types[3]:
     hippo:availability:
     - live
@@ -78,10 +78,10 @@
     - publicationsystem:dataset
     - publicationsystem:publication
     resourcebundle:messages:
-    - Archive
-    - Series
-    - Data Set
-    - Statistical Publication
+    - labels.archive
+    - labels.series
+    - labels.dataset
+    - labels.publication
   hippo:name: document types
   jcr:mixinTypes:
   - hippo:named

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/publication-system.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/publication-system.yaml
@@ -1,43 +1,13 @@
+---
 /content/documents/corporate-website/publication-system:
-  jcr:primaryType: hippostd:folder
-  jcr:mixinTypes: ['hippo:named', 'hippotranslation:translated', 'mix:versionable']
-  jcr:uuid: 7adaf1c8-f57c-462b-8a67-6dd189aa67a3
   hippo:name: Publication System
-  hippostd:foldertype: [new-translated-folder, new-document]
+  hippostd:foldertype:
+  - new-translated-folder
+  - new-document
   hippotranslation:id: 00000000-0000-0000-0000-000000000000
   hippotranslation:locale: en
-  /bfc4b2be-d52c-49dd-a849-511429458fd1-archive:
-    jcr:primaryType: hippo:handle
-    jcr:mixinTypes: ['hippo:named', 'mix:referenceable']
-    jcr:uuid: 8009f735-6dbb-4be8-973c-26ad2b87f8f9
-    hippo:name: bfc4b2be-d52c-49dd-a849-511429458fd1 Archive
-    /bfc4b2be-d52c-49dd-a849-511429458fd1-archive[1]:
-      jcr:primaryType: publicationsystem:archive
-      jcr:mixinTypes: ['mix:referenceable']
-      jcr:uuid: 5d51f177-89f6-416c-8ecc-d8b6f4b88f76
-      common:searchable: true
-      hippo:availability: []
-      hippostd:state: draft
-      hippostdpubwf:createdBy: admin
-      hippostdpubwf:creationDate: 2018-02-02T10:43:27.768Z
-      hippostdpubwf:lastModificationDate: 2018-02-02T10:43:27.768Z
-      hippostdpubwf:lastModifiedBy: admin
-      hippotranslation:id: 0316d5b2-6ffd-46ae-8a5a-44f7db145aae
-      hippotranslation:locale: en
-      publicationsystem:Summary: 244be544-a616-418d-baa2-8865b2111cfc Archive Summary
-      publicationsystem:Title: cc93262b-a670-42d7-b66a-6b64959db620 Archive Title
-    /bfc4b2be-d52c-49dd-a849-511429458fd1-archive[2]:
-      jcr:primaryType: publicationsystem:archive
-      jcr:mixinTypes: ['mix:referenceable', 'mix:versionable']
-      jcr:uuid: 7ddd6a3c-5cf8-4f39-9672-fbdcf49d0c1e
-      common:searchable: true
-      hippo:availability: [preview]
-      hippostd:state: unpublished
-      hippostdpubwf:createdBy: admin
-      hippostdpubwf:creationDate: 2018-02-02T10:43:27.768Z
-      hippostdpubwf:lastModificationDate: 2018-02-02T10:43:28.563Z
-      hippostdpubwf:lastModifiedBy: admin
-      hippotranslation:id: 0316d5b2-6ffd-46ae-8a5a-44f7db145aae
-      hippotranslation:locale: en
-      publicationsystem:Summary: 244be544-a616-418d-baa2-8865b2111cfc Archive Summary
-      publicationsystem:Title: cc93262b-a670-42d7-b66a-6b64959db620 Archive Title
+  jcr:mixinTypes:
+  - hippo:named
+  - hippotranslation:translated
+  - mix:versionable
+  jcr:primaryType: hippostd:folder

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/facets.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/facets.ftl
@@ -1,15 +1,15 @@
 <#ftl output_format="HTML">
 <#include "../include/imports.ftl">
 <!--Need to have a single setBundle call as subsequent ones will overwrite the previous values-->
-<@hst.setBundle basename="document-types,month-names"/>
+<@hst.setBundle basename="document-types,month-names,publicationsystem.labels"/>
 
 <div class="layout layout--flush">
     <div class="layout__item layout-1-2">
         <h3>Filter by:</h3>
     </div><!--
     --><div class="layout__item layout-1-2" style="text-align:right">
-        <@hst.link siteMapItemRefId="search" mount="common-context" var="searchLink"/>
-        <a href="${searchLink}?query=${query}" title="Clear all">Clear all</a>
+        <@hst.link siteMapItemRefId="search" var="searchLink" navigationStateful=true/>
+        <a href="${searchLink}" title="Clear all">Clear all</a>
     </div>
 </div>
 <#if facets??>
@@ -23,10 +23,10 @@
                             <@fmt.message key=value.name var="monthName"/>
                             <#assign valueName=monthName/>
                         <#elseif facet.name="CATEGORY">
-                            <#assign valueName=taxonomy.getCategoryByKey(value.name).getInfo("en").name/>
+                            <#assign valueName=taxonomy.getValueName(value.name)/>
                         <#elseif facet.name="DOCUMENT TYPE">
-                            <@fmt.message key=value.name var="documentType"/>
-                            <#assign valueName=documentType/>
+                            <@fmt.message key=value.name var="documentTypeKey"/>
+                            <@fmt.message key=documentTypeKey var="valueName"/>
                         <#else>
                             <#assign valueName=value.name/>
                         </#if>

--- a/site/src/main/java/uk/nhs/digital/common/components/FacetComponent.java
+++ b/site/src/main/java/uk/nhs/digital/common/components/FacetComponent.java
@@ -3,20 +3,45 @@ package uk.nhs.digital.common.components;
 import org.hippoecm.hst.core.component.HstRequest;
 import org.hippoecm.hst.core.component.HstResponse;
 import org.hippoecm.hst.site.HstServices;
+import org.onehippo.taxonomy.api.Category;
 import org.onehippo.taxonomy.api.Taxonomy;
 import org.onehippo.taxonomy.api.TaxonomyManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.nhs.digital.ps.beans.HippoBeanHelper;
 
+import java.util.Locale;
+
 public class FacetComponent extends SearchComponent {
+    private static Logger log = LoggerFactory.getLogger(FacetComponent.class);
 
     @Override
     public void doBeforeRender(HstRequest request, HstResponse response) {
         TaxonomyManager taxonomyManager = HstServices.getComponentManager().getComponent(TaxonomyManager.class.getName());
         Taxonomy taxonomy = taxonomyManager.getTaxonomies().getTaxonomy(HippoBeanHelper.getTaxonomyName());
+        TaxonomyWrapper taxonomyWrapper = new TaxonomyWrapper(taxonomy);
 
-        request.setAttribute("taxonomy", taxonomy);
+        request.setAttribute("taxonomy", taxonomyWrapper);
         request.setAttribute("query", getQueryParameter(request));
         request.setAttribute("facets", getFacetNavigationBean(request));
         request.setAttribute("cparam", getComponentInfo(request)) ;
+    }
+
+    public class TaxonomyWrapper {
+        private final Taxonomy taxonomy;
+
+        private TaxonomyWrapper(Taxonomy taxonomy) {
+            this.taxonomy = taxonomy;
+        }
+
+        public String getValueName(String key) {
+            Category taxonomyCategory = taxonomy.getCategoryByKey(key);
+            if (taxonomyCategory == null) {
+                log.error("No taxonomy for key: " + key);
+                return "Invalid Taxonomy: " + key;
+            } else {
+                return taxonomyCategory.getInfo(Locale.UK).getName();
+            }
+        }
     }
 }


### PR DESCRIPTION
Made them use the configurable doc type labels.
Also fixed a bug where taxonomy terms would repeat if the
taxonomy key was invalid.