### PR TITLE
[NIL] Remove Published Date from Indicator doc type

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/indicator.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/indicator.yaml
@@ -45,14 +45,6 @@ definitions:
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
-          /publishedDate:
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-            caption: Published date
-            field: publishedDate
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.field
           /reportingPeriod:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
@@ -296,14 +288,6 @@ definitions:
             hipposysedit:primary: false
             hipposysedit:type: Text
             jcr:primaryType: hipposysedit:field
-          /publishedDate:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: nationalindicatorlibrary:publishedDate
-            hipposysedit:primary: false
-            hipposysedit:type: Date
-            jcr:primaryType: hipposysedit:field
           /purpose:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
@@ -395,7 +379,6 @@ definitions:
           nationalindicatorlibrary:interpretationGuidelines: ''
           nationalindicatorlibrary:numerator: ''
           nationalindicatorlibrary:publishedBy: ''
-          nationalindicatorlibrary:publishedDate: 0001-01-01T12:00:00Z
           nationalindicatorlibrary:purpose: ''
           nationalindicatorlibrary:rating: ''
           nationalindicatorlibrary:reportingLevel: ''

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/national-indicator-library.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/national-indicator-library.yaml
@@ -44,7 +44,6 @@
       - headers.denominator
       - headers.calculation
       - headers.publishedBy
-      - headers.publishedDate
       - headers.purpose
       - headers.rating
       - headers.reportingLevel
@@ -65,7 +64,6 @@
       - 'Denominator:'
       - 'Calculation:'
       - 'Published by:'
-      - 'Published date:'
       - Purpose
       - 'Rating:'
       - 'Reporting level:'
@@ -116,7 +114,6 @@
       - headers.denominator
       - headers.calculation
       - headers.publishedBy
-      - headers.publishedDate
       - headers.purpose
       - headers.rating
       - headers.reportingLevel
@@ -137,7 +134,6 @@
       - 'Denominator:'
       - 'Calculation:'
       - 'Published by:'
-      - 'Published date:'
       - Purpose
       - 'Rating:'
       - 'Reporting level:'
@@ -188,7 +184,6 @@
       - headers.denominator
       - headers.calculation
       - headers.publishedBy
-      - headers.publishedDate
       - headers.purpose
       - headers.rating
       - headers.reportingLevel
@@ -209,7 +204,6 @@
       - 'Denominator:'
       - 'Calculation:'
       - 'Published by:'
-      - 'Published date:'
       - Purpose
       - 'Rating:'
       - 'Reporting level:'

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/sample-indicator.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/sample-indicator.yaml
@@ -67,7 +67,6 @@
       already in hospital at the time of new stroke occurrence, who are admitted to
       a stroke unit within 4 hours of onset of stroke symptoms.
     nationalindicatorlibrary:publishedBy: ''
-    nationalindicatorlibrary:publishedDate: 2018-02-09T00:00:00Z
     nationalindicatorlibrary:purpose: Patients who have had a stroke should be admitted
       directly to a specialist acute stroke unit. Getting patients to a stroke unit
       quickly is a strong indicator of eventual outcomes and is also closely linked
@@ -152,7 +151,6 @@
       already in hospital at the time of new stroke occurrence, who are admitted to
       a stroke unit within 4 hours of onset of stroke symptoms.
     nationalindicatorlibrary:publishedBy: ''
-    nationalindicatorlibrary:publishedDate: 2018-02-09T00:00:00Z
     nationalindicatorlibrary:purpose: Patients who have had a stroke should be admitted
       directly to a specialist acute stroke unit. Getting patients to a stroke unit
       quickly is a strong indicator of eventual outcomes and is also closely linked
@@ -237,7 +235,6 @@
       already in hospital at the time of new stroke occurrence, who are admitted to
       a stroke unit within 4 hours of onset of stroke symptoms.
     nationalindicatorlibrary:publishedBy: ''
-    nationalindicatorlibrary:publishedDate: 2018-02-09T00:00:00Z
     nationalindicatorlibrary:purpose: Patients who have had a stroke should be admitted
       directly to a specialist acute stroke unit. Getting patients to a stroke unit
       quickly is a strong indicator of eventual outcomes and is also closely linked

--- a/repository-data/webfiles/src/main/resources/site/freemarker/nationalindicatorlibrary/indicator.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/nationalindicatorlibrary/indicator.ftl
@@ -24,7 +24,7 @@
         <div class="layout">
             <div class="layout__item layout-1-2">
                 <p class="push-half--bottom"><strong><@fmt.message key="headers.publishedBy"/></strong> ${indicator.publishedBy}</p>
-                <p class="push-half--bottom"><strong><@fmt.message key="headers.publishedDate"/></strong> ${indicator.publishedDate.time?string[dateFormat]}</p>
+                <p class="push-half--bottom"><strong><@fmt.message key="headers.assuranceDate"/></strong> ${indicator.assuranceDate.time?string[dateFormat]}</p>
                 <p class="push-half--bottom"><strong><@fmt.message key="headers.reportingPeriod"/></strong> ${indicator.reportingPeriod}</p>
                 <p class="push-half--bottom"><strong><@fmt.message key="headers.basedOn"/></strong> ${indicator.basedOn}</p>
             </div><!--
@@ -108,7 +108,7 @@
                 <tr>
                     <td>Title</td>
                     <td>Publisher</td>
-                    <td>Published Date</td>
+                    <td>Assured Date</td>
                     <td>Assured Until</td>
                 </tr>
                 <tr>


### PR DESCRIPTION
Remove 'published date' from the NIL Indicator document type. Business decision made - this was causing confusion with the 'assured date' and is not required. Migrator will be updated separately.