### PR TITLE
[RPS-391] Add Google analytics download and external link tracking

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/base-layout.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/base-layout.ftl
@@ -9,10 +9,17 @@
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-76954916-2"></script>
     <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'UA-76954916-2');
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'UA-76954916-2');
+
+        function logGoogleAnalyticsEvent(action,category,label) {
+            gtag('event', action, {
+                    'event_category': category,
+                    'event_label': label
+                });
+        }
     </script>
 
     <title>NHS Digital Website</title>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/cilanding.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/cilanding.ftl
@@ -34,7 +34,7 @@
                                         <div class="attachment media push-half--bottom">
                                             <@resourceImage file=attachment.resource.filename />
                                             <p class="media__body zeta">
-                                                <a href="<@hst.link hippobean=attachment.resource/>" title="${attachment.text}">${attachment.text}</a>
+                                                <a href="<@hst.link hippobean=attachment.resource/>" onClick="logGoogleAnalyticsEvent('Download attachment','CI landing page','${document.title} - ${attachment.resource.filename}');" title="${attachment.text}">${attachment.text}</a>;
                                                 <span class="fileSize">size: <@formatFileSize bytesCount=attachment.resource.length/></span>
                                             </p>
                                         </div>
@@ -47,7 +47,7 @@
                             <ul data-uipath="ps.cilanding.links" class="push-double--bottom">
                                 <#list section.relatedLinks as link>
                                     <@hst.link var="assetLink" hippobean=asset />
-                                    <li><a href="${link.linkUrl}" title="${link.linkText}">${link.linkText}</a></li>
+                                    <li><a href="${link.linkUrl}" onClick="logGoogleAnalyticsEvent('Link click','CI landing page','${document.title} - ${link.linkUrl}');" title="${link.linkText}">${link.linkText}</a></li>
                                 </#list>
                             </ul>
                         </#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/dataset.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/dataset.ftl
@@ -100,13 +100,13 @@
         <ul data-uipath="ps.dataset.resources">
             <#list dataset.files as attachment>
                 <li class="attachment">
-                    <a title="${attachment.text}" href="<@hst.link hippobean=attachment.resource/>">${attachment.text}</a>;
+                    <a title="${attachment.text}" href="<@hst.link hippobean=attachment.resource/>" onClick="logGoogleAnalyticsEvent('Download attachment','Data set','${attachment.resource.filename}');">${attachment.text}</a>;
                     <span class="fileSize">size: <@formatFileSize bytesCount=attachment.resource.length/></span>
                 </li>
             </#list>
             <#list dataset.resourceLinks as link>
                 <li>
-                    <a href="${link.linkUrl}">${link.linkText}</a>
+                    <a href="${link.linkUrl}" onClick="logGoogleAnalyticsEvent('Link click','Data set','${link.linkUrl}');">${link.linkText}</a>
                 </li>
             </#list>
         </ul>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/legacy-publication.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/legacy-publication.ftl
@@ -136,13 +136,13 @@
                     <ul data-uipath="ps.publication.resources">
                         <#list publication.attachments as attachment>
                             <li class="attachment">
-                                <a title="${attachment.text}" href="<@hst.link hippobean=attachment.resource/>">${attachment.text}</a>;
+                                <a title="${attachment.text}" href="<@hst.link hippobean=attachment.resource/>" onClick="logGoogleAnalyticsEvent('Download attachment','Publication','${attachment.resource.filename}');">${attachment.text}</a>;
                                 <span class="fileSize">size: <@formatFileSize bytesCount=attachment.resource.length/></span>
                             </li>
                         </#list>
                         <#list publication.resourceLinks as link>
                             <li>
-                                <a href="${link.linkUrl}">${link.linkText}</a>
+                                <a href="${link.linkUrl}" onClick="logGoogleAnalyticsEvent('Link click','Publication','${link.linkUrl}');">${link.linkText}</a>
                             </li>
                         </#list>
                         <#list publication.datasets as dataset>
@@ -156,7 +156,7 @@
                         <ul data-uipath="ps.publication.related-links">
                             <#list publication.relatedLinks as link>
                             <li>
-                                <a href="${link.linkUrl}">${link.linkText}</a>
+                                <a href="${link.linkUrl}" onClick="logGoogleAnalyticsEvent('Link click','Publication','${link.linkUrl}');">${link.linkText}</a>
                             </li>
                             </#list>
                         </ul>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
@@ -154,13 +154,13 @@
                 <ul data-uipath="ps.publication.resources">
                     <#list publication.attachments as attachment>
                         <li class="attachment">
-                            <a title="${attachment.text}" href="<@hst.link hippobean=attachment.resource/>">${attachment.text}</a>;
+                            <a title="${attachment.text}" href="<@hst.link hippobean=attachment.resource/>" onClick="logGoogleAnalyticsEvent('Download attachment','Publication','${attachment.resource.filename}');">${attachment.text}</a>;
                             <span class="fileSize">size: <@formatFileSize bytesCount=attachment.resource.length/></span>
                         </li>
                     </#list>
                     <#list publication.resourceLinks as link>
                         <li>
-                            <a href="${link.linkUrl}">${link.linkText}</a>
+                            <a href="${link.linkUrl}" onClick="logGoogleAnalyticsEvent('Link click','Publication','${link.linkUrl}');">${link.linkText}</a>
                         </li>
                     </#list>
                 </ul>
@@ -171,7 +171,7 @@
                 <ul data-uipath="ps.publication.related-links">
                     <#list publication.relatedLinks as link>
                     <li>
-                        <a href="${link.linkUrl}">${link.linkText}</a>
+                        <a href="${link.linkUrl}" onClick="logGoogleAnalyticsEvent('Link click','Publication','${link.linkUrl}');">${link.linkText}</a>
                     </li>
                     </#list>
                 </ul>


### PR DESCRIPTION
Added Google Analytics tracking events (using gtag) for download clicks
and external link clicks.  Events are displayed will in Google Analytics
dashboard under 'Behaviour > Events' or 'Real Time > Events' and grouped
into Category, Action and Label.