### PR TITLE
[RPS-387] Fix attachment validation for non-admin users

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/cms/ps/CmsSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/cms/ps/CmsSteps.java
@@ -7,6 +7,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 import static org.slf4j.LoggerFactory.getLogger;
+import static uk.nhs.digital.ps.test.acceptance.util.AssertionHelper.assertWithinTimeoutThat;
 import static uk.nhs.digital.ps.test.acceptance.util.RandomHelper.getRandomInt;
 
 import cucumber.api.DataTable;
@@ -28,6 +29,7 @@ import uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPage;
 import uk.nhs.digital.ps.test.acceptance.steps.AbstractSpringSteps;
 import uk.nhs.digital.ps.test.acceptance.steps.cms.LoginSteps;
 
+import java.text.MessageFormat;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -132,8 +134,7 @@ public class CmsSteps extends AbstractSpringSteps {
     @Then("^the upload is rejected with an error message$")
     public void theUploadIsRejectedWithAnErrorMessage() throws Throwable {
 
-        // TODO: RPS-387 This doesn't currently work, i've raised a ticket to fix it
-        /*contentPage.getAttachmentsWidget().addUploadField();
+        contentPage.getAttachmentsWidget().addUploadField();
 
         testDataRepo.getAttachments().forEach(attachment -> {
             contentPage.getAttachmentsWidget().uploadAttachment(attachment);
@@ -146,7 +147,7 @@ public class CmsSteps extends AbstractSpringSteps {
 
             assertWithinTimeoutThat("Error message is displayed",
                () -> contentPage.getFirstErrorMessage(), startsWith(expectedErrorMessage));
-        });*/
+        });
     }
 
     // Scenario: Title and Summary validation ========================================================================
