### PR TITLE
[NIL] Split 'descriptor' field into four new fields

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/indicator.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/indicator.yaml
@@ -135,11 +135,38 @@ definitions:
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
-          /descriptor:
+          /dataSource:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-            caption: Descriptor
-            field: methodology
+            caption: Data source
+            field: dataSource
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /numerator:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Numerator
+            field: numerator
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /denominator:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Denominator
+            field: denominator
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /calculation:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Calculation
+            field: calculation
             hint: ''
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
@@ -181,6 +208,14 @@ definitions:
             hipposysedit:primary: false
             hipposysedit:type: Text
             jcr:primaryType: hipposysedit:field
+          /calculation:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:calculation
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
           /caveats:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
@@ -197,11 +232,27 @@ definitions:
             hipposysedit:primary: false
             hipposysedit:type: Text
             jcr:primaryType: hipposysedit:field
+          /dataSource:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:dataSource
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
           /definition:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
             hipposysedit:ordered: false
             hipposysedit:path: nationalindicatorlibrary:definition
+            hipposysedit:primary: false
+            hipposysedit:type: Text
+            jcr:primaryType: hipposysedit:field
+          /denominator:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:denominator
             hipposysedit:primary: false
             hipposysedit:type: Text
             jcr:primaryType: hipposysedit:field
@@ -229,11 +280,11 @@ definitions:
             hipposysedit:primary: false
             hipposysedit:type: Text
             jcr:primaryType: hipposysedit:field
-          /methodology:
+          /numerator:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
             hipposysedit:ordered: false
-            hipposysedit:path: nationalindicatorlibrary:descriptor
+            hipposysedit:path: nationalindicatorlibrary:numerator
             hipposysedit:primary: false
             hipposysedit:type: Text
             jcr:primaryType: hipposysedit:field
@@ -333,13 +384,16 @@ definitions:
           jcr:primaryType: nationalindicatorlibrary:indicator
           nationalindicatorlibrary:assuranceDate: 0001-01-01T12:00:00Z
           nationalindicatorlibrary:basedOn: ''
+          nationalindicatorlibrary:calculation: ''
           nationalindicatorlibrary:caveats: ''
           nationalindicatorlibrary:contactAuthor: ''
+          nationalindicatorlibrary:dataSource: ''
           nationalindicatorlibrary:definition: ''
-          nationalindicatorlibrary:descriptor: ''
+          nationalindicatorlibrary:denominator: ''
           nationalindicatorlibrary:iapCode: ''
           nationalindicatorlibrary:indicatorSet: ''
           nationalindicatorlibrary:interpretationGuidelines: ''
+          nationalindicatorlibrary:numerator: ''
           nationalindicatorlibrary:publishedBy: ''
           nationalindicatorlibrary:publishedDate: 0001-01-01T12:00:00Z
           nationalindicatorlibrary:purpose: ''

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/national-indicator-library.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/national-indicator-library.yaml
@@ -39,6 +39,10 @@
       - headers.indicatorSet
       - headers.interpretationGuidelines
       - headers.methodology
+      - headers.dataSource
+      - headers.numerator
+      - headers.denominator
+      - headers.calculation
       - headers.publishedBy
       - headers.publishedDate
       - headers.purpose
@@ -56,6 +60,10 @@
       - 'Indicator Set:'
       - 'Interpretation Guidelines:'
       - 'Methodology: how the indicator is calculated'
+      - 'Data Source:'
+      - 'Numerator:'
+      - 'Denominator:'
+      - 'Calculation:'
       - 'Published by:'
       - 'Published date:'
       - Purpose
@@ -103,6 +111,10 @@
       - headers.indicatorSet
       - headers.interpretationGuidelines
       - headers.methodology
+      - headers.dataSource
+      - headers.numerator
+      - headers.denominator
+      - headers.calculation
       - headers.publishedBy
       - headers.publishedDate
       - headers.purpose
@@ -120,6 +132,10 @@
       - 'Indicator Set:'
       - 'Interpretation Guidelines:'
       - 'Methodology: how the indicator is calculated'
+      - 'Data Source:'
+      - 'Numerator:'
+      - 'Denominator:'
+      - 'Calculation:'
       - 'Published by:'
       - 'Published date:'
       - Purpose
@@ -167,6 +183,10 @@
       - headers.indicatorSet
       - headers.interpretationGuidelines
       - headers.methodology
+      - headers.dataSource
+      - headers.numerator
+      - headers.denominator
+      - headers.calculation
       - headers.publishedBy
       - headers.publishedDate
       - headers.purpose
