### PR TITLE
[NIL] New NIL namespace and indicator document type

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations.yaml
@@ -2,9 +2,17 @@
 definitions:
   config:
     /hst:hst/hst:configurations:
+      /base:
+        jcr:primaryType: hst:configuration
       /common:
+        hst:inheritsfrom:
+        - ../base
+        jcr:primaryType: hst:configuration
+      /nationalindicatorlibrary:
+        hst:inheritsfrom:
+        - ../base
         jcr:primaryType: hst:configuration
       /publicationsystem:
         hst:inheritsfrom:
-        - ../common
+        - ../base
         jcr:primaryType: hst:configuration

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/base/abstractpages.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/base/abstractpages.yaml
@@ -1,0 +1,5 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/base/hst:abstractpages:
+      jcr:primaryType: hst:pages

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/base/abstractpages/basepage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/base/abstractpages/basepage.yaml
@@ -1,0 +1,13 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/base/hst:abstractpages/basepage:
+      /footer:
+        hst:template: footer
+        jcr:primaryType: hst:component
+      /top:
+        hst:componentclassname: uk.nhs.digital.common.components.SearchBarComponent
+        hst:template: searchbar
+        jcr:primaryType: hst:component
+      hst:template: base
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/base/pages.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/base/pages.yaml
@@ -1,0 +1,5 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/base/hst:pages:
+      jcr:primaryType: hst:pages

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/base/pages/404.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/base/pages/404.yaml
@@ -1,0 +1,10 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/base/hst:pages/404:
+      /main:
+        hst:componentclassname: uk.nhs.digital.common.components.PageNotFoundComponent
+        hst:template: '404'
+        jcr:primaryType: hst:component
+      hst:referencecomponent: hst:abstractpages/basepage
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/base/templates.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/base/templates.yaml
@@ -1,0 +1,17 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/base/hst:templates:
+      /404:
+        hst:renderpath: webfile:/freemarker/common/404.ftl
+        jcr:primaryType: hst:template
+      /base:
+        hst:renderpath: webfile:/freemarker/common/base-layout.ftl
+        jcr:primaryType: hst:template
+      /footer:
+        hst:renderpath: webfile:/freemarker/common/base-footer.ftl
+        jcr:primaryType: hst:template
+      /searchbar:
+        hst:renderpath: webfile:/freemarker/common/searchbar.ftl
+        jcr:primaryType: hst:template
+      jcr:primaryType: hst:templates

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates.yaml
@@ -11,20 +11,11 @@ definitions:
       /article:
         hst:renderpath: webfile:/freemarker/common/article-layout.ftl
         jcr:primaryType: hst:template
-      /base:
-        hst:renderpath: webfile:/freemarker/common/base-layout.ftl
-        jcr:primaryType: hst:template
       /cihub:
         hst:renderpath: webfile:/freemarker/publicationsystem/cihub.ftl
         jcr:primaryType: hst:template
       /facets:
         hst:renderpath: webfile:/freemarker/common/facets.ftl
-        jcr:primaryType: hst:template
-      /footer:
-        hst:renderpath: webfile:/freemarker/common/base-footer.ftl
-        jcr:primaryType: hst:template
-      /searchbar:
-        hst:renderpath: webfile:/freemarker/common/searchbar.ftl
         jcr:primaryType: hst:template
       /searchresults:
         hst:renderpath: webfile:/freemarker/common/searchresults.ftl

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/abstractpages.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/abstractpages.yaml
@@ -1,0 +1,5 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/nationalindicatorlibrary/hst:abstractpages:
+      jcr:primaryType: hst:pages

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/catalog.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/catalog.yaml
@@ -1,0 +1,7 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/nationalindicatorlibrary/hst:catalog:
+      /nationalindicatorlibrary-catalog:
+        jcr:primaryType: hst:containeritempackage
+      jcr:primaryType: hst:catalog

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/components.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/components.yaml
@@ -1,0 +1,5 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/nationalindicatorlibrary/hst:components:
+      jcr:primaryType: hst:components

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/components/indicator.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/components/indicator.yaml
@@ -1,0 +1,6 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/nationalindicatorlibrary/hst:components/indicator:
+      hst:componentclassname: uk.nhs.digital.nil.components.IndicatorComponent
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/pages.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/pages.yaml
@@ -1,0 +1,5 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/nationalindicatorlibrary/hst:pages:
+      jcr:primaryType: hst:pages

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/pages/indicator.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/pages/indicator.yaml
@@ -1,0 +1,10 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/nationalindicatorlibrary/hst:pages/indicator:
+      /main:
+        hst:componentclassname: uk.nhs.digital.nil.components.IndicatorComponent
+        hst:template: indicator
+        jcr:primaryType: hst:component
+      hst:referencecomponent: hst:abstractpages/basepage
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/prototypepages.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/prototypepages.yaml
@@ -1,0 +1,5 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/nationalindicatorlibrary/hst:prototypepages:
+      jcr:primaryType: hst:pages

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/sitemap.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/sitemap.yaml
@@ -1,0 +1,18 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/nationalindicatorlibrary/hst:sitemap:
+      /_any_:
+        hst:componentconfigurationid: hst:pages/404
+        hst:componentconfigurationmappingnames:
+        - nationalindicatorlibrary:indicator
+        - hippostd:folder
+        hst:componentconfigurationmappingvalues:
+        - hst:pages/indicator
+        - hst:pages/folder
+        hst:relativecontentpath: ${1}
+        jcr:primaryType: hst:sitemapitem
+      /root:
+        hst:componentconfigurationid: hst:pages/home
+        jcr:primaryType: hst:sitemapitem
+      jcr:primaryType: hst:sitemap

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/sitemenus.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/sitemenus.yaml
@@ -1,0 +1,5 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/nationalindicatorlibrary/hst:sitemenus:
+      jcr:primaryType: hst:sitemenus

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/templates.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/templates.yaml
@@ -1,0 +1,8 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/nationalindicatorlibrary/hst:templates:
+      /indicator:
+        hst:renderpath: webfile:/freemarker/nationalindicatorlibrary/indicator.ftl
+        jcr:primaryType: hst:template
+      jcr:primaryType: hst:templates

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/workspace.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/workspace.yaml
@@ -1,0 +1,5 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/nationalindicatorlibrary/hst:workspace:
+      jcr:primaryType: hst:workspace

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/workspace/containers.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/workspace/containers.yaml
@@ -1,0 +1,5 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/nationalindicatorlibrary/hst:workspace/hst:containers:
+      jcr:primaryType: hst:containercomponentfolder

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/workspace/pages.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/workspace/pages.yaml
@@ -1,0 +1,6 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/nationalindicatorlibrary/hst:workspace/hst:pages:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:pages

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/workspace/sitemap.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/workspace/sitemap.yaml
@@ -1,0 +1,6 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/nationalindicatorlibrary/hst:workspace/hst:sitemap:
+      .meta:residual-child-node-category: content
+      jcr:primaryType: hst:sitemap

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/workspace/sitemenus.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/nationalindicatorlibrary/workspace/sitemenus.yaml
@@ -1,0 +1,5 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/nationalindicatorlibrary/hst:workspace/hst:sitemenus:
+      jcr:primaryType: hst:sitemenus

--- a/repository-data/application/src/main/resources/hcm-config/hst/hosts.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/hosts.yaml
@@ -11,6 +11,10 @@ definitions:
                 /web:
                   /hippo-delivery:
                     /hst:root:
+                      /indicators:
+                        hst:homepage: root
+                        hst:mountpoint: /hst:hst/hst:sites/nationalindicatorlibrary
+                        jcr:primaryType: hst:mount
                       /publications:
                         hst:homepage: root
                         hst:mountpoint: /hst:hst/hst:sites/publicationsystem
@@ -38,6 +42,10 @@ definitions:
                 /web:
                   /hippo-authoring:
                     /hst:root:
