### PR TITLE
[NIL-96] NIL landing page content

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary.cnd
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary.cnd
@@ -5,6 +5,9 @@
 <'common'='http://digital.nhs.uk/jcr/common/nt/1.0'>
 <'hippotranslation'='http://www.onehippo.org/jcr/hippotranslation/nt/1.0'>
 
+[nationalindicatorlibrary:actionlink] > hippo:compound, hippostd:relaxed
+  orderable
+
 [nationalindicatorlibrary:basedocument] > hippo:document, hippostd:publishableSummary, hippostdpubwf:document
   orderable
   - common:searchable (boolean) = 'true' autocreated
@@ -13,5 +16,11 @@
   orderable
 
 [nationalindicatorlibrary:nihub] > hippostd:relaxed, hippotranslation:translated, nationalindicatorlibrary:basedocument
+  orderable
+
+[nationalindicatorlibrary:nihublink] > hippo:compound, hippostd:relaxed
+  orderable
+
+[nationalindicatorlibrary:nilanding] > hippostd:relaxed, hippotranslation:translated, nationalindicatorlibrary:basedocument
   orderable
 

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/actionlink.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/actionlink.yaml
@@ -1,0 +1,86 @@
+---
+definitions:
+  config:
+    /hippo:namespaces/nationalindicatorlibrary/actionlink:
+      /editor:templates:
+        /_default_:
+          jcr:primaryType: frontend:plugincluster
+          frontend:properties:
+          - mode
+          frontend:references:
+          - wicket.model
+          - model.compareTo
+          - engine
+          - validator.id
+          frontend:services:
+          - wicket.id
+          - validator.id
+          /root:
+            item: ${cluster.id}.field
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+          /actionLinkTitle:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Action Link Title
+            field: linktitle
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /actionLinkUrl:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Relative Link URL
+            field: linkurl
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+        jcr:primaryType: editor:templateset
+      /hipposysedit:nodetype:
+        /hipposysedit:nodetype:
+          /linktitle:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:actionLinkTitle
+            hipposysedit:primary: false
+            hipposysedit:type: String
+            hipposysedit:validators:
+            - non-empty
+            - required
+            jcr:primaryType: hipposysedit:field
+          /linkurl:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:actionLinkUrl
+            hipposysedit:primary: false
+            hipposysedit:type: String
+            hipposysedit:validators:
+            - non-empty
+            - required
+            jcr:primaryType: hipposysedit:field
+          hipposysedit:node: true
+          hipposysedit:supertype:
+          - hippo:compound
+          - hippostd:relaxed
+          hipposysedit:uri: http://digital.nhs.uk/jcr/nationalindicatorlibrary/nt/1.0
+          jcr:mixinTypes:
+          - mix:referenceable
+          - hipposysedit:remodel
+          jcr:primaryType: hipposysedit:nodetype
+        jcr:mixinTypes:
+        - mix:referenceable
+        jcr:primaryType: hippo:handle
+      /hipposysedit:prototypes:
+        /hipposysedit:prototype:
+          jcr:primaryType: nationalindicatorlibrary:actionlink
+          nationalindicatorlibrary:actionLinkTitle: ''
+          nationalindicatorlibrary:actionLinkUrl: ''
+        jcr:primaryType: hipposysedit:prototypeset
+      jcr:mixinTypes:
+      - editor:editable
+      - mix:referenceable
+      jcr:primaryType: hipposysedit:templatetype

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/nihublink.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/nihublink.yaml
@@ -1,7 +1,7 @@
 ---
 definitions:
   config:
-    /hippo:namespaces/nationalindicatorlibrary/nihub:
+    /hippo:namespaces/nationalindicatorlibrary/nihublink:
       /editor:templates:
         /_default_:
           jcr:primaryType: frontend:plugincluster
@@ -24,7 +24,6 @@ definitions:
               jcr:primaryType: frontend:pluginconfig
             caption: Title
             field: title
-            hint: ''
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
@@ -33,24 +32,16 @@ definitions:
               jcr:primaryType: frontend:pluginconfig
             caption: Summary
             field: summary
-            hint: ''
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
-          /populateTopicLinks:
+          /pagelink:
             /cluster.options:
+              base.path: /content/documents/corporate-website/national-indicator-library/nihub
               jcr:primaryType: frontend:pluginconfig
-            caption: Popular Topics
-            field: populateTopicLinks
-            hint: ''
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
-            wicket.id: ${cluster.id}.field
-          /nihublink:
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-            caption: National Indicator hub links
-            field: nihublink
+              nodetypes: []
+            caption: Landing page link
+            field: pagelink
             hint: ''
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
@@ -58,21 +49,15 @@ definitions:
         jcr:primaryType: editor:templateset
       /hipposysedit:nodetype:
         /hipposysedit:nodetype:
-          /nihublink:
+          /pagelink:
             hipposysedit:mandatory: false