@@ -184,6 +204,10 @@
       - 'Indicator Set:'
       - 'Interpretation Guidelines:'
       - 'Methodology: how the indicator is calculated'
+      - 'Data Source:'
+      - 'Numerator:'
+      - 'Denominator:'
+      - 'Calculation:'
       - 'Published by:'
       - 'Published date:'
       - Purpose

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/sample-indicator.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/sample-indicator.yaml
@@ -16,12 +16,17 @@
     nationalindicatorlibrary:assuranceDate: 2015-12-14T00:00:00Z
     nationalindicatorlibrary:basedOn: Royal College of Physicians’ Sentinel Stroke
       National Audit Programme (SSNAP)
+    nationalindicatorlibrary:calculation: The numerator is divided by the denominator
+      and multiplied by 100 to provide a percentage indicator value. 95% confidence
+      intervals are then calculated using the Wilson Score method.
     nationalindicatorlibrary:caveats: "The patterns of providing care may vary between\
       \ organisations in terms of hospital inpatient admission practices and policies.\r\
       \n\r\nThere may be variation in the prevalence of stroke due to differing levels\
       \ of deprivation, for other geo-demographic reasons or between patients of different\
       \ ethnic heritages."
     nationalindicatorlibrary:contactAuthor: ''
+    nationalindicatorlibrary:dataSource: Royal College of Physicians’ Sentinel Stroke
+      National Audit Programme (RCP SSNAP)
     nationalindicatorlibrary:definition: "The percentage of people with stroke admitted\
       \ to an acute stroke unit within 4 hours of arrival to hospital.\r\n\r\n(ITU\
       \ = Intensive Treatment Unit, CCU = Critical Care Unit, HDU = High Dependency\
@@ -36,15 +41,10 @@
       \ (I63) and stroke, not specified as haemorrhage or infarction (I64).\r\n\r\n\
       The indicator is published annually in December for each CCG in England. It\
       \ was published for the first time in December 2014 (2013/14 data)."
-    nationalindicatorlibrary:descriptor: "Numerator\r\nOf the denominator, the number\
-      \ of patients whose first ward of admission is a stroke unit AND who are admitted\
-      \ to the stroke unit within 4 hours of arrival at hospital, except for those\
-      \ patients who were already in hospital at the time of new stroke occurrence,\
-      \ who are admitted to a stroke unit within 4 hours of onset of stroke symptoms.\r\
-      \n\r\nDenominator\r\n(ITU = Intensive Treatment Unit, CCU = Critical Care Unit,\
-      \ HDU = High Dependency Unit)\r\n\r\nAll patients admitted to hospital with\
-      \ a primary diagnosis of stroke, except for those whose first ward of admission\
-      \ was ITU, CCU or HDU."
+    nationalindicatorlibrary:denominator: All patients admitted to hospital with a
+      primary diagnosis of stroke, except for those whose first ward of admission
+      was Intensive Treatment Unit (ITU), Critical Care Unit (CCU) or High Dependency
+      Unity (HDU).
     nationalindicatorlibrary:iapCode: IAP00094
     nationalindicatorlibrary:indicatorSet: CCG OIS
     nationalindicatorlibrary:interpretationGuidelines: "A high percentage of patients\
@@ -61,6 +61,11 @@
       \ stroke unit key indicators. When evaluated together, these will help to provide\
       \ a holistic view of CCG outcomes and provide a more complete overview of the\
       \ impact of the CCGs’ processes on outcomes."
+    nationalindicatorlibrary:numerator: Of the denominator, the number of patients
+      whose first ward of admission is a stroke unit AND who are admitted to the stroke
+      unit within 4 hours of arrival at hospital, except for those patients who were
+      already in hospital at the time of new stroke occurrence, who are admitted to
+      a stroke unit within 4 hours of onset of stroke symptoms.
     nationalindicatorlibrary:publishedBy: ''
     nationalindicatorlibrary:publishedDate: 2018-02-09T00:00:00Z
     nationalindicatorlibrary:purpose: Patients who have had a stroke should be admitted
@@ -96,12 +101,17 @@
     nationalindicatorlibrary:assuranceDate: 2015-12-14T00:00:00Z
     nationalindicatorlibrary:basedOn: Royal College of Physicians’ Sentinel Stroke
       National Audit Programme (SSNAP)