+                      /indicators:
+                        hst:homepage: root
+                        hst:mountpoint: /hst:hst/hst:sites/nationalindicatorlibrary
+                        jcr:primaryType: hst:mount
                       /publications:
                         hst:homepage: root
                         hst:mountpoint: /hst:hst/hst:sites/publicationsystem
@@ -64,6 +72,10 @@ definitions:
             /digital:
               /beta:
                 /hst:root:
+                  /indicators:
+                    hst:homepage: root
+                    hst:mountpoint: /hst:hst/hst:sites/nationalindicatorlibrary
+                    jcr:primaryType: hst:mount
                   /publications:
                     hst:homepage: root
                     hst:mountpoint: /hst:hst/hst:sites/publicationsystem
@@ -86,6 +98,10 @@ definitions:
             /digital:
               /cms:
                 /hst:root:
+                  /indicators:
+                    hst:homepage: root
+                    hst:mountpoint: /hst:hst/hst:sites/nationalindicatorlibrary
+                    jcr:primaryType: hst:mount
                   /publications:
                     hst:homepage: root
                     hst:mountpoint: /hst:hst/hst:sites/publicationsystem
@@ -107,6 +123,10 @@ definitions:
           /nhsd:
             /tst:
               /hst:root:
+                /indicators:
+                  hst:homepage: root
+                  hst:mountpoint: /hst:hst/hst:sites/nationalindicatorlibrary
+                  jcr:primaryType: hst:mount
                 /publications:
                   hst:homepage: root
                   hst:mountpoint: /hst:hst/hst:sites/publicationsystem
@@ -127,6 +147,10 @@ definitions:
           /nhsd:
             /cms-tst:
               /hst:root:
+                /indicators:
+                  hst:homepage: root
+                  hst:mountpoint: /hst:hst/hst:sites/nationalindicatorlibrary
+                  jcr:primaryType: hst:mount
                 /publications:
                   hst:homepage: root
                   hst:mountpoint: /hst:hst/hst:sites/publicationsystem
@@ -147,6 +171,10 @@ definitions:
           /nhsd:
             /uat:
               /hst:root:
+                /indicators:
+                  hst:homepage: root
+                  hst:mountpoint: /hst:hst/hst:sites/nationalindicatorlibrary
+                  jcr:primaryType: hst:mount
                 /publications:
                   hst:homepage: root
                   hst:mountpoint: /hst:hst/hst:sites/publicationsystem
@@ -167,6 +195,10 @@ definitions:
           /nhsd:
             /cms-uat:
               /hst:root:
+                /indicators:
+                  hst:homepage: root
+                  hst:mountpoint: /hst:hst/hst:sites/nationalindicatorlibrary
+                  jcr:primaryType: hst:mount
                 /publications:
                   hst:homepage: root
                   hst:mountpoint: /hst:hst/hst:sites/publicationsystem

--- a/repository-data/application/src/main/resources/hcm-config/hst/sites.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/sites.yaml
@@ -6,6 +6,9 @@ definitions:
       /common:
         hst:content: /content/documents/corporate-website
         jcr:primaryType: hst:site
+      /nationalindicatorlibrary:
+        hst:content: /content/documents/corporate-website/national-indicator-library
+        jcr:primaryType: hst:site
       /publicationsystem:
         hst:content: /content/documents/corporate-website/publication-system
         jcr:primaryType: hst:site

--- a/repository-data/application/src/main/resources/hcm-config/main.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/main.yaml
@@ -44,6 +44,9 @@ definitions:
     common:
       cnd: namespaces/common.cnd
       uri: http://digital.nhs.uk/jcr/common/nt/1.0