-            hipposysedit:multiple: true
-            hipposysedit:ordered: true
-            hipposysedit:path: nationalindicatorlibrary:nihublink
-            hipposysedit:primary: false
-            hipposysedit:type: nationalindicatorlibrary:nihublink
-            jcr:primaryType: hipposysedit:field
-          /populateTopicLinks:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: true
+            hipposysedit:multiple: false
             hipposysedit:ordered: false
-            hipposysedit:path: nationalindicatorlibrary:populateTopicLinks
+            hipposysedit:path: nationalindicatorlibrary:pagelink
             hipposysedit:primary: false
-            hipposysedit:type: nationalindicatorlibrary:actionlink
+            hipposysedit:type: hippo:mirror
+            hipposysedit:validators:
+            - required
             jcr:primaryType: hipposysedit:field
           /summary:
             hipposysedit:mandatory: false
@@ -80,7 +65,7 @@ definitions:
             hipposysedit:ordered: false
             hipposysedit:path: nationalindicatorlibrary:summary
             hipposysedit:primary: false
-            hipposysedit:type: String
+            hipposysedit:type: Text
             hipposysedit:validators:
             - non-empty
             - required
@@ -98,9 +83,8 @@ definitions:
             jcr:primaryType: hipposysedit:field
           hipposysedit:node: true
           hipposysedit:supertype:
-          - nationalindicatorlibrary:basedocument
+          - hippo:compound
           - hippostd:relaxed
-          - hippotranslation:translated
           hipposysedit:uri: http://digital.nhs.uk/jcr/nationalindicatorlibrary/nt/1.0
           jcr:mixinTypes:
           - mix:referenceable
@@ -111,22 +95,10 @@ definitions:
         jcr:primaryType: hippo:handle
       /hipposysedit:prototypes:
         /hipposysedit:prototype:
-          /nationalindicatorlibrary:populateTopicLinks:
-            jcr:primaryType: nationalindicatorlibrary:actionlink
-            nationalindicatorlibrary:actionLinkTitle: ''
-            nationalindicatorlibrary:actionLinkUrl: ''
-          common:searchable: true
-          hippostd:holder: holder
-          hippostd:state: draft
-          hippostdpubwf:createdBy: ''
-          hippostdpubwf:creationDate: 2018-02-13T13:56:11.446Z
-          hippostdpubwf:lastModificationDate: 2018-02-13T13:56:11.446Z
-          hippostdpubwf:lastModifiedBy: ''
-          hippotranslation:id: document-type-locale-id
-          hippotranslation:locale: document-type-locale
-          jcr:mixinTypes:
-          - mix:referenceable
-          jcr:primaryType: nationalindicatorlibrary:nihub
+          /nationalindicatorlibrary:pagelink:
+            hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+            jcr:primaryType: hippo:mirror
+          jcr:primaryType: nationalindicatorlibrary:nihublink
           nationalindicatorlibrary:summary: ''
           nationalindicatorlibrary:title: ''
         jcr:primaryType: hipposysedit:prototypeset

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/nilanding.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/nilanding.yaml
@@ -1,7 +1,7 @@
 ---
 definitions:
   config:
-    /hippo:namespaces/nationalindicatorlibrary/nihub:
+    /hippo:namespaces/nationalindicatorlibrary/nilanding:
       /editor:templates:
         /_default_:
           jcr:primaryType: frontend:plugincluster
@@ -24,66 +24,28 @@ definitions:
               jcr:primaryType: frontend:pluginconfig
             caption: Title
             field: title
-            hint: ''
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
-          /summary:
+          /content:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-            caption: Summary
-            field: summary
+            caption: Content
+            field: content
             hint: ''
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.field
-          /populateTopicLinks:
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-            caption: Popular Topics
-            field: populateTopicLinks
-            hint: ''
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
-            wicket.id: ${cluster.id}.field
-          /nihublink:
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-            caption: National Indicator hub links
-            field: nihublink
-            hint: ''
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
             wicket.id: ${cluster.id}.field
         jcr:primaryType: editor:templateset
       /hipposysedit:nodetype:
         /hipposysedit:nodetype:
-          /nihublink:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: true
-            hipposysedit:ordered: true
-            hipposysedit:path: nationalindicatorlibrary:nihublink
-            hipposysedit:primary: false
-            hipposysedit:type: nationalindicatorlibrary:nihublink
-            jcr:primaryType: hipposysedit:field
-          /populateTopicLinks:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: true
-            hipposysedit:ordered: false
-            hipposysedit:path: nationalindicatorlibrary:populateTopicLinks
-            hipposysedit:primary: false
-            hipposysedit:type: nationalindicatorlibrary:actionlink
-            jcr:primaryType: hipposysedit:field
-          /summary:
+          /content:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
             hipposysedit:ordered: false
-            hipposysedit:path: nationalindicatorlibrary:summary
+            hipposysedit:path: nationalindicatorlibrary:content
             hipposysedit:primary: false