+    nationalindicatorlibrary:calculation: The numerator is divided by the denominator
+      and multiplied by 100 to provide a percentage indicator value. 95% confidence
+      intervals are then calculated using the Wilson Score method.
     nationalindicatorlibrary:caveats: "The patterns of providing care may vary between\
       \ organisations in terms of hospital inpatient admission practices and policies.\r\
       \n\r\nThere may be variation in the prevalence of stroke due to differing levels\
       \ of deprivation, for other geo-demographic reasons or between patients of different\
       \ ethnic heritages."
     nationalindicatorlibrary:contactAuthor: ''
+    nationalindicatorlibrary:dataSource: Royal College of Physicians’ Sentinel Stroke
+      National Audit Programme (RCP SSNAP)
     nationalindicatorlibrary:definition: "The percentage of people with stroke admitted\
       \ to an acute stroke unit within 4 hours of arrival to hospital.\r\n\r\n(ITU\
       \ = Intensive Treatment Unit, CCU = Critical Care Unit, HDU = High Dependency\
@@ -116,15 +126,10 @@
       \ (I63) and stroke, not specified as haemorrhage or infarction (I64).\r\n\r\n\
       The indicator is published annually in December for each CCG in England. It\
       \ was published for the first time in December 2014 (2013/14 data)."
-    nationalindicatorlibrary:descriptor: "Numerator\r\nOf the denominator, the number\
-      \ of patients whose first ward of admission is a stroke unit AND who are admitted\
-      \ to the stroke unit within 4 hours of arrival at hospital, except for those\
-      \ patients who were already in hospital at the time of new stroke occurrence,\
-      \ who are admitted to a stroke unit within 4 hours of onset of stroke symptoms.\r\
-      \n\r\nDenominator\r\n(ITU = Intensive Treatment Unit, CCU = Critical Care Unit,\
-      \ HDU = High Dependency Unit)\r\n\r\nAll patients admitted to hospital with\
-      \ a primary diagnosis of stroke, except for those whose first ward of admission\
-      \ was ITU, CCU or HDU."
+    nationalindicatorlibrary:denominator: All patients admitted to hospital with a
+      primary diagnosis of stroke, except for those whose first ward of admission
+      was Intensive Treatment Unit (ITU), Critical Care Unit (CCU) or High Dependency
+      Unity (HDU).
     nationalindicatorlibrary:iapCode: IAP00094
     nationalindicatorlibrary:indicatorSet: CCG OIS
     nationalindicatorlibrary:interpretationGuidelines: "A high percentage of patients\
@@ -141,6 +146,11 @@
       \ stroke unit key indicators. When evaluated together, these will help to provide\
       \ a holistic view of CCG outcomes and provide a more complete overview of the\
       \ impact of the CCGs’ processes on outcomes."
+    nationalindicatorlibrary:numerator: Of the denominator, the number of patients
+      whose first ward of admission is a stroke unit AND who are admitted to the stroke
+      unit within 4 hours of arrival at hospital, except for those patients who were
+      already in hospital at the time of new stroke occurrence, who are admitted to
+      a stroke unit within 4 hours of onset of stroke symptoms.
     nationalindicatorlibrary:publishedBy: ''
     nationalindicatorlibrary:publishedDate: 2018-02-09T00:00:00Z
     nationalindicatorlibrary:purpose: Patients who have had a stroke should be admitted
@@ -176,12 +186,17 @@
     nationalindicatorlibrary:assuranceDate: 2015-12-14T00:00:00Z
     nationalindicatorlibrary:basedOn: Royal College of Physicians’ Sentinel Stroke
       National Audit Programme (SSNAP)
+    nationalindicatorlibrary:calculation: The numerator is divided by the denominator
+      and multiplied by 100 to provide a percentage indicator value. 95% confidence
+      intervals are then calculated using the Wilson Score method.
     nationalindicatorlibrary:caveats: "The patterns of providing care may vary between\
       \ organisations in terms of hospital inpatient admission practices and policies.\r\
       \n\r\nThere may be variation in the prevalence of stroke due to differing levels\
       \ of deprivation, for other geo-demographic reasons or between patients of different\
       \ ethnic heritages."
     nationalindicatorlibrary:contactAuthor: ''
+    nationalindicatorlibrary:dataSource: Royal College of Physicians’ Sentinel Stroke
+      National Audit Programme (RCP SSNAP)
     nationalindicatorlibrary:definition: "The percentage of people with stroke admitted\
       \ to an acute stroke unit within 4 hours of arrival to hospital.\r\n\r\n(ITU\
       \ = Intensive Treatment Unit, CCU = Critical Care Unit, HDU = High Dependency\
@@ -196,15 +211,10 @@
       \ (I63) and stroke, not specified as haemorrhage or infarction (I64).\r\n\r\n\
       The indicator is published annually in December for each CCG in England. It\
       \ was published for the first time in December 2014 (2013/14 data)."