+    nationalindicatorlibrary:
+      cnd: namespaces/nationalindicatorlibrary.cnd
+      uri: http://digital.nhs.uk/jcr/nationalindicatorlibrary/nt/1.0
     publicationsystem:
       cnd: namespaces/publicationsystem.cnd
       uri: http://digital.nhs.uk/jcr/publicationsystem/nt/1.0

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary.cnd
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary.cnd
@@ -1,0 +1,13 @@
+<'nationalindicatorlibrary'='http://digital.nhs.uk/jcr/nationalindicatorlibrary/nt/1.0'>
+<'hippo'='http://www.onehippo.org/jcr/hippo/nt/2.0.4'>
+<'hippostd'='http://www.onehippo.org/jcr/hippostd/nt/2.0'>
+<'hippostdpubwf'='http://www.onehippo.org/jcr/hippostdpubwf/nt/1.0'>
+<'common'='http://digital.nhs.uk/jcr/common/nt/1.0'>
+<'hippotranslation'='http://www.onehippo.org/jcr/hippotranslation/nt/1.0'>
+
+[nationalindicatorlibrary:basedocument] > hippo:document, hippostd:publishableSummary, hippostdpubwf:document
+  orderable
+  - common:searchable (boolean) = 'true' autocreated
+
+[nationalindicatorlibrary:indicator] > hippostd:relaxed, hippotranslation:translated, nationalindicatorlibrary:basedocument
+  orderable

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary.yaml
@@ -1,0 +1,7 @@
+---
+definitions:
+  config:
+    /hippo:namespaces/nationalindicatorlibrary:
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: hipposysedit:namespace

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/basedocument.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/basedocument.yaml
@@ -1,0 +1,18 @@
+---
+definitions:
+  config:
+    /hippo:namespaces/nationalindicatorlibrary/basedocument:
+      /hipposysedit:nodetype:
+        /hipposysedit:nodetype:
+          hipposysedit:supertype:
+          - common:basedocument
+          hipposysedit:uri: http://digital.nhs.uk/jcr/nationalindicatorlibrary/nt/1.0
+          jcr:mixinTypes:
+          - hipposysedit:remodel
+          jcr:primaryType: hipposysedit:nodetype
+        jcr:mixinTypes:
+        - mix:referenceable
+        jcr:primaryType: hippo:handle
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: hipposysedit:templatetype

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/indicator.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/indicator.yaml
@@ -1,0 +1,355 @@
+---
+definitions:
+  config:
+    /hippo:namespaces/nationalindicatorlibrary/indicator:
+      /editor:templates:
+        /_default_:
+          jcr:primaryType: frontend:plugincluster
+          frontend:properties:
+          - mode
+          frontend:references:
+          - wicket.model
+          - model.compareTo
+          - engine
+          - validator.id
+          frontend:services:
+          - wicket.id
+          - validator.id
+          /root:
+            item: ${cluster.id}.field
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+          /iapCode:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: IAP Code
+            field: iapCode
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /title:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Title
+            field: title
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /publishedBy:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: 'Published by:'
+            field: publishedBy
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /publishedDate:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Published date
+            field: publishedDate
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /reportingPeriod:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: 'Reporting period:'
+            field: reportingPeriod
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /reportingLevel:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: 'Reporting Level(s):'
+            field: reportingLevel
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /basedOn:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: 'Based on data from:'
+            field: basedOn
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /contactAuthor:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: 'Contact Author:'
+            field: contactAuthor
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /rating:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Rating
+            field: rating
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /assuranceDate:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Assurance Date
+            field: assuranceDate
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /reviewDate:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Review Date
+            field: reviewDate
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /indicatorSet:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Indicator Set
+            field: indicatorSet
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /purpose:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Purpose
+            field: purpose
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /definition:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Definition
+            field: definition
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /descriptor:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Descriptor
+            field: methodology
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /interpretationGuidelines:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Interpretation Guidelines
+            field: interpretationGuidelines
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /caveats:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Caveats
+            field: caveats
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+        jcr:primaryType: editor:templateset
+      /hipposysedit:nodetype:
+        /hipposysedit:nodetype:
+          /assuranceDate:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:assuranceDate
+            hipposysedit:primary: false
+            hipposysedit:type: Date
+            jcr:primaryType: hipposysedit:field
+          /basedOn:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:basedOn
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
+          /caveats:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:caveats
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
+          /contactAuthor:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:contactAuthor
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
+          /definition:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:definition
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
+          /iapCode:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:iapCode
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
+          /indicatorSet:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:indicatorSet
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
+          /interpretationGuidelines:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:interpretationGuidelines
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
+          /methodology:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:descriptor
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
+          /publishedBy:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:publishedBy
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
+          /publishedDate:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:publishedDate
+            hipposysedit:primary: false
+            hipposysedit:type: Date
+            jcr:primaryType: hipposysedit:field
+          /purpose:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:purpose
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
+          /rating:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:rating
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
+          /reportingLevel:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:reportingLevel
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
+          /reportingPeriod:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:reportingPeriod
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
+          /reviewDate:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:reviewDate
+            hipposysedit:primary: false
+            hipposysedit:type: Date
+            jcr:primaryType: hipposysedit:field
+          /title:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:title
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            hipposysedit:validators:
+            - non-empty
+            - required
+            jcr:primaryType: hipposysedit:field
+          hipposysedit:node: true
+          hipposysedit:supertype:
+          - nationalindicatorlibrary:basedocument
+          - hippostd:relaxed
+          - hippotranslation:translated
+          hipposysedit:uri: http://digital.nhs.uk/jcr/nationalindicatorlibrary/nt/1.0
+          jcr:mixinTypes:
+          - hipposysedit:remodel
+          - mix:referenceable
+          jcr:primaryType: hipposysedit:nodetype
+        jcr:mixinTypes:
+        - mix:referenceable
+        jcr:primaryType: hippo:handle
+      /hipposysedit:prototypes:
+        /hipposysedit:prototype:
+          common:searchable: true
+          hippostd:holder: holder
+          hippostd:state: draft
+          hippostdpubwf:createdBy: ''
+          hippostdpubwf:creationDate: 2018-02-06T15:13:38.762Z
+          hippostdpubwf:lastModificationDate: 2018-02-06T15:13:38.762Z
+          hippostdpubwf:lastModifiedBy: ''
+          hippotranslation:id: document-type-locale-id
+          hippotranslation:locale: document-type-locale
+          jcr:mixinTypes:
+          - mix:referenceable
+          jcr:primaryType: nationalindicatorlibrary:indicator
+          nationalindicatorlibrary:assuranceDate: 0001-01-01T12:00:00Z
+          nationalindicatorlibrary:basedOn: ''
+          nationalindicatorlibrary:caveats: ''
+          nationalindicatorlibrary:contactAuthor: ''
+          nationalindicatorlibrary:definition: ''
+          nationalindicatorlibrary:descriptor: ''
+          nationalindicatorlibrary:iapCode: ''
+          nationalindicatorlibrary:indicatorSet: ''
+          nationalindicatorlibrary:interpretationGuidelines: ''
+          nationalindicatorlibrary:publishedBy: ''
+          nationalindicatorlibrary:publishedDate: 0001-01-01T12:00:00Z
+          nationalindicatorlibrary:purpose: ''
+          nationalindicatorlibrary:rating: ''
+          nationalindicatorlibrary:reportingLevel: ''
+          nationalindicatorlibrary:reportingPeriod: ''
+          nationalindicatorlibrary:reviewDate: 0001-01-01T12:00:00Z
+          nationalindicatorlibrary:title: ''
+        jcr:primaryType: hipposysedit:prototypeset
+      jcr:mixinTypes:
+      - editor:editable
+      - mix:referenceable
+      jcr:primaryType: hipposysedit:templatetype

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/national-indicator-library.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/national-indicator-library.yaml
@@ -1,0 +1,206 @@
+---
+/content/documents/administration/national-indicator-library:
+  /headers:
+    /headers[1]:
+      hippo:availability: []
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-02-08T11:24:07.560Z
+      hippostdpubwf:lastModificationDate: 2018-02-12T16:11:24.823Z
+      hippostdpubwf:lastModifiedBy: admin
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: resourcebundle:resourcebundle
+      resourcebundle:descriptions:
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      resourcebundle:id: nationalindicatorlibrary.headers
+      resourcebundle:keys:
+      - headers.assuranceDate
+      - headers.basedOn
+      - headers.caveats
+      - headers.contactAuthor
+      - headers.definition
+      - headers.iapCode
+      - headers.indicatorSet
+      - headers.interpretationGuidelines
+      - headers.methodology
+      - headers.publishedBy
+      - headers.publishedDate
+      - headers.purpose
+      - headers.rating
+      - headers.reportingLevel
+      - headers.reportingPeriod
+      - headers.reviewDate
+      resourcebundle:messages:
+      - 'Assurance Date:'
+      - 'Based on data from:'
+      - 'Caveats:'
+      - 'Contact Author:'
+      - Definition
+      - 'IAP Code:'
+      - 'Indicator Set:'
+      - 'Interpretation Guidelines:'
+      - 'Methodology: how the indicator is calculated'
+      - 'Published by:'
+      - 'Published date:'
+      - Purpose
+      - 'Rating:'
+      - 'Reporting level:'
+      - 'Reporting period:'
+      - 'Review date:'
+    /headers[2]:
+      hippo:availability:
+      - preview
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-02-08T11:24:07.560Z
+      hippostdpubwf:lastModificationDate: 2018-02-12T16:16:17.438Z
+      hippostdpubwf:lastModifiedBy: admin
+      jcr:mixinTypes:
+      - mix:referenceable
+      - mix:versionable
+      jcr:primaryType: resourcebundle:resourcebundle
+      resourcebundle:descriptions:
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      resourcebundle:id: nationalindicatorlibrary.headers
+      resourcebundle:keys:
+      - headers.assuranceDate
+      - headers.basedOn
+      - headers.caveats
+      - headers.contactAuthor
+      - headers.definition
+      - headers.iapCode
+      - headers.indicatorSet
+      - headers.interpretationGuidelines
+      - headers.methodology
+      - headers.publishedBy
+      - headers.publishedDate
+      - headers.purpose
+      - headers.rating
+      - headers.reportingLevel
+      - headers.reportingPeriod
+      - headers.reviewDate
+      resourcebundle:messages:
+      - 'Assurance Date:'
+      - 'Based on data from:'
+      - 'Caveats:'
+      - 'Contact Author:'
+      - Definition
+      - 'IAP Code:'
+      - 'Indicator Set:'
+      - 'Interpretation Guidelines:'
+      - 'Methodology: how the indicator is calculated'
+      - 'Published by:'
+      - 'Published date:'
+      - Purpose
+      - 'Rating:'
+      - 'Reporting level:'
+      - 'Reporting period:'
+      - 'Review date:'
+    /headers[3]:
+      hippo:availability:
+      - live
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-02-08T11:24:07.560Z
+      hippostdpubwf:lastModificationDate: 2018-02-12T16:16:17.438Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2018-02-12T16:16:20.388Z
+      jcr:mixinTypes:
+      - mix:referenceable
+      jcr:primaryType: resourcebundle:resourcebundle
+      resourcebundle:descriptions:
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      - ''
+      resourcebundle:id: nationalindicatorlibrary.headers
+      resourcebundle:keys:
+      - headers.assuranceDate
+      - headers.basedOn
+      - headers.caveats
+      - headers.contactAuthor
+      - headers.definition
+      - headers.iapCode
+      - headers.indicatorSet
+      - headers.interpretationGuidelines
+      - headers.methodology
+      - headers.publishedBy
+      - headers.publishedDate
+      - headers.purpose
+      - headers.rating
+      - headers.reportingLevel
+      - headers.reportingPeriod
+      - headers.reviewDate
+      resourcebundle:messages:
+      - 'Assurance Date:'
+      - 'Based on data from:'
+      - 'Caveats:'
+      - 'Contact Author:'
+      - Definition
+      - 'IAP Code:'
+      - 'Indicator Set:'
+      - 'Interpretation Guidelines:'
+      - 'Methodology: how the indicator is calculated'
+      - 'Published by:'
+      - 'Published date:'
+      - Purpose
+      - 'Rating:'
+      - 'Reporting level:'
+      - 'Reporting period:'
+      - 'Review date:'
+    hippo:name: Headers
+    jcr:mixinTypes:
+    - hippo:named
+    - mix:referenceable
+    jcr:primaryType: hippo:handle
+  hippo:name: National Indicator Library
+  hippostd:foldertype:
+  - new-document
+  - new-folder
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:versionable
+  jcr:primaryType: hippostd:folder

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/publication-system.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/publication-system.yaml
@@ -1,5 +1,6 @@
 ---
 /content/documents/administration/publication-system:
+  .meta:order-before: national-indicator-library
   hippo:name: Publication System
   hippostd:foldertype:
   - new-document

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/website.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/website.yaml
@@ -1,5 +1,6 @@
 ---
 /content/documents/administration/website:
+  .meta:order-before: national-indicator-library
   /section-type:
     /section-type:
       hippo:availability:

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library.yaml
@@ -1,14 +1,13 @@
 ---
-/content/documents/corporate-website:
-  hippo:name: Corporate Website
+/content/documents/corporate-website/national-indicator-library:
+  hippo:name: National Indicator Library
   hippostd:foldertype:
   - new-translated-folder
   - new-document
-  hippotranslation:id: 00000000-0000-0000-0000-000000000000
+  hippotranslation:id: a79f6853-1e85-4eb3-8a65-5c6c2aba1a61
   hippotranslation:locale: en
   jcr:mixinTypes:
   - hippo:named
   - hippotranslation:translated
   - mix:versionable
   jcr:primaryType: hippostd:folder
-  jcr:uuid: 12345678-1234-1234-1234-123456789abc

--- a/repository-data/development/src/main/resources/hcm-config/hst/hosts.yaml
+++ b/repository-data/development/src/main/resources/hcm-config/hst/hosts.yaml
@@ -9,6 +9,11 @@ definitions:
           .meta:residual-child-node-category: content
           /hst:root:
             .meta:residual-child-node-category: content
+            /indicators:
+              .meta:residual-child-node-category: content
+              hst:homepage: root
+              hst:mountpoint: /hst:hst/hst:sites/nationalindicatorlibrary
+              jcr:primaryType: hst:mount
             /publications:
               .meta:residual-child-node-category: content
               hst:homepage: root
@@ -32,6 +37,11 @@ definitions:
             .meta:residual-child-node-category: content
             /hst:root:
               .meta:residual-child-node-category: content