-            hipposysedit:type: String
-            hipposysedit:validators:
-            - non-empty
-            - required
+            hipposysedit:type: Html
             jcr:primaryType: hipposysedit:field
           /title:
             hipposysedit:mandatory: false
@@ -111,23 +73,19 @@ definitions:
         jcr:primaryType: hippo:handle
       /hipposysedit:prototypes:
         /hipposysedit:prototype:
-          /nationalindicatorlibrary:populateTopicLinks:
-            jcr:primaryType: nationalindicatorlibrary:actionlink
-            nationalindicatorlibrary:actionLinkTitle: ''
-            nationalindicatorlibrary:actionLinkUrl: ''
           common:searchable: true
           hippostd:holder: holder
           hippostd:state: draft
           hippostdpubwf:createdBy: ''
-          hippostdpubwf:creationDate: 2018-02-13T13:56:11.446Z
-          hippostdpubwf:lastModificationDate: 2018-02-13T13:56:11.446Z
+          hippostdpubwf:creationDate: 2018-02-20T09:13:04.762Z
+          hippostdpubwf:lastModificationDate: 2018-02-20T09:13:04.762Z
           hippostdpubwf:lastModifiedBy: ''
           hippotranslation:id: document-type-locale-id
           hippotranslation:locale: document-type-locale
           jcr:mixinTypes:
           - mix:referenceable
-          jcr:primaryType: nationalindicatorlibrary:nihub
-          nationalindicatorlibrary:summary: ''
+          jcr:primaryType: nationalindicatorlibrary:nilanding
+          nationalindicatorlibrary:content: ''
           nationalindicatorlibrary:title: ''
         jcr:primaryType: hipposysedit:prototypeset
       jcr:mixinTypes:

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/national-indicator-library/headers.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/national-indicator-library/headers.yaml
@@ -51,6 +51,9 @@
     - headers.numerator
     - headers.denominator
     - headers.calculation
+    - headers.popularTopics
+    - headers.topicsAZ
+    - headers.indicatorsAndAssurance
     resourcebundle:messages:
     - Assurance Date
     - Based on data from
@@ -71,6 +74,9 @@
     - Numerator
     - Denominator
     - Calculation
+    - Popular indicator topics
+    - Indicator topics A-Z
+    - Indicators and assurance
   /headers[2]:
     hippo:availability:
     - preview
@@ -124,6 +130,9 @@
     - headers.numerator
     - headers.denominator
     - headers.calculation
+    - headers.popularTopics
+    - headers.topicsAZ
+    - headers.indicatorsAndAssurance
     resourcebundle:messages:
     - Assurance Date
     - Based on data from
@@ -144,6 +153,9 @@
     - Numerator
     - Denominator
     - Calculation
+    - Popular indicator topics
+    - Indicator topics A-Z
+    - Indicators and assurance
   /headers[3]:
     hippo:availability:
     - live
@@ -197,6 +209,9 @@
     - headers.numerator
     - headers.denominator
     - headers.calculation
+    - headers.popularTopics
+    - headers.topicsAZ
+    - headers.indicatorsAndAssurance
     resourcebundle:messages:
     - Assurance Date
     - Based on data from
@@ -217,6 +232,9 @@
     - Numerator
     - Denominator
     - Calculation
