### PR TITLE
[NIL-108] Add taxonomy to the NIL Indicator document type

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/indicator.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/indicator.yaml
@@ -181,6 +181,15 @@ definitions:
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
+          /classifiable:
+            /cluster.options:
+              caption: Taxonomy
+              jcr:primaryType: frontend:pluginconfig
+              taxonomy.name: publication_taxonomy
+            jcr:primaryType: frontend:plugin
+            mixin: hippotaxonomy:classifiable
+            plugin.class: org.hippoecm.frontend.editor.plugins.mixin.MixinLoaderPlugin
+            wicket.id: ${cluster.id}.field
         jcr:primaryType: editor:templateset
       /hipposysedit:nodetype:
         /hipposysedit:nodetype:
@@ -344,6 +353,7 @@ definitions:
           - nationalindicatorlibrary:basedocument
           - hippostd:relaxed
           - hippotranslation:translated
+          - hippotaxonomy:classifiable
           hipposysedit:uri: http://digital.nhs.uk/jcr/nationalindicatorlibrary/nt/1.0
           jcr:mixinTypes:
           - hipposysedit:remodel
@@ -365,6 +375,7 @@ definitions:
           hippotranslation:locale: document-type-locale
           jcr:mixinTypes:
           - mix:referenceable
+          - hippotaxonomy:classifiable
           jcr:primaryType: nationalindicatorlibrary:indicator
           nationalindicatorlibrary:assuranceDate: 0001-01-01T12:00:00Z
           nationalindicatorlibrary:basedOn: ''

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/sample-indicator.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/sample-indicator.yaml
@@ -1,16 +1,22 @@
 ---
 /content/documents/corporate-website/national-indicator-library/sample-indicator:
   /sample-indicator[1]:
+    common:FullTaxonomy:
+    - cancer
+    - conditions
     common:searchable: true
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-08T16:11:52.307Z
-    hippostdpubwf:lastModificationDate: 2018-02-08T16:21:00.045Z
+    hippostdpubwf:lastModificationDate: 2018-02-21T09:01:26.071Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - cancer
     hippotranslation:id: 4323bc7c-735f-41b5-91da-cc37cc8c18cd
     hippotranslation:locale: en
     jcr:mixinTypes:
+    - hippotaxonomy:classifiable
     - mix:referenceable
     jcr:primaryType: nationalindicatorlibrary:indicator
     nationalindicatorlibrary:assuranceDate: 2015-12-14T00:00:00Z
@@ -83,6 +89,9 @@
     nationalindicatorlibrary:title: People with stroke admitted to an acute stroke
       unit within 4 hours of arrival at hospital
   /sample-indicator[2]:
+    common:FullTaxonomy:
+    - cancer
+    - conditions
     common:searchable: true
     hippo:availability:
     - preview
@@ -91,9 +100,12 @@
     hippostdpubwf:creationDate: 2018-02-08T16:11:52.307Z
     hippostdpubwf:lastModificationDate: 2018-02-09T10:06:10.974Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - cancer
     hippotranslation:id: 4323bc7c-735f-41b5-91da-cc37cc8c18cd
     hippotranslation:locale: en
     jcr:mixinTypes:
+    - hippotaxonomy:classifiable
     - mix:referenceable
     - mix:versionable
     jcr:primaryType: nationalindicatorlibrary:indicator
@@ -167,6 +179,9 @@
     nationalindicatorlibrary:title: People with stroke admitted to an acute stroke
       unit within 4 hours of arrival at hospital
   /sample-indicator[3]:
+    common:FullTaxonomy:
+    - cancer
+    - conditions
     common:searchable: true
     hippo:availability:
     - live
@@ -176,9 +191,12 @@
     hippostdpubwf:lastModificationDate: 2018-02-09T10:06:10.974Z
     hippostdpubwf:lastModifiedBy: admin
     hippostdpubwf:publicationDate: 2018-02-09T10:06:13.538Z
+    hippotaxonomy:keys:
+    - cancer
     hippotranslation:id: 4323bc7c-735f-41b5-91da-cc37cc8c18cd
     hippotranslation:locale: en
     jcr:mixinTypes:
+    - hippotaxonomy:classifiable
     - mix:referenceable
     jcr:primaryType: nationalindicatorlibrary:indicator
     nationalindicatorlibrary:assuranceDate: 2015-12-14T00:00:00Z


### PR DESCRIPTION
Update the Indicator document type to be classifiable. No impact on searching yet - that will be a later PR.