+              /indicators:
+                .meta:residual-child-node-category: content
+                hst:homepage: root
+                hst:mountpoint: /hst:hst/hst:sites/nationalindicatorlibrary
+                jcr:primaryType: hst:mount
               /publications:
                 .meta:residual-child-node-category: content
                 hst:homepage: root

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/sample-indicator.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/sample-indicator.yaml
@@ -1,0 +1,245 @@
+---
+/content/documents/corporate-website/national-indicator-library/sample-indicator:
+  /sample-indicator[1]:
+    common:searchable: true
+    hippo:availability: []
+    hippostd:state: draft
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-02-08T16:11:52.307Z
+    hippostdpubwf:lastModificationDate: 2018-02-08T16:21:00.045Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: 4323bc7c-735f-41b5-91da-cc37cc8c18cd
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: nationalindicatorlibrary:indicator
+    nationalindicatorlibrary:assuranceDate: 2015-12-14T00:00:00Z
+    nationalindicatorlibrary:basedOn: Royal College of Physicians’ Sentinel Stroke
+      National Audit Programme (SSNAP)
+    nationalindicatorlibrary:caveats: "The patterns of providing care may vary between\
+      \ organisations in terms of hospital inpatient admission practices and policies.\r\
+      \n\r\nThere may be variation in the prevalence of stroke due to differing levels\
+      \ of deprivation, for other geo-demographic reasons or between patients of different\
+      \ ethnic heritages."
+    nationalindicatorlibrary:contactAuthor: ''
+    nationalindicatorlibrary:definition: "The percentage of people with stroke admitted\
+      \ to an acute stroke unit within 4 hours of arrival to hospital.\r\n\r\n(ITU\
+      \ = Intensive Treatment Unit, CCU = Critical Care Unit, HDU = High Dependency\
+      \ Unit)\r\n\r\nTechnical description: Of all patients admitted to hospital with\
+      \ a primary diagnosis of stroke (except for those whose first ward of admission\
+      \ was ITU, CCU or HDU), the percentage whose first ward of admission is a stroke\
+      \ unit AND who arrive on the stroke unit within 4 hours of arrival at hospital\
+      \ (except for those patients who were already in hospital at the time of new\
+      \ stroke occurrence, who should instead be admitted to a stroke unit within\
+      \ 4 hours of onset of stroke symptoms).\r\n\r\nStroke is defined within this\
+      \ indicator as intracerebral haemorrhage (ICD-10 code: I61), cerebral infarction\
+      \ (I63) and stroke, not specified as haemorrhage or infarction (I64).\r\n\r\n\
+      The indicator is published annually in December for each CCG in England. It\
+      \ was published for the first time in December 2014 (2013/14 data)."
+    nationalindicatorlibrary:descriptor: "Numerator\r\nOf the denominator, the number\
+      \ of patients whose first ward of admission is a stroke unit AND who are admitted\
+      \ to the stroke unit within 4 hours of arrival at hospital, except for those\
+      \ patients who were already in hospital at the time of new stroke occurrence,\
+      \ who are admitted to a stroke unit within 4 hours of onset of stroke symptoms.\r\
+      \n\r\nDenominator\r\n(ITU = Intensive Treatment Unit, CCU = Critical Care Unit,\
+      \ HDU = High Dependency Unit)\r\n\r\nAll patients admitted to hospital with\
+      \ a primary diagnosis of stroke, except for those whose first ward of admission\
+      \ was ITU, CCU or HDU."
+    nationalindicatorlibrary:iapCode: IAP00094
+    nationalindicatorlibrary:indicatorSet: CCG OIS
+    nationalindicatorlibrary:interpretationGuidelines: "A high percentage of patients\
+      \ with stroke admitted to an acute stroke unit within 4 hours of arrival to\
+      \ hospital is desirable.\r\n\r\nThis indicator acknowledges that for a small\
+      \ percentage of patients direct admission to a stroke unit is not appropriate.\
+      \ It differentiates between those who go to an acceptable other location (i.e.\
+      \ people transferred to intensive care are excluded from the indicator) compared\
+      \ to a ‘non acceptable’ location (e.g. generic admissions unit).\r\n\r\nThis\
+      \ indicator requires careful interpretation and should not be viewed in isolation,\
+      \ but instead be considered alongside information from other indicators and\
+      \ alternative sources, such as CCG OIS 3.9 (People who have had an acute stroke\
+      \ who spend 90% or more of their stay on a stroke unit) and the CCG level SSNAP\
+      \ stroke unit key indicators. When evaluated together, these will help to provide\
+      \ a holistic view of CCG outcomes and provide a more complete overview of the\
+      \ impact of the CCGs’ processes on outcomes."
+    nationalindicatorlibrary:publishedBy: ''
+    nationalindicatorlibrary:publishedDate: 2018-02-09T00:00:00Z
+    nationalindicatorlibrary:purpose: Patients who have had a stroke should be admitted
+      directly to a specialist acute stroke unit. Getting patients to a stroke unit
+      quickly is a strong indicator of eventual outcomes and is also closely linked
+      to improved quality of care across other stroke care markers. The indicator
+      is therefore an important measure of the effectiveness of recognition and assessment
+      of the symptoms of stroke, and the process to transfer people to a stroke unit
+      in a timely manner. Patients who have a stroke in hospital are included in the
+      indicator to take into account the process of recognising the stroke has occurred
+      and the systems in place for in-hospital pathways.
+    nationalindicatorlibrary:rating: Fit for use with caveats
+    nationalindicatorlibrary:reportingLevel: CCG
+    nationalindicatorlibrary:reportingPeriod: Annually
+    nationalindicatorlibrary:reviewDate: 2018-12-14T00:00:00Z
+    nationalindicatorlibrary:title: People with stroke admitted to an acute stroke
+      unit within 4 hours of arrival at hospital
+  /sample-indicator[2]:
+    common:searchable: true
+    hippo:availability:
+    - preview
+    hippostd:state: unpublished
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-02-08T16:11:52.307Z
+    hippostdpubwf:lastModificationDate: 2018-02-09T10:06:10.974Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: 4323bc7c-735f-41b5-91da-cc37cc8c18cd
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: nationalindicatorlibrary:indicator
+    nationalindicatorlibrary:assuranceDate: 2015-12-14T00:00:00Z
+    nationalindicatorlibrary:basedOn: Royal College of Physicians’ Sentinel Stroke
+      National Audit Programme (SSNAP)
+    nationalindicatorlibrary:caveats: "The patterns of providing care may vary between\
+      \ organisations in terms of hospital inpatient admission practices and policies.\r\
+      \n\r\nThere may be variation in the prevalence of stroke due to differing levels\
+      \ of deprivation, for other geo-demographic reasons or between patients of different\
+      \ ethnic heritages."
+    nationalindicatorlibrary:contactAuthor: ''
+    nationalindicatorlibrary:definition: "The percentage of people with stroke admitted\
+      \ to an acute stroke unit within 4 hours of arrival to hospital.\r\n\r\n(ITU\
+      \ = Intensive Treatment Unit, CCU = Critical Care Unit, HDU = High Dependency\
+      \ Unit)\r\n\r\nTechnical description: Of all patients admitted to hospital with\
+      \ a primary diagnosis of stroke (except for those whose first ward of admission\
+      \ was ITU, CCU or HDU), the percentage whose first ward of admission is a stroke\
+      \ unit AND who arrive on the stroke unit within 4 hours of arrival at hospital\
+      \ (except for those patients who were already in hospital at the time of new\
+      \ stroke occurrence, who should instead be admitted to a stroke unit within\
+      \ 4 hours of onset of stroke symptoms).\r\n\r\nStroke is defined within this\
+      \ indicator as intracerebral haemorrhage (ICD-10 code: I61), cerebral infarction\
+      \ (I63) and stroke, not specified as haemorrhage or infarction (I64).\r\n\r\n\
+      The indicator is published annually in December for each CCG in England. It\
+      \ was published for the first time in December 2014 (2013/14 data)."
+    nationalindicatorlibrary:descriptor: "Numerator\r\nOf the denominator, the number\
+      \ of patients whose first ward of admission is a stroke unit AND who are admitted\
+      \ to the stroke unit within 4 hours of arrival at hospital, except for those\
+      \ patients who were already in hospital at the time of new stroke occurrence,\
+      \ who are admitted to a stroke unit within 4 hours of onset of stroke symptoms.\r\
+      \n\r\nDenominator\r\n(ITU = Intensive Treatment Unit, CCU = Critical Care Unit,\
+      \ HDU = High Dependency Unit)\r\n\r\nAll patients admitted to hospital with\
+      \ a primary diagnosis of stroke, except for those whose first ward of admission\
+      \ was ITU, CCU or HDU."
+    nationalindicatorlibrary:iapCode: IAP00094
+    nationalindicatorlibrary:indicatorSet: CCG OIS
+    nationalindicatorlibrary:interpretationGuidelines: "A high percentage of patients\
+      \ with stroke admitted to an acute stroke unit within 4 hours of arrival to\
+      \ hospital is desirable.\r\n\r\nThis indicator acknowledges that for a small\
+      \ percentage of patients direct admission to a stroke unit is not appropriate.\
+      \ It differentiates between those who go to an acceptable other location (i.e.\
+      \ people transferred to intensive care are excluded from the indicator) compared\
+      \ to a ‘non acceptable’ location (e.g. generic admissions unit).\r\n\r\nThis\
+      \ indicator requires careful interpretation and should not be viewed in isolation,\
+      \ but instead be considered alongside information from other indicators and\
+      \ alternative sources, such as CCG OIS 3.9 (People who have had an acute stroke\
+      \ who spend 90% or more of their stay on a stroke unit) and the CCG level SSNAP\
+      \ stroke unit key indicators. When evaluated together, these will help to provide\
+      \ a holistic view of CCG outcomes and provide a more complete overview of the\
+      \ impact of the CCGs’ processes on outcomes."
+    nationalindicatorlibrary:publishedBy: ''
+    nationalindicatorlibrary:publishedDate: 2018-02-09T00:00:00Z
+    nationalindicatorlibrary:purpose: Patients who have had a stroke should be admitted
+      directly to a specialist acute stroke unit. Getting patients to a stroke unit
+      quickly is a strong indicator of eventual outcomes and is also closely linked
+      to improved quality of care across other stroke care markers. The indicator
+      is therefore an important measure of the effectiveness of recognition and assessment
+      of the symptoms of stroke, and the process to transfer people to a stroke unit
+      in a timely manner. Patients who have a stroke in hospital are included in the
+      indicator to take into account the process of recognising the stroke has occurred
+      and the systems in place for in-hospital pathways.
+    nationalindicatorlibrary:rating: Fit for use with caveats
+    nationalindicatorlibrary:reportingLevel: CCG
+    nationalindicatorlibrary:reportingPeriod: Annually
+    nationalindicatorlibrary:reviewDate: 2018-12-14T00:00:00Z
+    nationalindicatorlibrary:title: People with stroke admitted to an acute stroke
+      unit within 4 hours of arrival at hospital
+  /sample-indicator[3]:
+    common:searchable: true
+    hippo:availability:
+    - live
+    hippostd:state: published
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-02-08T16:11:52.307Z
+    hippostdpubwf:lastModificationDate: 2018-02-09T10:06:10.974Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippostdpubwf:publicationDate: 2018-02-09T10:06:13.538Z
+    hippotranslation:id: 4323bc7c-735f-41b5-91da-cc37cc8c18cd
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: nationalindicatorlibrary:indicator
+    nationalindicatorlibrary:assuranceDate: 2015-12-14T00:00:00Z
+    nationalindicatorlibrary:basedOn: Royal College of Physicians’ Sentinel Stroke
+      National Audit Programme (SSNAP)
+    nationalindicatorlibrary:caveats: "The patterns of providing care may vary between\
+      \ organisations in terms of hospital inpatient admission practices and policies.\r\
+      \n\r\nThere may be variation in the prevalence of stroke due to differing levels\
+      \ of deprivation, for other geo-demographic reasons or between patients of different\
+      \ ethnic heritages."
+    nationalindicatorlibrary:contactAuthor: ''
+    nationalindicatorlibrary:definition: "The percentage of people with stroke admitted\
+      \ to an acute stroke unit within 4 hours of arrival to hospital.\r\n\r\n(ITU\
+      \ = Intensive Treatment Unit, CCU = Critical Care Unit, HDU = High Dependency\
+      \ Unit)\r\n\r\nTechnical description: Of all patients admitted to hospital with\
+      \ a primary diagnosis of stroke (except for those whose first ward of admission\
+      \ was ITU, CCU or HDU), the percentage whose first ward of admission is a stroke\
+      \ unit AND who arrive on the stroke unit within 4 hours of arrival at hospital\
+      \ (except for those patients who were already in hospital at the time of new\
+      \ stroke occurrence, who should instead be admitted to a stroke unit within\
+      \ 4 hours of onset of stroke symptoms).\r\n\r\nStroke is defined within this\
+      \ indicator as intracerebral haemorrhage (ICD-10 code: I61), cerebral infarction\
+      \ (I63) and stroke, not specified as haemorrhage or infarction (I64).\r\n\r\n\
+      The indicator is published annually in December for each CCG in England. It\
+      \ was published for the first time in December 2014 (2013/14 data)."
+    nationalindicatorlibrary:descriptor: "Numerator\r\nOf the denominator, the number\
+      \ of patients whose first ward of admission is a stroke unit AND who are admitted\
+      \ to the stroke unit within 4 hours of arrival at hospital, except for those\
+      \ patients who were already in hospital at the time of new stroke occurrence,\
+      \ who are admitted to a stroke unit within 4 hours of onset of stroke symptoms.\r\
+      \n\r\nDenominator\r\n(ITU = Intensive Treatment Unit, CCU = Critical Care Unit,\
+      \ HDU = High Dependency Unit)\r\n\r\nAll patients admitted to hospital with\
+      \ a primary diagnosis of stroke, except for those whose first ward of admission\
+      \ was ITU, CCU or HDU."
+    nationalindicatorlibrary:iapCode: IAP00094
+    nationalindicatorlibrary:indicatorSet: CCG OIS
+    nationalindicatorlibrary:interpretationGuidelines: "A high percentage of patients\
+      \ with stroke admitted to an acute stroke unit within 4 hours of arrival to\
+      \ hospital is desirable.\r\n\r\nThis indicator acknowledges that for a small\
+      \ percentage of patients direct admission to a stroke unit is not appropriate.\
+      \ It differentiates between those who go to an acceptable other location (i.e.\
+      \ people transferred to intensive care are excluded from the indicator) compared\
+      \ to a ‘non acceptable’ location (e.g. generic admissions unit).\r\n\r\nThis\
+      \ indicator requires careful interpretation and should not be viewed in isolation,\
+      \ but instead be considered alongside information from other indicators and\
+      \ alternative sources, such as CCG OIS 3.9 (People who have had an acute stroke\
+      \ who spend 90% or more of their stay on a stroke unit) and the CCG level SSNAP\
+      \ stroke unit key indicators. When evaluated together, these will help to provide\
+      \ a holistic view of CCG outcomes and provide a more complete overview of the\
+      \ impact of the CCGs’ processes on outcomes."
+    nationalindicatorlibrary:publishedBy: ''
+    nationalindicatorlibrary:publishedDate: 2018-02-09T00:00:00Z
+    nationalindicatorlibrary:purpose: Patients who have had a stroke should be admitted
+      directly to a specialist acute stroke unit. Getting patients to a stroke unit
+      quickly is a strong indicator of eventual outcomes and is also closely linked
+      to improved quality of care across other stroke care markers. The indicator
+      is therefore an important measure of the effectiveness of recognition and assessment
+      of the symptoms of stroke, and the process to transfer people to a stroke unit
+      in a timely manner. Patients who have a stroke in hospital are included in the
+      indicator to take into account the process of recognising the stroke has occurred
+      and the systems in place for in-hospital pathways.
+    nationalindicatorlibrary:rating: Fit for use with caveats
+    nationalindicatorlibrary:reportingLevel: CCG
+    nationalindicatorlibrary:reportingPeriod: Annually
+    nationalindicatorlibrary:reviewDate: 2018-12-14T00:00:00Z
+    nationalindicatorlibrary:title: People with stroke admitted to an acute stroke
+      unit within 4 hours of arrival at hospital
+  hippo:name: sample indicator
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/webfiles/src/main/resources/site/freemarker/include/imports.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/include/imports.ftl
@@ -1,4 +1,6 @@
 <#ftl output_format="HTML">