+    - Popular indicator topics
+    - Indicator topics A-Z
+    - Indicators and assurance
   hippo:name: Headers
   jcr:mixinTypes:
   - hippo:named

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/add.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/add.yaml
@@ -1,0 +1,59 @@
+---
+/content/documents/corporate-website/national-indicator-library/add:
+  /add[1]:
+    common:searchable: true
+    hippo:availability: []
+    hippostd:state: draft
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-02-20T09:22:42.456Z
+    hippostdpubwf:lastModificationDate: 2018-02-20T09:22:42.457Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: 6f24af63-b255-4cdc-a308-94b512347e7e
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: nationalindicatorlibrary:nilanding
+    nationalindicatorlibrary:content: <p>Tell us about your indicator, to have it
+      added to the National Indicator Library</p>
+    nationalindicatorlibrary:title: Add your indicator to the library
+  /add[2]:
+    common:searchable: true
+    hippo:availability:
+    - preview
+    hippostd:state: unpublished
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-02-20T09:22:42.456Z
+    hippostdpubwf:lastModificationDate: 2018-02-20T09:22:57.115Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: 6f24af63-b255-4cdc-a308-94b512347e7e
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: nationalindicatorlibrary:nilanding
+    nationalindicatorlibrary:content: <p>Tell us about your indicator, to have it
+      added to the National Indicator Library</p>
+    nationalindicatorlibrary:title: Add your indicator to the library
+  /add[3]:
+    common:searchable: true
+    hippo:availability:
+    - live
+    hippostd:state: published
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-02-20T09:22:42.456Z
+    hippostdpubwf:lastModificationDate: 2018-02-20T09:22:57.115Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippostdpubwf:publicationDate: 2018-02-20T09:23:00.221Z
+    hippotranslation:id: 6f24af63-b255-4cdc-a308-94b512347e7e
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: nationalindicatorlibrary:nilanding
+    nationalindicatorlibrary:content: <p>Tell us about your indicator, to have it
+      added to the National Indicator Library</p>
+    nationalindicatorlibrary:title: Add your indicator to the library
+  hippo:name: add
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/advice.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/advice.yaml
@@ -1,0 +1,83 @@
+---
+/content/documents/corporate-website/national-indicator-library/advice:
+  /advice[1]:
+    common:searchable: true
+    hippo:availability: []
+    hippostd:state: draft
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-02-20T09:16:21.247Z
+    hippostdpubwf:lastModificationDate: 2018-02-20T09:16:21.247Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: 0651891e-d82f-42e5-85d3-a8a730b63028
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: nationalindicatorlibrary:nilanding
+    nationalindicatorlibrary:content: |-
+      <p>If you need a steer as an indicator developer, tell us your problem and we can help you.</p>
+
+      <p>&nbsp;</p>
+
+      <p>Complete for the form and email to:&nbsp;nhsdigital.imas@nhs.net</p>
+
+      <p>&nbsp;</p>
+
+      <p>You will hear back from us in 5 working days</p>
+    nationalindicatorlibrary:title: Get advice for how to develop an indicator
+  /advice[2]:
+    common:searchable: true
+    hippo:availability:
+    - preview
+    hippostd:state: unpublished
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-02-20T09:16:21.247Z
+    hippostdpubwf:lastModificationDate: 2018-02-20T09:19:38.992Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: 0651891e-d82f-42e5-85d3-a8a730b63028
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: nationalindicatorlibrary:nilanding
+    nationalindicatorlibrary:content: |-
+      <p>If you need a steer as an indicator developer, tell us your problem and we can help you.</p>
+
+      <p>&nbsp;</p>
+
+      <p>Complete for the form and email to:&nbsp;nhsdigital.imas@nhs.net</p>
+
+      <p>&nbsp;</p>
+
+      <p>You will hear back from us in 5 working days</p>
+    nationalindicatorlibrary:title: Get advice for how to develop an indicator
+  /advice[3]:
+    common:searchable: true
+    hippo:availability:
+    - live
+    hippostd:state: published
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-02-20T09:16:21.247Z
+    hippostdpubwf:lastModificationDate: 2018-02-20T09:19:38.992Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippostdpubwf:publicationDate: 2018-02-20T09:19:45.040Z
+    hippotranslation:id: 0651891e-d82f-42e5-85d3-a8a730b63028
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: nationalindicatorlibrary:nilanding
+    nationalindicatorlibrary:content: |-
+      <p>If you need a steer as an indicator developer, tell us your problem and we can help you.</p>
+
+      <p>&nbsp;</p>
+
+      <p>Complete for the form and email to:&nbsp;nhsdigital.imas@nhs.net</p>
+
+      <p>&nbsp;</p>
+
+      <p>You will hear back from us in 5 working days</p>
+    nationalindicatorlibrary:title: Get advice for how to develop an indicator
+  hippo:name: advice
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/apply.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/apply.yaml
@@ -1,0 +1,71 @@
+---
+/content/documents/corporate-website/national-indicator-library/apply:
+  /apply[1]:
+    common:searchable: true
+    hippo:availability: []
+    hippostd:state: draft
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-02-20T09:23:22.530Z
+    hippostdpubwf:lastModificationDate: 2018-02-20T09:23:22.530Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: 0fed32d0-d693-42bf-900a-8e99f5ecfee0
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: nationalindicatorlibrary:nilanding
+    nationalindicatorlibrary:content: |-
+      <p>Use this service to:</p>
+
+      <p>- allow health and social care experts to review and approve your indicator's methodology</p>
+
+      <p>- show how your indicator is constructed, so that others can develop indicators too</p>
+    nationalindicatorlibrary:title: Apply to have to have you indicator assured
+  /apply[2]:
+    common:searchable: true
+    hippo:availability:
+    - preview
+    hippostd:state: unpublished
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-02-20T09:23:22.530Z
+    hippostdpubwf:lastModificationDate: 2018-02-20T09:24:29.477Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: 0fed32d0-d693-42bf-900a-8e99f5ecfee0
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: nationalindicatorlibrary:nilanding
+    nationalindicatorlibrary:content: |-
+      <p>Use this service to:</p>
+
+      <p>- allow health and social care experts to review and approve your indicator's methodology</p>
+
+      <p>- show how your indicator is constructed, so that others can develop indicators too</p>
+    nationalindicatorlibrary:title: Apply to have to have you indicator assured
+  /apply[3]:
+    common:searchable: true
+    hippo:availability:
+    - live
+    hippostd:state: published
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-02-20T09:23:22.530Z
+    hippostdpubwf:lastModificationDate: 2018-02-20T09:24:29.477Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippostdpubwf:publicationDate: 2018-02-20T09:24:33.165Z
+    hippotranslation:id: 0fed32d0-d693-42bf-900a-8e99f5ecfee0
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: nationalindicatorlibrary:nilanding
+    nationalindicatorlibrary:content: |-
+      <p>Use this service to:</p>
+
+      <p>- allow health and social care experts to review and approve your indicator's methodology</p>
+
+      <p>- show how your indicator is constructed, so that others can develop indicators too</p>
+    nationalindicatorlibrary:title: Apply to have to have you indicator assured
+  hippo:name: apply
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/nihub.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/nihub.yaml
@@ -1,56 +1,239 @@
 ---
 /content/documents/corporate-website/national-indicator-library/nihub:
   /nihub[1]:
+    /nationalindicatorlibrary:nihublink[1]:
+      /nationalindicatorlibrary:pagelink:
+        hippo:docbase: f9d31602-6aaf-4098-b883-4878429cff17
+        jcr:primaryType: hippo:mirror
+      jcr:primaryType: nationalindicatorlibrary:nihublink
+      nationalindicatorlibrary:summary: Get advice from our health and social care
+        experts, on how to develop good quality indicators.
+      nationalindicatorlibrary:title: Advice from our experts
+    /nationalindicatorlibrary:nihublink[2]:
+      /nationalindicatorlibrary:pagelink:
+        hippo:docbase: 6e26182c-2fac-405d-bfb5-d836ac030255
+        jcr:primaryType: hippo:mirror
+      jcr:primaryType: nationalindicatorlibrary:nihublink
+      nationalindicatorlibrary:summary: Add an indicator to the library, from your
+        health or social care organisation.
+      nationalindicatorlibrary:title: Add your indicator to the library
+    /nationalindicatorlibrary:nihublink[3]:
+      /nationalindicatorlibrary:pagelink:
+        hippo:docbase: 4a58887d-6125-4808-a7f2-e998f9e171e8
+        jcr:primaryType: hippo:mirror
+      jcr:primaryType: nationalindicatorlibrary:nihublink
+      nationalindicatorlibrary:summary: Apply to have your indicator's methodology
+        independently assured by industry experts.
+      nationalindicatorlibrary:title: Apply for independent assurance
+    /nationalindicatorlibrary:populateTopicLinks[1]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Accidents and emergencies
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/accident-and-emergency
+    /nationalindicatorlibrary:populateTopicLinks[2]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Mental health
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/mental-health
+    /nationalindicatorlibrary:populateTopicLinks[3]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Autism
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/autistic-spectrum
+    /nationalindicatorlibrary:populateTopicLinks[4]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Mortality
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/mortality-and-death
+    /nationalindicatorlibrary:populateTopicLinks[5]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Cancer
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/cancer
+    /nationalindicatorlibrary:populateTopicLinks[6]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Pregnancy
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/pregnancy
+    /nationalindicatorlibrary:populateTopicLinks[7]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Child health
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/child-development
+    /nationalindicatorlibrary:populateTopicLinks[8]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Population health
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/population
+    /nationalindicatorlibrary:populateTopicLinks[9]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Diabetes
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/diabetes
     common:searchable: true
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2018-02-13T14:27:19.616Z
-    hippostdpubwf:lastModificationDate: 2018-02-14T13:18:56.235Z
+    hippostdpubwf:creationDate: 2018-02-19T14:04:05.264Z
+    hippostdpubwf:lastModificationDate: 2018-02-21T14:06:39.349Z
     hippostdpubwf:lastModifiedBy: admin
-    hippotranslation:id: 14bca618-b33b-4e45-a102-57e0aa6218a0
+    hippotranslation:id: cc1f9325-d13d-4864-963d-7058e02362be
     hippotranslation:locale: en
     jcr:mixinTypes:
     - mix:referenceable
     jcr:primaryType: nationalindicatorlibrary:nihub
+    jcr:uuid: 9f385787-ebe8-4b15-937d-40f7bea88887
     nationalindicatorlibrary:summary: The official hub for health and social care
       indicators in England. Includes methodology, data output and any independent
       assurance rating.
     nationalindicatorlibrary:title: National Indicator Library
   /nihub[2]:
