### PR TITLE
[RPS-381] Create Splunk HEC for each environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ HOME ?= $(shell printenv HOME)
 MAVEN_OPTS ?= "-XX:+TieredCompilation -XX:TieredStopAtLevel=1"
 PWD = $(shell pwd)
 SPLUNK_TOKEN ?=
+SPLUNK_URL ?=
+SPLUNK_HEC ?= localhost
 
 export HIPPO_MAVEN_PASSWORD
 export HIPPO_MAVEN_USERNAME
@@ -39,7 +41,10 @@ serve.noexport: essentials/target/essentials.war
 
 ## Start server using cargo.run
 run:
-	mvn -P cargo.run -Dsplunk.token=$(SPLUNK_TOKEN)
+	mvn -P cargo.run \
+		-Dsplunk.token=$(SPLUNK_TOKEN) \
+		-Dsplunk.url=$(SPLUNK_URL) \
+		-Dsplunk.hec.name=$(SPLUNK_HEC)
 
 # we don't have to recompile it every time.
 essentials/target/essentials.war:

--- a/cms/pom.xml
+++ b/cms/pom.xml
@@ -81,6 +81,10 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.splunk.logging</groupId>
+            <artifactId>splunk-library-javalogging</artifactId>
+        </dependency>
 
         <!-- TEST DEPENDENCIES -->
 

--- a/conf/log4j2-dev.xml
+++ b/conf/log4j2-dev.xml
@@ -53,7 +53,7 @@
             token="${sys:splunk.token}"
             batch_size_count="${sys:splunk.batch.size.count}"
             disableCertificateValidation="true"
-            source="nhsdhippocms"
+            source="${sys:splunk.hec.name}"
             sourcetype="hippo-cms">
             <LookupFilter key="jndi:logging/contextName" value="cms" onMatch="ACCEPT"/>
             <PatternLayout pattern="%m"/>
@@ -65,7 +65,7 @@
             token="${sys:splunk.token}"
             batch_size_count="${sys:splunk.batch.size.count}"
             disableCertificateValidation="true"
-            source="nhsdhippocms"
+            source="${sys:splunk.hec.name}"
             sourcetype="hippo-site">
             <LookupFilter key="jndi:logging/contextName" value="site" onMatch="ACCEPT"/>
             <PatternLayout pattern="%m"/>
@@ -77,7 +77,7 @@
             token="${sys:splunk.token}"
             batch_size_count="${sys:splunk.batch.size.count}"
             disableCertificateValidation="true"
-            source="nhsdhippocms"
+            source="${sys:splunk.hec.name}"
             sourcetype="hippo-audit">
             <PatternLayout pattern="%m"/>
         </Http>

--- a/pom.xml
+++ b/pom.xml
@@ -72,11 +72,13 @@
         default, local value. Please don't change it. -->
         <revision>dev-SNAPSHOT</revision>
 
+        <!-- Splunk HTTP Event Collector (HEC) name -->
+        <splunk.hec.name></splunk.hec.name>
         <!-- Unique token for the Splunk HTTP Event Collector (HEC)
         defined in the Splunk instance -->
         <splunk.token></splunk.token>
         <!-- Splunk HEC endpoint URL -->
-        <splunk.url>https://localhost:8088</splunk.url>
+        <splunk.url></splunk.url>
         <!-- Set to 1 for testing (once 1 event is queued, it's considered a batch).
         In production, start with a setting of "10" and adjust as necessary. -->
         <splunk.batch.size.count>1</splunk.batch.size.count>
@@ -462,6 +464,7 @@
                                     <send.usage.statistics.to.hippo>false</send.usage.statistics.to.hippo>
                                     <repo.config>file://${project.basedir}/conf/repository.xml</repo.config>
                                     <!-- Splunk forwarder config -->
+                                    <splunk.hec.name>${splunk.hec.name}</splunk.hec.name>
                                     <splunk.token>${splunk.token}</splunk.token>
                                     <splunk.url>${splunk.url}</splunk.url>
                                     <splunk.batch.size.count>${splunk.batch.size.count}</splunk.batch.size.count>


### PR DESCRIPTION
Update config to allow passing in of Splunk HTTP Event
Collector (HEC) name which feeds the Source in the
log4j Appenders configuration. The Splunk instance will
have a HEC setup for each environment, making it easy to
filter events in queries (i.e only show PROD or TEST events)