+<#assign dateFormat="dd/MM/yyyy"/>
+
 <#assign hst=JspTaglibs["http://www.hippoecm.org/jsp/hst/core"] >
 <#assign fmt=JspTaglibs["http://java.sun.com/jsp/jstl/fmt"] >
 

--- a/repository-data/webfiles/src/main/resources/site/freemarker/nationalindicatorlibrary/indicator.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/nationalindicatorlibrary/indicator.ftl
@@ -1,0 +1,157 @@
+<#ftl output_format="HTML">
+<#include "../include/imports.ftl">
+<#--  <#include "../common/macro/structured-text.ftl">  -->
+<#assign formatRestrictableDate="uk.nhs.digital.ps.directives.RestrictableDateFormatterDirective"?new() />
+<#assign formatCoverageDates="uk.nhs.digital.ps.directives.CoverageDatesFormatterDirective"?new() />
+
+<@hst.setBundle basename="nationalindicatorlibrary.headers"/>
+<head>
+  <title>NHS - Clinical Indicator - Indicator Page</title>
+  <meta charset="UTF-8" />
+  <meta name="title" content="NHS - National Indicator Library" />
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0" />
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body>
+  <section class="document-header push-double--bottom">
+      <div class="document-header__inner">
+        <h1 class="layout-5-6 push--bottom">${indicator.title}</h1>
+
+        <div class="document-header__divider">&nbsp;</div>
+
+        <h2>Independently assured by IGB</h2>
+
+        <div class="layout">
+            <div class="layout__item layout-1-2">
+                <p class="push-half--bottom"><strong><@fmt.message key="headers.publishedBy"/></strong> ${indicator.publishedBy}</p>
+                <p class="push-half--bottom"><strong><@fmt.message key="headers.publishedDate"/></strong> ${indicator.publishedDate.time?string[dateFormat]}</p>
+                <p class="push-half--bottom"><strong><@fmt.message key="headers.reportingPeriod"/></strong> ${indicator.reportingPeriod}</p>
+                <p class="push-half--bottom"><strong><@fmt.message key="headers.basedOn"/></strong> ${indicator.basedOn}</p>
+            </div><!--
+            --><div class="layout__item layout-1-2">
+                <p class="push-half--bottom"><strong><@fmt.message key="headers.contactAuthor"/></strong> <a href="mailto:${indicator.contactAuthor}"> ${indicator.contactAuthor}</a></p>
+                <p class="push-half--bottom"><strong><@fmt.message key="headers.reportingLevel"/></strong> ${indicator.reportingLevel}</p>
+                <p class="push-half--bottom"><strong><@fmt.message key="headers.reviewDate"/></strong> ${indicator.reviewDate.time?string[dateFormat]}</p>
+            </div>
+        </div>
+      </div>
+    </section> 
+
+    <section class="jumpto">
+        <div class="jumpto__inner">
+            <div class="jumpto__inner__nav">
+
+                <h4>Contents</h4>
+                <div class="jumpto__inner__nav__divider">&nbsp;</div>
+
+                <ul>
+                    <li><a href="#purpose"><@fmt.message key="headers.purpose"/></a></li>
+                    <li><a href="#definition"><@fmt.message key="headers.definition"/></a></li>
+                    <li><a href="#methodology"><@fmt.message key="headers.methodology"/></a></li>
+                    <li><a href="#interpretations"><@fmt.message key="headers.interpretationGuidelines"/></a></li>
+                    <li><a href="#resources">Resources</a></li>
+                </ul>
+            </div>
+        </div>
+    </section>
+
+    <section class="document-content jumpto-offset-left">
+
+        <section id="purpose" class="push-double--bottom">
+            <h2><@fmt.message key="headers.purpose"/></h2>
+            <p>${indicator.purpose}</p>
+        </section>
+
+        <section id="definition" class="push-double--bottom">
+            <h2><@fmt.message key="headers.definition"/></h2>
+            <p>${indicator.definition}</p>
+        </section>
+
+        <section id="methodology" class="push-double--bottom">
+            <h2><@fmt.message key="headers.methodology"/></h2>
+
+            <h3><@fmt.message key="headers.methodology"/></h3>
+            <p>${indicator.descriptor}</p>
+
+            <h3><@fmt.message key="headers.caveats"/></h3>
+            <p>${indicator.caveats}</p>
+
+        </section>
+
+        <section id="interpretations" class="push-double--bottom">
+            <h3><@fmt.message key="headers.interpretationGuidelines"/></h3>
+            <li>${indicator.interpretationGuidelines}</li>
+        </section>
+
+        <section id="resources" class="push-double--bottom">
+            <h3>Resources</h3>
+            <ul>
+                <li><a href="#">Sample file</a></li>
+                <li><a href="#">Sample file</a></li>
+                <li><a href="#">Sample file</a></li>
+                <li><a href="#">Sample file</a></li>
+            </ul>
+        </section>
+
+        <section id="compare" class="push-double--bottom">
+            <h2>Compare</h2>
+            <table>
+                <tr>
+                    <td>Title</td>
+                    <td>Publisher</td>
+                    <td>Published Date</td>
+                    <td>Assured Until</td>
+                </tr>
+                <tr>
+                    <td><a href="#">Cancers diagnosed via emergency routes</a></td>
+                    <td>PHE</td>
+                    <td>10 June 2017</td>
+                    <td>10 June 2020</td>
+                </tr>
+                <tr>
+                    <td><a href="#">PHE</a></td>
+                    <td>PHE</td>
+                    <td>10 June 2017</td>
+                    <td>10 June 2020</td>
+                </tr>
+                <tr>
+                    <td><a href="#">Under 75 mortality rate from cancer</a></td>
+                    <td>PHE</td>
+                    <td>10 June 2017</td>
+                    <td>10 June 2020</td>
+                </tr>
+            </table>
+        </section>
+
+        <section id="resources" class="push-double--bottom">
+            <h2>5 comments</h2>
+            <div class="panel panel--grey">
+                <p>TBC</p>
+            </div>
+        </section>
+
+    </section>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/waypoints/1.1.6/waypoints.min.js"></script>
+
+<script>
+
+$(function() {
+  var $container = $('.jumpto');
+  var $b = $('body');
+  $.waypoints.settings.scrollThrottle = 0;
+  $container.waypoint({
+    handler: function(e, d) {
+      $b.toggleClass('sticky', d === 'down');
+      e.preventDefault();
+    }
+  });
+});
+
+</script>
+
+
+
+</body>
+

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
@@ -4,7 +4,7 @@
 <#assign dateFormat="dd/MM/yyyy"/>
 <#assign formatFileSize="uk.nhs.digital.ps.directives.FileSizeFormatterDirective"?new() />
 <#assign formatRestrictableDate="uk.nhs.digital.ps.directives.RestrictableDateFormatterDirective"?new() />