+    /nationalindicatorlibrary:nihublink[1]:
+      /nationalindicatorlibrary:pagelink:
+        hippo:docbase: f9d31602-6aaf-4098-b883-4878429cff17
+        jcr:primaryType: hippo:mirror
+      jcr:primaryType: nationalindicatorlibrary:nihublink
+      nationalindicatorlibrary:summary: Get advice from our health and social care
+        experts, on how to develop good quality indicators.
+      nationalindicatorlibrary:title: Advice from our experts
+    /nationalindicatorlibrary:nihublink[2]:
+      /nationalindicatorlibrary:pagelink:
+        hippo:docbase: 6e26182c-2fac-405d-bfb5-d836ac030255
+        jcr:primaryType: hippo:mirror
+      jcr:primaryType: nationalindicatorlibrary:nihublink
+      nationalindicatorlibrary:summary: Add an indicator to the library, from your
+        health or social care organisation.
+      nationalindicatorlibrary:title: Add your indicator to the library
+    /nationalindicatorlibrary:nihublink[3]:
+      /nationalindicatorlibrary:pagelink:
+        hippo:docbase: 4a58887d-6125-4808-a7f2-e998f9e171e8
+        jcr:primaryType: hippo:mirror
+      jcr:primaryType: nationalindicatorlibrary:nihublink
+      nationalindicatorlibrary:summary: Apply to have your indicator's methodology
+        independently assured by industry experts.
+      nationalindicatorlibrary:title: Apply for independent assurance
+    /nationalindicatorlibrary:populateTopicLinks[1]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Accidents and emergencies
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/accident-and-emergency
+    /nationalindicatorlibrary:populateTopicLinks[2]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Mental health
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/mental-health
+    /nationalindicatorlibrary:populateTopicLinks[3]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Autism
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/autistic-spectrum
+    /nationalindicatorlibrary:populateTopicLinks[4]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Mortality
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/mortality-and-death
+    /nationalindicatorlibrary:populateTopicLinks[5]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Cancer
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/cancer
+    /nationalindicatorlibrary:populateTopicLinks[6]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Pregnancy
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/pregnancy
+    /nationalindicatorlibrary:populateTopicLinks[7]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Child health
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/child-development
+    /nationalindicatorlibrary:populateTopicLinks[8]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Population health
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/population
+    /nationalindicatorlibrary:populateTopicLinks[9]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Diabetes
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/diabetes
     common:searchable: true
     hippo:availability:
     - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2018-02-13T14:27:19.616Z
-    hippostdpubwf:lastModificationDate: 2018-02-14T13:18:59.799Z
+    hippostdpubwf:creationDate: 2018-02-19T14:04:05.264Z
+    hippostdpubwf:lastModificationDate: 2018-02-21T14:07:09.079Z
     hippostdpubwf:lastModifiedBy: admin
-    hippotranslation:id: 14bca618-b33b-4e45-a102-57e0aa6218a0
+    hippotranslation:id: cc1f9325-d13d-4864-963d-7058e02362be
     hippotranslation:locale: en
     jcr:mixinTypes:
     - mix:referenceable
     - mix:versionable
     jcr:primaryType: nationalindicatorlibrary:nihub
+    jcr:uuid: d0b3fd9d-d7ac-4aab-b4cb-28b719ba9e08
     nationalindicatorlibrary:summary: The official hub for health and social care
       indicators in England. Includes methodology, data output and any independent
       assurance rating.
     nationalindicatorlibrary:title: National Indicator Library
   /nihub[3]:
+    /nationalindicatorlibrary:nihublink[1]:
+      /nationalindicatorlibrary:pagelink:
+        hippo:docbase: f9d31602-6aaf-4098-b883-4878429cff17
+        jcr:primaryType: hippo:mirror
+      jcr:primaryType: nationalindicatorlibrary:nihublink
+      nationalindicatorlibrary:summary: Get advice from our health and social care
+        experts, on how to develop good quality indicators.
+      nationalindicatorlibrary:title: Advice from our experts
+    /nationalindicatorlibrary:nihublink[2]:
+      /nationalindicatorlibrary:pagelink:
+        hippo:docbase: 6e26182c-2fac-405d-bfb5-d836ac030255
+        jcr:primaryType: hippo:mirror
+      jcr:primaryType: nationalindicatorlibrary:nihublink
+      nationalindicatorlibrary:summary: Add an indicator to the library, from your
+        health or social care organisation.
+      nationalindicatorlibrary:title: Add your indicator to the library
+    /nationalindicatorlibrary:nihublink[3]:
+      /nationalindicatorlibrary:pagelink:
+        hippo:docbase: 4a58887d-6125-4808-a7f2-e998f9e171e8
+        jcr:primaryType: hippo:mirror
+      jcr:primaryType: nationalindicatorlibrary:nihublink
+      nationalindicatorlibrary:summary: Apply to have your indicator's methodology
+        independently assured by industry experts.
+      nationalindicatorlibrary:title: Apply for independent assurance
+    /nationalindicatorlibrary:populateTopicLinks[1]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Accidents and emergencies
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/accident-and-emergency
+    /nationalindicatorlibrary:populateTopicLinks[2]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Mental health
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/mental-health
+    /nationalindicatorlibrary:populateTopicLinks[3]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Autism
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/autistic-spectrum
+    /nationalindicatorlibrary:populateTopicLinks[4]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Mortality
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/mortality-and-death
+    /nationalindicatorlibrary:populateTopicLinks[5]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Cancer
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/cancer
+    /nationalindicatorlibrary:populateTopicLinks[6]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Pregnancy
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/pregnancy
+    /nationalindicatorlibrary:populateTopicLinks[7]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Child health
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/child-development
+    /nationalindicatorlibrary:populateTopicLinks[8]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Population health
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/population
+    /nationalindicatorlibrary:populateTopicLinks[9]:
+      jcr:primaryType: nationalindicatorlibrary:actionlink
+      nationalindicatorlibrary:actionLinkTitle: Diabetes
+      nationalindicatorlibrary:actionLinkUrl: ../search/document-type/indicator/category/diabetes
     common:searchable: true
     hippo:availability:
     - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2018-02-13T14:27:19.616Z
