### PR TITLE
[RPS-377] Fix maven transitive dependencies

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <cucumber.version>1.2.5</cucumber.version>
-        <spring.version>5.0.3.RELEASE</spring.version>
+        <spring.version>5.0.4.RELEASE</spring.version>
         <selenium.version>3.9.1</selenium.version>
     </properties>
 

--- a/conf/maven-version-rules.xml
+++ b/conf/maven-version-rules.xml
@@ -10,4 +10,12 @@
         <ignoreVersion type="regex">(?i).*CR-?.?\d*</ignoreVersion>
         <ignoreVersion type="regex">(?i).*M-?.?\d*</ignoreVersion>
     </ignoreVersions>
+    <rules>
+        <rule groupId="xml-apis" comparisonMethod="maven">
+            <ignoreVersions>
+                <!-- For reasons beyond me, 2.0 versions are actually older than 1.0 -->
+                <ignoreVersion type="regex">2\.0\..*</ignoreVersion>
+            </ignoreVersions>
+        </rule>
+    </rules>
 </ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -222,13 +222,61 @@
                 <scope>test</scope>
             </dependency>
 
+            <!-- Although we don't explicitly use these dependencys, there are conflicts
+            with these libraries in our transitive dependencies so we explicitly declare them -->
+            <dependency>
+                <groupId>xml-apis</groupId>
+                <artifactId>xml-apis</artifactId>
+                <version>1.4.01</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>1.11</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>2.9.4</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>3.0.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>4.5.5</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore</artifactId>
+                <version>4.4.9</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>3.1.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-component-annotations</artifactId>
+                <version>1.7.1</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>24.0-jre</version>
+            </dependency>
+
             <!--
                 Import Export
             -->
             <dependency>
                 <groupId>org.onehippo.forge.content-exim</groupId>
                 <artifactId>content-exim-core</artifactId>
-                <version>2.1.2</version>
+                <version>2.1.3</version>
             </dependency>
 
         </dependencies>
@@ -358,7 +406,33 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M1</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <rules>
+                        <reactorModuleConvergence/>
+                        <requireUpperBoundDeps/>
+                        <requireJavaVersion>
+                            <!-- Any Java 8 version is allowed -->
+                            <version>[1.8.0,1.8.1)</version>
+                        </requireJavaVersion>
+                        <requireMavenVersion>
+                            <!-- Any Maven 3 version is allowed -->
+                            <version>[3.0,4.0)</version>
+                        </requireMavenVersion>
+                    </rules>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Added a plugin that will enforce that the version of a dependency used
in our project is at least the version specified by any of the
transitive dependancies.

Also fixed some of the errors and added a few more useful enforcer
rules.