@@ -186,11 +187,6 @@ public class CmsSteps extends AbstractSpringSteps {
 
     @Then("^the save is rejected with error message containing \"([^\"]+)\"$")
     public void validationErrorMessageIsShownAndContains(String errorMessageFragment) throws Throwable {
-
-        // TODO: RPS-387 This doesn't currently work, i've raised a ticket to fix it
-        if (errorMessageFragment.contains("There is an attachment field without an attachment")) {
-            return;
-        }
 
         assertThat("Error message should be shown and contains",
             contentPage.getErrorMessages(),

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/statistical-publications-and-clinical-indicators-read.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/statistical-publications-and-clinical-indicators-read.yaml
@@ -29,6 +29,24 @@ definitions:
           hipposys:value: /content
           jcr:primaryType: hipposys:facetrule
         jcr:primaryType: hipposys:domainrule
+      /document-types-attachment-node:
+        /path-by-uuid:
+          hipposys:equals: true
+          hipposys:facet: jcr:path
+          hipposys:filter: false
+          hipposys:type: Reference
+          hipposys:value: /hippo:namespaces/publicationsystem/attachment
+          jcr:primaryType: hipposys:facetrule
+        jcr:primaryType: hipposys:domainrule
+      /document-types-resource-node:
+        /path-by-uuid:
+          hipposys:equals: true
+          hipposys:facet: jcr:path
+          hipposys:filter: false
+          hipposys:type: Reference
+          hipposys:value: /hippo:namespaces/publicationsystem/resource
+          jcr:primaryType: hipposys:facetrule
+        jcr:primaryType: hipposys:domainrule
       /documents-node:
         /node-by-uuid:
           hipposys:equals: true

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/another-upcoming-publication.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/another-upcoming-publication.yaml
@@ -21,14 +21,14 @@
       - mix:referenceable
       jcr:primaryType: publicationsystem:publication
       publicationsystem:AdministrativeSources: ''
-      publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-      publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+      publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+      publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
       publicationsystem:InformationType:
       - Official statistics
       publicationsystem:KeyFacts: Ipsum dolor sit amet, consectetur adipiscing elit.
         Mauris mattis sodales felis, vitae ultricies turpis porttitor in. Integer
         sit amet efficitur urna.
-      publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+      publicationsystem:NominalDate: 2017-06-01T00:00:00Z
       publicationsystem:PubliclyAccessible: false
       publicationsystem:Summary: Published Upcoming Publication summary.
       publicationsystem:Title: Published Upcoming Publication
@@ -54,14 +54,14 @@
       - mix:versionable
       jcr:primaryType: publicationsystem:publication
       publicationsystem:AdministrativeSources: ''
-      publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-      publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+      publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+      publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
       publicationsystem:InformationType:
       - Official statistics
       publicationsystem:KeyFacts: Ipsum dolor sit amet, consectetur adipiscing elit.
         Mauris mattis sodales felis, vitae ultricies turpis porttitor in. Integer
         sit amet efficitur urna.
-      publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+      publicationsystem:NominalDate: 2017-06-01T00:00:00Z
       publicationsystem:PubliclyAccessible: false
       publicationsystem:Summary: Published Upcoming Publication summary.
       publicationsystem:Title: Published Upcoming Publication
@@ -87,14 +87,14 @@
       - mix:referenceable
       jcr:primaryType: publicationsystem:publication
       publicationsystem:AdministrativeSources: ''
-      publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-      publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+      publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+      publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
       publicationsystem:InformationType:
       - Official statistics
       publicationsystem:KeyFacts: Ipsum dolor sit amet, consectetur adipiscing elit.
         Mauris mattis sodales felis, vitae ultricies turpis porttitor in. Integer
         sit amet efficitur urna.
-      publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+      publicationsystem:NominalDate: 2017-06-01T00:00:00Z
       publicationsystem:PubliclyAccessible: false
       publicationsystem:Summary: Published Upcoming Publication summary.
       publicationsystem:Title: Published Upcoming Publication

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/fusce-viverra-dolor.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/fusce-viverra-dolor.yaml
@@ -1,12 +1,6 @@
 ---
 /content/documents/corporate-website/publication-system/lorem-ipsum-content/fusce-viverra-dolor:
   /fusce-viverra-dolor[1]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability: []
@@ -24,14 +18,14 @@
     - mix:referenceable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: Ipsum dolor sit amet, consectetur adipiscing elit.
       Mauris mattis sodales felis, vitae ultricies turpis porttitor in. Integer sit
       amet efficitur urna.
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc pellentesque,
       lobortis orci eu, placerat nibh. Nulla est mauris, vehicula nec ornare a, lacinia
@@ -41,12 +35,6 @@
       Curabitur justo nisi, mattis vel neque placerat, imperdiet ultrices tortor.
     publicationsystem:Title: Fusce viverra dolor
   /fusce-viverra-dolor[2]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability:
@@ -66,14 +54,14 @@
     - mix:versionable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: Ipsum dolor sit amet, consectetur adipiscing elit.
       Mauris mattis sodales felis, vitae ultricies turpis porttitor in. Integer sit
       amet efficitur urna.
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc pellentesque,
       lobortis orci eu, placerat nibh. Nulla est mauris, vehicula nec ornare a, lacinia
@@ -83,12 +71,6 @@
       Curabitur justo nisi, mattis vel neque placerat, imperdiet ultrices tortor.
     publicationsystem:Title: Fusce viverra dolor
   /fusce-viverra-dolor[3]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability:
@@ -108,14 +90,14 @@
     - mix:referenceable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: Ipsum dolor sit amet, consectetur adipiscing elit.
       Mauris mattis sodales felis, vitae ultricies turpis porttitor in. Integer sit
       amet efficitur urna.
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc pellentesque,
       lobortis orci eu, placerat nibh. Nulla est mauris, vehicula nec ornare a, lacinia

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/lorem-ipsum.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/lorem-ipsum.yaml
@@ -1,20 +1,14 @@
 ---
 /content/documents/corporate-website/publication-system/lorem-ipsum-content/lorem-ipsum:
   /lorem-ipsum[1]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2017-10-16T14:00:00Z
-    hippostdpubwf:lastModificationDate: 2017-10-16T14:00:00Z
-    hippostdpubwf:lastModifiedBy: admin
+    hippostdpubwf:lastModificationDate: 2018-02-16T16:25:43.238Z
+    hippostdpubwf:lastModifiedBy: ci-editor
     hippotaxonomy:keys:
     - infectious-diseases
     hippotranslation:id: 00000000-0000-0000-0000-000000000000
@@ -24,12 +18,12 @@
     - mix:referenceable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc pellentesque,
       lobortis orci eu, placerat lorem. Nulla est mauris, vehicula nec ornare a, lacinia
@@ -39,12 +33,6 @@
       Curabitur justo nisi, mattis vel neque placerat, imperdiet ultrices tortor.
     publicationsystem:Title: Lorem ipsum dolor sit amet.
   /lorem-ipsum[2]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability:
@@ -64,12 +52,12 @@
     - mix:versionable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc pellentesque,
       lobortis orci eu, placerat lorem. Nulla est mauris, vehicula nec ornare a, lacinia
@@ -79,12 +67,6 @@
       Curabitur justo nisi, mattis vel neque placerat, imperdiet ultrices tortor.
     publicationsystem:Title: Lorem ipsum dolor sit amet.
   /lorem-ipsum[3]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability:
@@ -104,12 +86,12 @@
     - mix:referenceable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Maecenas laoreet ullamcorper aliquam. Sed ac nunc pellentesque,
       lobortis orci eu, placerat lorem. Nulla est mauris, vehicula nec ornare a, lacinia

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-tempor-euismod-vehicula.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-tempor-euismod-vehicula.yaml
@@ -1,12 +1,6 @@
 ---
 /content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-tempor-euismod-vehicula:
   /morbi-tempor-euismod-vehicula[1]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability: []
@@ -24,12 +18,12 @@
     - mix:referenceable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Duis vel ultricies ante. Vestibulum nec commodo justo.
       Donec et tellus justo. Nunc id lobortis odio. Morbi quis lectus scelerisque,
@@ -41,12 +35,6 @@
       porta ante, id iaculis nisl est ac velit.
     publicationsystem:Title: Morbi tempor euismod vehicula
   /morbi-tempor-euismod-vehicula[2]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability:
@@ -66,12 +54,12 @@
     - mix:versionable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Duis vel ultricies ante. Vestibulum nec commodo justo.
       Donec et tellus justo. Nunc id lobortis odio. Morbi quis lectus scelerisque,
@@ -83,12 +71,6 @@
       porta ante, id iaculis nisl est ac velit.
     publicationsystem:Title: Morbi tempor euismod vehicula
   /morbi-tempor-euismod-vehicula[3]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability:
@@ -108,12 +90,12 @@
     - mix:referenceable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Duis vel ultricies ante. Vestibulum nec commodo justo.
       Donec et tellus justo. Nunc id lobortis odio. Morbi quis lectus scelerisque,

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-vitae-nunc-ac-lacus-malesuada-tempus.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-vitae-nunc-ac-lacus-malesuada-tempus.yaml
@@ -1,12 +1,6 @@
 ---
 /content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-vitae-nunc-ac-lacus-malesuada-tempus:
   /morbi-vitae-nunc-ac-lacus-malesuada-tempus[1]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability: []
@@ -25,13 +19,13 @@
     - mix:referenceable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: Donec ultricies fringilla mauris nec varius. Pellentesque
       ultricies et libero et venenatis. Mauris accumsan ligula sed enim volutpat scelerisque.
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Etiam tempus quam sed massa ullamcorper, in vestibulum
       ex ultrices. Duis ipsum, eros et accumsan auctor, turpis lectus viverra urna,
@@ -42,12 +36,6 @@
       ipsum a ante nec, tincidunt eleifend tortor.
     publicationsystem:Title: Morbi vitae nunc ac lacus malesuada tempus
   /morbi-vitae-nunc-ac-lacus-malesuada-tempus[2]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability:
@@ -68,13 +56,13 @@
     - mix:versionable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: Donec ultricies fringilla mauris nec varius. Pellentesque
       ultricies et libero et venenatis. Mauris accumsan ligula sed enim volutpat scelerisque.
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Etiam tempus quam sed massa ullamcorper, in vestibulum
       ex ultrices. Duis ipsum, eros et accumsan auctor, turpis lectus viverra urna,
@@ -85,12 +73,6 @@
       ipsum a ante nec, tincidunt eleifend tortor.
     publicationsystem:Title: Morbi vitae nunc ac lacus malesuada tempus
   /morbi-vitae-nunc-ac-lacus-malesuada-tempus[3]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability:
@@ -111,13 +93,13 @@
     - mix:referenceable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: Donec ultricies fringilla mauris nec varius. Pellentesque
       ultricies et libero et venenatis. Mauris accumsan ligula sed enim volutpat scelerisque.
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Etiam tempus quam sed massa ullamcorper, in vestibulum
       ex ultrices. Duis ipsum, eros et accumsan auctor, turpis lectus viverra urna,

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/nullam-vel-ligula-dapibus.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/nullam-vel-ligula-dapibus.yaml
@@ -1,12 +1,6 @@
 ---
 /content/documents/corporate-website/publication-system/lorem-ipsum-content/nullam-vel-ligula-dapibus:
   /nullam-vel-ligula-dapibus[1]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability: []
@@ -26,12 +20,12 @@
     - mix:referenceable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Vivamus eros ipsum, facilisis vitae orci sit amet,
       viverra commodo sem. Phasellus commodo turpis non ultrices feugiat. Proin non
@@ -42,12 +36,6 @@
       eget, tempor sit amet ante.
     publicationsystem:Title: Nullam vel ligula dapibus
   /nullam-vel-ligula-dapibus[2]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability:
@@ -69,12 +57,12 @@
     - mix:versionable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Vivamus eros ipsum, facilisis vitae orci sit amet,
       viverra commodo sem. Phasellus commodo turpis non ultrices feugiat. Proin non
@@ -85,12 +73,6 @@
       eget, tempor sit amet ante.
     publicationsystem:Title: Nullam vel ligula dapibus
   /nullam-vel-ligula-dapibus[3]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability:
@@ -112,12 +94,12 @@
     - mix:referenceable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Vivamus eros ipsum, facilisis vitae orci sit amet,
       viverra commodo sem. Phasellus commodo turpis non ultrices feugiat. Proin non

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/nunc-tempus-ante-nec.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/nunc-tempus-ante-nec.yaml
@@ -1,12 +1,6 @@
 ---
 /content/documents/corporate-website/publication-system/lorem-ipsum-content/nunc-tempus-ante-nec:
   /nunc-tempus-ante-nec[1]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability: []
@@ -25,14 +19,14 @@
     - mix:referenceable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: Quisque fermentum eros turpis, non laoreet lacus tempus
       quis. Donec eget orci at massa egestas cursus. Duis at diam et eros fringilla
       porta.
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Aenean dictum et diam sit amet egestas. Nullam ultrices,
       lacus vel pretium bibendum, erat metus gravida quam, id elementum urna sapien
@@ -44,12 +38,6 @@
       turpis eros.
     publicationsystem:Title: Nunc tempus ante nec
   /nunc-tempus-ante-nec[2]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability:
@@ -70,14 +58,14 @@
     - mix:versionable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: Quisque fermentum eros turpis, non laoreet lacus tempus
       quis. Donec eget orci at massa egestas cursus. Duis at diam et eros fringilla
       porta.
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Aenean dictum et diam sit amet egestas. Nullam ultrices,
       lacus vel pretium bibendum, erat metus gravida quam, id elementum urna sapien
@@ -89,12 +77,6 @@
       turpis eros.
     publicationsystem:Title: Nunc tempus ante nec
   /nunc-tempus-ante-nec[3]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability:
@@ -115,14 +97,14 @@
     - mix:referenceable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: Quisque fermentum eros turpis, non laoreet lacus tempus
       quis. Donec eget orci at massa egestas cursus. Duis at diam et eros fringilla
       porta.
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Aenean dictum et diam sit amet egestas. Nullam ultrices,
       lacus vel pretium bibendum, erat metus gravida quam, id elementum urna sapien

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-elementum-justo-eu-tortor.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-elementum-justo-eu-tortor.yaml
@@ -1,12 +1,6 @@
 ---
 /content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-elementum-justo-eu-tortor:
   /proin-elementum-justo-eu-tortor[1]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability: []
@@ -25,12 +19,12 @@
     - mix:referenceable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Suspendisse pellentesque, purus nec fermentum vulputate,
       lorem metus interdum dolor, eget facilisis lacus ligula sed dui. Praesent facilisis
@@ -40,12 +34,6 @@
       id orci eu sem vehicula interdum vitae vitae diam.
     publicationsystem:Title: Proin elementum justo eu tortor
   /proin-elementum-justo-eu-tortor[2]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability:
@@ -66,12 +54,12 @@
     - mix:versionable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Suspendisse pellentesque, purus nec fermentum vulputate,
       lorem metus interdum dolor, eget facilisis lacus ligula sed dui. Praesent facilisis
@@ -81,12 +69,6 @@
       id orci eu sem vehicula interdum vitae vitae diam.
     publicationsystem:Title: Proin elementum justo eu tortor
   /proin-elementum-justo-eu-tortor[3]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability:
@@ -107,12 +89,12 @@
     - mix:referenceable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Suspendisse pellentesque, purus nec fermentum vulputate,
       lorem metus interdum dolor, eget facilisis lacus ligula sed dui. Praesent facilisis

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-nec-justo.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-nec-justo.yaml
@@ -1,12 +1,6 @@
 ---
 /content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-nec-justo:
   /proin-nec-justo[1]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability: []
@@ -25,12 +19,12 @@
     - mix:referenceable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Nulla eu augue eros. Maecenas ultrices tempus placerat.
       Phasellus commodo nulla in gravida pretium. Donec justo magna, vehicula tristique
@@ -44,12 +38,6 @@
       ligula ac elit efficitur viverra eu quis libero.
     publicationsystem:Title: Proin nec justo
   /proin-nec-justo[2]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability:
@@ -71,12 +59,12 @@
     - mix:versionable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Nulla eu augue eros. Maecenas ultrices tempus placerat.
       Phasellus commodo nulla in gravida pretium. Donec justo magna, vehicula tristique
@@ -90,12 +78,6 @@
       ligula ac elit efficitur viverra eu quis libero.
     publicationsystem:Title: Proin nec justo
   /proin-nec-justo[3]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability:
@@ -117,12 +99,12 @@
     - mix:referenceable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: Nulla eu augue eros. Maecenas ultrices tempus placerat.
       Phasellus commodo nulla in gravida pretium. Donec justo magna, vehicula tristique

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/loremimsumdolor.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/loremimsumdolor.yaml
@@ -1,12 +1,6 @@
 ---
 /content/documents/corporate-website/publication-system/search-test-loremipsumdolor/loremipsumdolor:
   /loremipsumdolor[1]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability: []
@@ -26,22 +20,16 @@
     - mix:referenceable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: ''
     publicationsystem:Title: loremipsumdolor
   /loremipsumdolor[2]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability:
@@ -63,22 +51,16 @@
     - mix:versionable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: ''
     publicationsystem:Title: loremipsumdolor
   /loremipsumdolor[3]:
-    /publicationsystem:RelatedLinks:
-      jcr:primaryType: publicationsystem:relatedlink
-      publicationsystem:linkText: ''
-      publicationsystem:linkUrl: ''
-      publicationsystem:link_text: ''
-      publicationsystem:link_url: ''
     common:FacetType: publication
     common:searchable: true
     hippo:availability:
@@ -100,12 +82,12 @@
     - mix:referenceable
     jcr:primaryType: publicationsystem:publication
     publicationsystem:AdministrativeSources: ''
-    publicationsystem:CoverageEnd: 2017-04-01T08:00:00Z
-    publicationsystem:CoverageStart: 2017-01-01T08:00:00Z
+    publicationsystem:CoverageEnd: 2017-04-01T00:00:00Z
+    publicationsystem:CoverageStart: 2017-01-01T00:00:00Z
     publicationsystem:InformationType:
     - Official statistics
     publicationsystem:KeyFacts: ''
-    publicationsystem:NominalDate: 2017-06-01T08:30:00Z
+    publicationsystem:NominalDate: 2017-06-01T00:00:00Z
     publicationsystem:PubliclyAccessible: true
     publicationsystem:Summary: ''
     publicationsystem:Title: loremipsumdolor


### PR DESCRIPTION
Fix bug whereby for non-admin users, validation didnt fire upon
leaving a blank attachment field or when uploading file types
which are prohibited.

Also corrected issue with test data coverage start and end date times,
which are now defaulted to midnight since user cannot select time.