-    hippostdpubwf:lastModificationDate: 2018-02-14T13:18:59.799Z
+    hippostdpubwf:creationDate: 2018-02-19T14:04:05.264Z
+    hippostdpubwf:lastModificationDate: 2018-02-21T14:07:09.079Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2018-02-14T13:19:03.225Z
-    hippotranslation:id: 14bca618-b33b-4e45-a102-57e0aa6218a0
+    hippostdpubwf:publicationDate: 2018-02-21T14:07:17.847Z
+    hippotranslation:id: cc1f9325-d13d-4864-963d-7058e02362be
     hippotranslation:locale: en
     jcr:mixinTypes:
     - mix:referenceable
     jcr:primaryType: nationalindicatorlibrary:nihub
+    jcr:uuid: cad9848d-e1ac-44e4-a5e3-96841819c646
     nationalindicatorlibrary:summary: The official hub for health and social care
       indicators in England. Includes methodology, data output and any independent
       assurance rating.
@@ -60,3 +243,4 @@
   - hippo:named
   - mix:referenceable
   jcr:primaryType: hippo:handle
+  jcr:uuid: ac829abf-ad89-462d-8185-8cfa405a9e62

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/sample-indicator.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/sample-indicator.yaml
@@ -1,10 +1,10 @@
 ---
 /content/documents/corporate-website/national-indicator-library/sample-indicator:
   /sample-indicator[1]:
+    common:FacetType: indicator
     common:FullTaxonomy:
     - cancer
     - conditions
-    common:FacetType: indicator
     common:searchable: true
     hippo:availability: []
     hippostd:state: draft
@@ -90,10 +90,10 @@
     nationalindicatorlibrary:title: People with stroke admitted to an acute stroke
       unit within 4 hours of arrival at hospital
   /sample-indicator[2]:
+    common:FacetType: indicator
     common:FullTaxonomy:
     - cancer
     - conditions
-    common:FacetType: indicator
     common:searchable: true
     hippo:availability:
     - preview
@@ -181,10 +181,10 @@
     nationalindicatorlibrary:title: People with stroke admitted to an acute stroke
       unit within 4 hours of arrival at hospital
   /sample-indicator[3]:
+    common:FacetType: indicator
     common:FullTaxonomy:
     - cancer
     - conditions
-    common:FacetType: indicator
     common:searchable: true
     hippo:availability:
     - live

--- a/repository-data/development/src/main/script/YamlFormatter.groovy
+++ b/repository-data/development/src/main/script/YamlFormatter.groovy
@@ -24,7 +24,9 @@ rootDir.eachFileRecurse(FileType.DIRECTORIES) { dir ->
         // Same for ci-hub and cihublink, since referenced for page links
         boolean removeUuid = !file.getName().equals("corporate-website.yaml") &&
             !file.getName().equals("ci-hub.yaml") &&
-            !file.getName().equals("cihublink.yaml")
+            !file.getName().equals("cihublink.yaml") &&
+            !file.getName().equals("nihub.yaml") &&
+            !file.getName().equals("nihublink.yaml")
         map = format(map, removeUuid, true)
 
         // Write out the formatted yaml

--- a/repository-data/webfiles/src/main/resources/site/freemarker/nationalindicatorlibrary/nihub.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/nationalindicatorlibrary/nihub.ftl
@@ -1,8 +1,51 @@
 <#ftl output_format="HTML">
 <#include "../include/imports.ftl">
+<@hst.setBundle basename="nationalindicatorlibrary.headers"/>
+
 <section class="document-content">
     <#if document??>
         <h1 data-uipath="ps.document.title">${document.title}</h1>
         <p>${document.summary}</p>      
     </#if>
 </section>
+
+<section class="document-content">
+    <h2><@fmt.message key="headers.popularTopics"/></h1>
+    <div class="nihubSection">
+        <div class="document-content">
+            <#list document.popularTopicLinks as link>
+                <li>
+                    <a href="${link.linkUrl}" target="_blank">${link.linkText}</a>
+                </li>
+            </#list>
+        </div>
+    </div>
+</section>
+
+<section class="document-content">
+    <h2><@fmt.message key="headers.topicsAZ"/></h1>
+    <div class="nihubSection">
+        <div class="document-content">
+            <#list ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'] as x>
+                <a class="niHubAlpha" href="/indicators/search?topic=a" title="">${x}</a>
+            </#list>
+        </div>
+    </div>
+</section>
+
+<section class="document-content">
+    <h2><@fmt.message key="headers.indicatorsAndAssurance"/></h1>
+
+    <div class="nihubSection">
+            <div class="document-content">
+                <#list document.niHubLink as link><!--
+                    --><div class="layout__item layout-1-3">
+                        <@hst.link var="landingPageLink" hippobean=link.pageLink />
+                        <h3><a href="${landingPageLink}" title="${link.title}">${link.title}</a></h3>
+                        <p class="zeta">${link.summary}</p>
+                    </div><!--
+                --></#list>
+            </div>
+    </div>
+</section>
+

--- a/repository-data/webfiles/src/main/resources/site/less/style.less
+++ b/repository-data/webfiles/src/main/resources/site/less/style.less
@@ -721,3 +721,20 @@ div.breadcrumb a {
     }
 
 }