-    nationalindicatorlibrary:descriptor: "Numerator\r\nOf the denominator, the number\
-      \ of patients whose first ward of admission is a stroke unit AND who are admitted\
-      \ to the stroke unit within 4 hours of arrival at hospital, except for those\
-      \ patients who were already in hospital at the time of new stroke occurrence,\
-      \ who are admitted to a stroke unit within 4 hours of onset of stroke symptoms.\r\
-      \n\r\nDenominator\r\n(ITU = Intensive Treatment Unit, CCU = Critical Care Unit,\
-      \ HDU = High Dependency Unit)\r\n\r\nAll patients admitted to hospital with\
-      \ a primary diagnosis of stroke, except for those whose first ward of admission\
-      \ was ITU, CCU or HDU."
+    nationalindicatorlibrary:denominator: All patients admitted to hospital with a
+      primary diagnosis of stroke, except for those whose first ward of admission
+      was Intensive Treatment Unit (ITU), Critical Care Unit (CCU) or High Dependency
+      Unity (HDU).
     nationalindicatorlibrary:iapCode: IAP00094
     nationalindicatorlibrary:indicatorSet: CCG OIS
     nationalindicatorlibrary:interpretationGuidelines: "A high percentage of patients\
@@ -221,6 +231,11 @@
       \ stroke unit key indicators. When evaluated together, these will help to provide\
       \ a holistic view of CCG outcomes and provide a more complete overview of the\
       \ impact of the CCGs’ processes on outcomes."
+    nationalindicatorlibrary:numerator: Of the denominator, the number of patients
+      whose first ward of admission is a stroke unit AND who are admitted to the stroke
+      unit within 4 hours of arrival at hospital, except for those patients who were
+      already in hospital at the time of new stroke occurrence, who are admitted to
+      a stroke unit within 4 hours of onset of stroke symptoms.
     nationalindicatorlibrary:publishedBy: ''
     nationalindicatorlibrary:publishedDate: 2018-02-09T00:00:00Z
     nationalindicatorlibrary:purpose: Patients who have had a stroke should be admitted

--- a/repository-data/webfiles/src/main/resources/site/freemarker/nationalindicatorlibrary/indicator.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/nationalindicatorlibrary/indicator.ftl
@@ -70,8 +70,17 @@
         <section id="methodology" class="push-double--bottom">
             <h2><@fmt.message key="headers.methodology"/></h2>
 
-            <h3><@fmt.message key="headers.methodology"/></h3>
-            <p>${indicator.descriptor}</p>
+            <h3><@fmt.message key="headers.dataSource"/></h3>
+            <p>${indicator.dataSource}</p>
+
+            <h3><@fmt.message key="headers.numerator"/></h3>
+            <p>${indicator.numerator}</p>
+
+            <h3><@fmt.message key="headers.denominator"/></h3>
+            <p>${indicator.denominator}</p>
+
+            <h3><@fmt.message key="headers.calculation"/></h3>
+            <p>${indicator.calculation}</p>                        
 
             <h3><@fmt.message key="headers.caveats"/></h3>
             <p>${indicator.caveats}</p>

--- a/site/src/main/java/uk/nhs/digital/nil/beans/Indicator.java
+++ b/site/src/main/java/uk/nhs/digital/nil/beans/Indicator.java
@@ -89,8 +89,23 @@ public class Indicator extends BaseDocument {
         return getProperty("nationalindicatorlibrary:reviewDate");
     }
 
-    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:descriptor")
-    public String getDescriptor() {
-        return getProperty("nationalindicatorlibrary:descriptor");
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:dataSource")
+    public String getDataSource() {
+        return getProperty("nationalindicatorlibrary:dataSource");
     }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:numerator")
+    public String getNumerator() {
+        return getProperty("nationalindicatorlibrary:numerator");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:denominator")
+    public String getDenominator() {
+        return getProperty("nationalindicatorlibrary:denominator");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:calculation")
+    public String getCalculation() {
+        return getProperty("nationalindicatorlibrary:calculation");
+    }            
 }


### PR DESCRIPTION
Evolution of the NIL Indicator document type - split the field 'descriptor' into four fields - 'data source', 'numerator', 'denominator' and 'calculation'. Updated the seeded sample indicator.

Migration project will be updated next.