### PR TITLE
[RPS-384] Consistent date formats on publication/dataset page

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
@@ -63,6 +63,10 @@ public class TestContentUrls {
         add("attachment test dataset",
             "/publications/acceptance-tests/attachment-test/dataset");
 
+        // coverage date test
+        add("coverage date publication",
+            "/publications/acceptance-tests/coveragedates-test/coverage-test");
+
         // bare minimum documents
         add("bare minimum publication",
             "/publications/acceptance-tests/bare-minimum-publication");

--- a/acceptance-tests/src/test/resources/features/site/datasets.feature
+++ b/acceptance-tests/src/test/resources/features/site/datasets.feature
@@ -10,9 +10,9 @@ Feature: As a consumer I need to be able to navigate to publication data sets
             | Dataset Summary               | Mauris ex est, dapibus in dictum ut, elementum sit amet ... |
             | Dataset Granularity           | NHS Trusts                                                  |
             | Dataset Geographic Coverage   | England                                                     |
-            | Dataset Date Range            | 01/02/2016 to 01/07/2017                                    |
+            | Dataset Date Range            | 01 Feb 2016 to 01 Jul 2017                                  |
             | Dataset Nominal Date          | 10 Oct 2017                                                 |
-            | Dataset Next Publication Date | 09/07/2018                                                  |
+            | Dataset Next Publication Date | 09 Jul 2018                                                 |
 
     Scenario: Headers don't display for empty fields
         Given I navigate to the "bare minimum dataset" page

--- a/acceptance-tests/src/test/resources/features/site/publication.feature
+++ b/acceptance-tests/src/test/resources/features/site/publication.feature
@@ -9,7 +9,14 @@ Feature: Ensure publication page displays required fields.
             | Publication Geographic Coverage       | England                                                           |
             | Publication Granularity               | NHS Trusts                                                        |
             | Publication Administrative Sources    | Mauris pretium orci ac gravida accumsan. Cras mattis massa ...    |
-            | Publication Date Range                | 10/02/2015 to 15/09/2016                                          |
+            | Publication Date Range                | 10 Feb 2015 to 15 Sep 2016                                        |
+            | Publication Date                      | 10 Oct 2016                                                       |
+
+    Scenario: Check coverage date range when dates are equal
+        Given I navigate to "coverage date publication" page
+        Then I should see publication page titled "Coverage dates Document"
+        And I should also see:
+            | Publication Date Range                | Snapshot on 27 Jan 2018                                           |
 
     Scenario: Display Resource Links, Attachments and Datasets in one list
         Given I navigate to "publication with datasets" page

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/coveragedates-test.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/coveragedates-test.yaml
@@ -1,0 +1,90 @@
+---
+/content/documents/corporate-website/publication-system/acceptance-tests/coveragedates-test:
+  /coverage-test:
+    /coverage-test[1]:
+      common:searchable: true
+      hippo:availability: []
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-29T12:24:30.725Z
+      hippostdpubwf:lastModificationDate: 2018-01-29T12:48:50.731Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 6ca4d793-489b-4b57-b646-d444ba76eb0b
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 2018-01-27T00:00:00Z
+      publicationsystem:CoverageStart: 2018-01-27T00:00:00Z
+      publicationsystem:GeographicCoverage: ''
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2018-01-29T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: Coverage dates Document
+      publicationsystem:Title: Coverage dates Document
+    /coverage-test[2]:
+      common:searchable: true
+      hippo:availability:
+      - preview
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-29T12:24:30.725Z
+      hippostdpubwf:lastModificationDate: 2018-01-29T12:26:27.027Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 6ca4d793-489b-4b57-b646-d444ba76eb0b
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      - mix:versionable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 2018-01-27T00:00:00Z
+      publicationsystem:CoverageStart: 2018-01-27T00:00:00Z
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2018-01-29T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: Coverage dates Document
+      publicationsystem:Title: Coverage dates Document
+    /coverage-test[3]:
+      common:searchable: true
+      hippo:availability:
+      - live
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-29T12:24:30.725Z
+      hippostdpubwf:lastModificationDate: 2018-01-29T12:26:27.027Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2018-01-29T12:26:31.087Z
+      hippotranslation:id: 6ca4d793-489b-4b57-b646-d444ba76eb0b
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 2018-01-27T00:00:00Z
+      publicationsystem:CoverageStart: 2018-01-27T00:00:00Z
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2018-01-29T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: Coverage dates Document
+      publicationsystem:Title: Coverage dates Document
+    hippo:name: Coverage Dates Dummy Document
+    jcr:mixinTypes:
+    - hippo:named
+    - mix:referenceable
+    jcr:primaryType: hippo:handle
+  hippo:name: Coverage Dates
+  hippostd:foldertype:
+  - new-statistical-publications-and-clinical-indicators-document
+  - new-statistical-publications-and-clinical-indicators-folder
+  hippotranslation:id: eaf4fc44-8d7c-4bdf-afae-550d6a45adac
+  hippotranslation:locale: en
+  jcr:mixinTypes:
+  - hippo:named
+  - hippotranslation:translated
+  - mix:versionable
+  jcr:primaryType: hippostd:folder

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/dataset.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/dataset.ftl
@@ -4,7 +4,7 @@
 <@hst.setBundle basename="publicationsystem.headers,publicationsystem.labels"/>
 <#assign formatRestrictableDate="uk.nhs.digital.ps.directives.RestrictableDateFormatterDirective"?new() />
 
-<#assign dateFormat="dd/MM/yyyy"/>
+<#assign dateFormat="dd MMM yyyy"/>
 <#assign formatFileSize="uk.nhs.digital.ps.directives.FileSizeFormatterDirective"?new() >
 <#assign formatCoverageDates="uk.nhs.digital.ps.directives.CoverageDatesFormatterDirective"?new() >
 

--- a/site/src/main/java/uk/nhs/digital/ps/directives/CoverageDatesFormatterDirective.java
+++ b/site/src/main/java/uk/nhs/digital/ps/directives/CoverageDatesFormatterDirective.java
@@ -49,7 +49,7 @@ public class CoverageDatesFormatterDirective implements TemplateDirectiveModel {
     }
 
     private String formatDate(final Date dateToFormat) {
-        SimpleDateFormat requiredFormat = new SimpleDateFormat("dd/MM/yyyy");
+        SimpleDateFormat requiredFormat = new SimpleDateFormat("dd MMM yyyy");
         return requiredFormat.format(dateToFormat);
     }
 


### PR DESCRIPTION
Update coverage dates and next publication date (datasets) to be
consistent with publication date. Format should be dd MMM yyyy