+
+/* National Indicator Library */
+/* ########################################################## */
+
+div.nihubSection {
+  border-top: 1px solid #768692;
+}
+
+.niHubAlpha {
+  text-decoration:none;
+  height:50px;
+  width:50px;
+  background-color: rgb(0, 93, 184);
+  color :white;
+  padding:10px 10px 10px 10px;
+}
+

--- a/site/src/main/java/uk/nhs/digital/nil/beans/ActionLink.java
+++ b/site/src/main/java/uk/nhs/digital/nil/beans/ActionLink.java
@@ -1,0 +1,19 @@
+package uk.nhs.digital.nil.beans;
+
+import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoCompound;
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+
+@HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:actionlink")
+@Node(jcrType = "nationalindicatorlibrary:actionlink")
+public class ActionLink extends HippoCompound {
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:actionLinkTitle")
+    public String getLinkText() {
+        return getProperty("nationalindicatorlibrary:actionLinkTitle", getLinkUrl());
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:actionLinkUrl")
+    public String getLinkUrl() {
+        return getProperty("nationalindicatorlibrary:actionLinkUrl");
+    }
+}

--- a/site/src/main/java/uk/nhs/digital/nil/beans/NiHub.java
+++ b/site/src/main/java/uk/nhs/digital/nil/beans/NiHub.java
@@ -5,6 +5,7 @@ import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerat
 
 import uk.nhs.digital.ps.beans.BaseDocument;
 
+import java.util.List;
 
 
 @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:nihub")
@@ -20,4 +21,14 @@ public class NiHub extends BaseDocument {
     public String getSummary() {
         return getProperty("nationalindicatorlibrary:summary");
     }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:populateTopicLinks")
+    public List<ActionLink> getPopularTopicLinks() {
+        return getChildBeansByName("nationalindicatorlibrary:populateTopicLinks", ActionLink.class);
+    }
+    
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:nihublink")
+    public List<NiHubLink> getNiHubLink() {
+        return getChildBeansByName("nationalindicatorlibrary:nihublink", NiHubLink.class);
+    }    
 }

--- a/site/src/main/java/uk/nhs/digital/nil/beans/NiHubLink.java
+++ b/site/src/main/java/uk/nhs/digital/nil/beans/NiHubLink.java
@@ -1,0 +1,25 @@
+package uk.nhs.digital.nil.beans;
+
+import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
+import org.hippoecm.hst.content.beans.standard.HippoCompound;
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+
+@HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:nihublink")
+@Node(jcrType = "nationalindicatorlibrary:nihublink")
+public class NiHubLink extends HippoCompound {
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:title")
+    public String getTitle() {
+        return getProperty("nationalindicatorlibrary:title");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:summary")
+    public String getSummary() {
+        return getProperty("nationalindicatorlibrary:summary");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:pagelink")
+    public HippoBean getPageLink() {
+        return getLinkedBean("nationalindicatorlibrary:pagelink", HippoBean.class);
+    }
+}

--- a/site/src/main/java/uk/nhs/digital/nil/beans/NiLanding.java
+++ b/site/src/main/java/uk/nhs/digital/nil/beans/NiLanding.java
@@ -1,0 +1,22 @@
+package uk.nhs.digital.nil.beans;
+
+import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoHtml;
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+
+import uk.nhs.digital.ps.beans.BaseDocument;
+
+@HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:nilanding")
+@Node(jcrType = "nationalindicatorlibrary:nilanding")
+public class NiLanding extends BaseDocument {
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:title")
+    public String getTitle() {
+        return getProperty("nationalindicatorlibrary:title");
+    }
+
+    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:content")
+    public HippoHtml getContent() {
+        return getHippoHtml("nationalindicatorlibrary:content");
+    }
+
+}


### PR DESCRIPTION
This change comprises of:

1) NIL "hub links" and landing pages doc types. The test instances of these are just skeletal.
2) New "action link" compound - this is to allow the configuration of multiple links within the NI hub. Similar to related link but without the protocol validation.
3) Changes to the NI hub template to support the above. The test content is a work in progress to match the evolving prototype - there will have to be a further iteration of this along with an acceptance test feature when that is signed off.

NB, I've added a few styles in to the main .less file. I'm not 100% sure where this should go.