-<#assign formatCoverageDates="uk.nhs.digital.ps.directives.CoverageDatesFormatterDirective"?new() >
+<#assign formatCoverageDates="uk.nhs.digital.ps.directives.CoverageDatesFormatterDirective"?new() />
 <@hst.setBundle basename="publicationsystem.labels,publicationsystem.headers"/>
 <#-- @ftlvariable name="publication" type="uk.nhs.digital.ps.beans.Publication" -->
 

--- a/site/src/main/java/uk/nhs/digital/nil/beans/Indicator.java
+++ b/site/src/main/java/uk/nhs/digital/nil/beans/Indicator.java
@@ -1,0 +1,96 @@
+package uk.nhs.digital.nil.beans;
+
+import org.hippoecm.hst.content.beans.Node;
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+import uk.nhs.digital.ps.beans.BaseDocument;
+
+import java.util.Calendar;
+
+@HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:indicator")
+@Node(jcrType = "nationalindicatorlibrary:indicator")
+public class Indicator extends BaseDocument {
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:definition")
+    public String getDefinition() {
+        return getProperty("nationalindicatorlibrary:definition");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:title")
+    public String getTitle() {
+        return getProperty("nationalindicatorlibrary:title");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:basedOn")
+    public String getBasedOn() {
+        return getProperty("nationalindicatorlibrary:basedOn");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:reportingLevel")
+    public String getReportingLevel() {
+        return getProperty("nationalindicatorlibrary:reportingLevel");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:rating")
+    public String getRating() {
+        return getProperty("nationalindicatorlibrary:rating");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:indicatorSet")
+    public String getIndicatorSet() {
+        return getProperty("nationalindicatorlibrary:indicatorSet");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:interpretationGuidelines")
+    public String getInterpretationGuidelines() {
+        return getProperty("nationalindicatorlibrary:interpretationGuidelines");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:caveats")
+    public String getCaveats() {
+        return getProperty("nationalindicatorlibrary:caveats");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:assuranceDate")
+    public Calendar getAssuranceDate() {
+        return getProperty("nationalindicatorlibrary:assuranceDate");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:contactAuthor")
+    public String getContactAuthor() {
+        return getProperty("nationalindicatorlibrary:contactAuthor");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:iapCode")
+    public String getIapCode() {
+        return getProperty("nationalindicatorlibrary:iapCode");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:publishedBy")
+    public String getPublishedBy() {
+        return getProperty("nationalindicatorlibrary:publishedBy");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:publishedDate")
+    public Calendar getPublishedDate() {
+        return getProperty("nationalindicatorlibrary:publishedDate");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:purpose")
+    public String getPurpose() {
+        return getProperty("nationalindicatorlibrary:purpose");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:reportingPeriod")
+    public String getReportingPeriod() {
+        return getProperty("nationalindicatorlibrary:reportingPeriod");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:reviewDate")
+    public Calendar getReviewDate() {
+        return getProperty("nationalindicatorlibrary:reviewDate");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:descriptor")
+    public String getDescriptor() {
+        return getProperty("nationalindicatorlibrary:descriptor");
+    }
+}

--- a/site/src/main/java/uk/nhs/digital/nil/components/IndicatorComponent.java
+++ b/site/src/main/java/uk/nhs/digital/nil/components/IndicatorComponent.java
@@ -1,0 +1,36 @@
+package uk.nhs.digital.nil.components;
+
+import org.hippoecm.hst.component.support.bean.BaseHstComponent;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
+import org.hippoecm.hst.core.component.HstComponentException;
+import org.hippoecm.hst.core.component.HstRequest;
+import org.hippoecm.hst.core.component.HstResponse;
+import org.hippoecm.hst.core.request.HstRequestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.nhs.digital.nil.beans.Indicator;
+
+public class IndicatorComponent extends BaseHstComponent {
+
+    private static final Logger log = LoggerFactory.getLogger(IndicatorComponent.class);
+
+    @Override
+    public void doBeforeRender(final HstRequest request, final HstResponse response) throws HstComponentException {
+        super.doBeforeRender(request, response);
+        final HstRequestContext ctx = request.getRequestContext();
+        Indicator indicator = getIndicator(ctx);
+
+        request.setAttribute("indicator", indicator);
+    }
+
+    private Indicator getIndicator(HstRequestContext ctx) throws HstComponentException {
+        HippoBean content = ctx.getContentBean();
+
+        if (content instanceof Indicator) {
+            return (Indicator) content;
+        }
+
+        log.warn("Cannot find Indicator document for: {}", content.getPath());
+        throw new HstComponentException("Cannot find Indicator document based on request content");
+    }
+}

--- a/styleguide/ci-lib-indicator-page.html
+++ b/styleguide/ci-lib-indicator-page.html
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="en" class="">
+<head>
+
+  <title>NHS - Clinical Indicator - Indicator Page</title>
+
+  <meta charset="UTF-8" />
+  <meta name="title" content="NHS - Replacement Publication System" />
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, maximum-scale=1.0" />
+  <link rel="stylesheet" href="css/style.css" />
+  <!-- <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'> -->
+
+</head>
+<body class="">
+
+  <header class="top-header">
+    <div class="top-header__col1">
+      <img class="top-header__logo" src="https://digital.nhs.uk/media/89/NHSDigital/variant1/NHS-Digital-logo_WEB_LEFT-100x855" alt="NHS Digital">
+    </div><!--
+    --><div class="top-header__col2">
+      <div class="top-header__nav">
+        <ul class="top-header__nav__list">
+          <li class="top-header__nav__list__item"><a href="#">Data and information</a></li>
+          <li class="top-header__nav__list__item"><a href="#">Systems and services</a></li>
+          <li class="top-header__nav__list__item"><a href="#">News and events</a></li>
+          <li class="top-header__nav__list__item"><a href="#">About NHS Digital</a></li>
+        </ul>
+      </div>
+    </div>
+  </header>
+
+
+  <div class="breadcrumb">
+      <ol class="breadcrumb">
+          <li class="breadcrumb__crumb">
+              <span class="label">You are here:</span>
+          </li>
+          <li class="breadcrumb__crumb">
+              <a href="https://digital.nhs.uk">Home</a>
+          </li>
+          <li class="separator">/</li>
+          <li class="breadcrumb__crumb">
+              <a href="#">Indicators</a>
+          </li>
+          <li class="separator">/</li>
+          <li class="breadcrumb__crumb">
+              Library
+          </li>
+      </ol>
+  </div>
+
+
+
+  <section class="document-header push-double--bottom">
+      <div class="document-header__inner">
+        <h1 class="layout-5-6 push--bottom">Record of stage of cancer at diagnosis</h1>
+
+        <div class="document-header__divider">&nbsp;</div>
+
+        <h2>Independantly assured by IGB</h2>
+
+        <div class="layout">
+            <div class="layout__item layout-1-2">
+                <p class="push-half--bottom"><strong>Published by:</strong> Public Health England (PHE)</p>
+                <p class="push-half--bottom"><strong>Published date:</strong> 24 Nov 2017</p>
+                <p class="push-half--bottom"><strong>Reporting period:</strong> Calendar year</p>
+                <p class="push-half--bottom"><strong>Based on data from:</strong> <a href="http://www.phewebsite.co.uk">phewebsite.co.uk</a></p>
+            </div><!--
+            --><div class="layout__item layout-1-2">
+                <p class="push-half--bottom"><strong>Contact author:</strong> <a href="mailto:enquiries@phe.net">enquiries@phe.net</a></p>
+                <p class="push-half--bottom"><strong>Level:</strong> CCG</p>
+                <p class="push-half--bottom"><strong>Assured until:</strong> July 2018</p>
+            </div>
+        </div>
+
+
+
+      </div>
+    </section>
+
+
+
+    <section class="jumpto">
+        <div class="jumpto__inner">
+            <div class="jumpto__inner__nav">
+
+                <h4>Contents</h4>
+                <div class="jumpto__inner__nav__divider">&nbsp;</div>
+
+                <ul>
+                    <li><a href="#purpose">Purpose</a></li>
+                    <li><a href="#definition">Definition</a></li>
+                    <li><a href="#methodology">Methodology</a></li>
+                    <li><a href="#interpretations">Interpretations</a></li>
+                    <li><a href="#resources">Resources</a></li>
+                    <li><a href="#compare">Compare indicators</a></li>
+                </ul>
+            </div>
+        </div>
+    </section>
+
+
+    <section class="document-content jumpto-offset-left">
+
+        <section id="purpose" class="push-double--bottom">
+            <h2>Purpose</h2>
+            <p>This indicator is to inform decisions made by clinical commissioning groups (CCGs), to improve their cancer survival rates. The proxy measure used for cancer survival is the overall proportion of cancers for which a stage is recorded.</p>
+        </section>
+
+        <section id="definition" class="push-double--bottom">
+            <h2>Definition</h2>
+            <p>The percentage of all cases of cancer (including non-melanoma skin cancer) for which a valid stage is recorded, given by CCG per year.</p>
+        </section>
+
+        <section id="methodology" class="push-double--bottom">
+            <h2>Methodology: how the indicator is calculated</h2>
+
+            <h3>Descriptor</h3>
+            <p>The number of new invasive cases of cancer  where ICD-10 diagnosis codes are C00-C97, not including non-melanoma skin cancer (code C44), diagnosed during the year in question.</p>
+
+            <h3>Denominator</h3>
+            <p>The number of new invasive cases of cancer  where ICD-10 diagnosis codes are C00-C97, not including non-melanoma skin cancer (code C44), diagnosed during the year in question.</p>
+
+            <h3>Numerator</h3>
+            <p>The number of cases of cancer in the denominator with a valid stage recorded at diagnosis.</p>
+
+            <h3>Coverage</h3>
+            <p>All data included have been signed off by the cancer registries and so have reached the standard required for them to be recognised as newly-diagnosed tumours.</p>
+            <p>These data feed the official national cancer statistics at the Office for National Statistics (ONS).</p>
+        </section>
+
+        <section id="interpretations" class="push-double--bottom">
+            <h3>Interpretations and risks</h3>
+            <ol>
+                <li>Data for this indicator will be extracted from the National Cancer Intelligence Network (NCIN)  cancer analysis system (CAS). The CAS contains an extract of cancer registration data for analytical purposes, once data have been signed off as complete by the cancer registries. </li>
+                <li>The assignment of a CCG to a patient will be based on GP or practice code where possible and, if not, on the patient’s home postcode.</li>
+                <li>Where the patient's practice and postcode are both unavailable, the responsible CCG is the location of the hospital or trust. As the numerator is a subset of the denominator, the same method will be used for any particular patient.</li>
+                <li>This indicator requires careful interpretation and should not be viewed in isolation, but instead be considered alongside information from other indicators and alternative sources. The NCIN's service profiles provide information on other indicators. </li>
+                <li>When evaluated together, these will help to provide a complete view of CCG outcomes and provide a fuller overview of the impact of the CCGs' processes on outcomes.</li>
+            </ol>
+        </section>
+
+        <section id="resources" class="push-double--bottom">
+            <h3>Resources</h3>
+            <ul>
+                <li><a href="#">Sample file</a></li>
+                <li><a href="#">Sample file</a></li>
+                <li><a href="#">Sample file</a></li>
+                <li><a href="#">Sample file</a></li>
+            </ul>
+        </section>
+
+        <section id="compare" class="push-double--bottom">
+            <h2>Compare</h2>
+            <table>
+                <tr>
+                    <td>Title</td>
+                    <td>Publisher</td>
+                    <td>Published Date</td>
+                    <td>Assured Until</td>
+                </tr>
+                <tr>
+                    <td><a href="#">Cancers diagnosed via emergency routes</a></td>
+                    <td>PHE</td>
+                    <td>10 June 2017</td>
+                    <td>10 June 2020</td>
+                </tr>
+                <tr>
+                    <td><a href="#">PHE</a></td>
+                    <td>PHE</td>
+                    <td>10 June 2017</td>
+                    <td>10 June 2020</td>
+                </tr>
+                <tr>
+                    <td><a href="#">Under 75 mortality rate from cancer</a></td>
+                    <td>PHE</td>
+                    <td>10 June 2017</td>
+                    <td>10 June 2020</td>
+                </tr>
+            </table>
+        </section>
+
+        <section id="resources" class="push-double--bottom">
+            <h2>5 comments</h2>
+            <div class="panel panel--grey">
+                <p>TBC</p>
+            </div>
+        </section>
+
+    </section>
+
+
+
+
+    <section class="document-content">
+
+
+    <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+    <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+    <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+    <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+    <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+    <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+    <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+    <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+    <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>
+
+
+
+
+
+  </section>
+
+
+  <footer class="footer">
+    <div class="footer__inner">
+      FOOTER
+    </div>
+  </footer>
+
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/waypoints/1.1.6/waypoints.min.js"></script>
+
+<script>
+
+$(function() {
+  var $container = $('.jumpto');
+  var $b = $('body');
+  $.waypoints.settings.scrollThrottle = 0;
+  $container.waypoint({
+    handler: function(e, d) {
+      $b.toggleClass('sticky', d === 'down');
+      e.preventDefault();
+    }
+  });
+});
+
+</script>
+
+
+
+</body>
+</html>


### PR DESCRIPTION
New nationalindicatorlibrary namespace created for use by NIL team. Created new document type with required fields to facilitate migration. Render pipeline complete between new document in CMS and rendering on local site.