### PR TITLE
[NIL-99] Adds more details to indicator search results

### DIFF
--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/national-indicator-library/headers.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/national-indicator-library/headers.yaml
@@ -5,12 +5,16 @@
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-08T11:24:07.560Z
-    hippostdpubwf:lastModificationDate: 2018-02-20T14:49:38.783Z
+    hippostdpubwf:lastModificationDate: 2018-02-23T16:09:19.123Z
     hippostdpubwf:lastModifiedBy: admin
     jcr:mixinTypes:
     - mix:referenceable
     jcr:primaryType: resourcebundle:resourcebundle
     resourcebundle:descriptions:
+    - ''
+    - ''
+    - ''
+    - ''
     - ''
     - ''
     - ''
@@ -54,6 +58,7 @@
     - headers.popularTopics
     - headers.topicsAZ
     - headers.indicatorsAndAssurance
+    - headers.assured
     resourcebundle:messages:
     - Assurance Date
     - Based on data from
@@ -77,13 +82,14 @@
     - Popular indicator topics
     - Indicator topics A-Z
     - Indicators and assurance
+    - Assured
   /headers[2]:
     hippo:availability:
     - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-08T11:24:07.560Z
-    hippostdpubwf:lastModificationDate: 2018-02-20T14:50:36.857Z
+    hippostdpubwf:lastModificationDate: 2018-02-23T15:55:50.150Z
     hippostdpubwf:lastModifiedBy: admin
     jcr:mixinTypes:
     - mix:referenceable
@@ -109,6 +115,10 @@
     - ''
     - ''
     - ''
+    - ''
+    - ''
+    - ''
+    - ''
     resourcebundle:id: nationalindicatorlibrary.headers
     resourcebundle:keys:
     - headers.assuranceDate
@@ -133,6 +143,7 @@
     - headers.popularTopics
     - headers.topicsAZ
     - headers.indicatorsAndAssurance
+    - headers.assured
     resourcebundle:messages:
     - Assurance Date
     - Based on data from
@@ -156,15 +167,16 @@
     - Popular indicator topics
     - Indicator topics A-Z
     - Indicators and assurance
+    - Assured
   /headers[3]:
     hippo:availability:
     - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-08T11:24:07.560Z
-    hippostdpubwf:lastModificationDate: 2018-02-20T14:50:36.857Z
+    hippostdpubwf:lastModificationDate: 2018-02-23T15:55:50.150Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2018-02-20T14:50:38.555Z
+    hippostdpubwf:publicationDate: 2018-02-23T15:55:51.653Z
     jcr:mixinTypes:
     - mix:referenceable
     jcr:primaryType: resourcebundle:resourcebundle
@@ -188,6 +200,10 @@
     - ''
     - ''
     - ''
+    - ''
+    - ''
+    - ''
+    - ''
     resourcebundle:id: nationalindicatorlibrary.headers
     resourcebundle:keys:
     - headers.assuranceDate
@@ -212,6 +228,7 @@
     - headers.popularTopics
     - headers.topicsAZ
     - headers.indicatorsAndAssurance
+    - headers.assured
     resourcebundle:messages:
     - Assurance Date
     - Based on data from
@@ -235,6 +252,7 @@
     - Popular indicator topics
     - Indicator topics A-Z
     - Indicators and assurance
+    - Assured
   hippo:name: Headers
   jcr:mixinTypes:
   - hippo:named

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/sample-indicator.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/sample-indicator.yaml
@@ -93,7 +93,7 @@
         nationalindicatorlibrary:contactAuthorName: Hugo
       jcr:primaryType: nationalindicatorlibrary:topbar
       nationalindicatorlibrary:assuranceDate: 2015-12-14T00:00:00Z
-      nationalindicatorlibrary:assuredStatus: false
+      nationalindicatorlibrary:assuredStatus: true
       nationalindicatorlibrary:basedOn: Royal College of Physicians’ Sentinel Stroke
         National Audit Programme (SSNAP)
       nationalindicatorlibrary:publishedBy: Publisher
@@ -208,7 +208,7 @@
         nationalindicatorlibrary:contactAuthorName: Hugo
       jcr:primaryType: nationalindicatorlibrary:topbar
       nationalindicatorlibrary:assuranceDate: 2015-12-14T00:00:00Z
-      nationalindicatorlibrary:assuredStatus: false
+      nationalindicatorlibrary:assuredStatus: true
       nationalindicatorlibrary:basedOn: Royal College of Physicians’ Sentinel Stroke
         National Audit Programme (SSNAP)
       nationalindicatorlibrary:publishedBy: Publisher
@@ -325,7 +325,7 @@
         nationalindicatorlibrary:contactAuthorName: Hugo
       jcr:primaryType: nationalindicatorlibrary:topbar
       nationalindicatorlibrary:assuranceDate: 2015-12-14T00:00:00Z
-      nationalindicatorlibrary:assuredStatus: false
+      nationalindicatorlibrary:assuredStatus: true
       nationalindicatorlibrary:basedOn: Royal College of Physicians’ Sentinel Stroke
         National Audit Programme (SSNAP)
       nationalindicatorlibrary:publishedBy: Publisher
@@ -341,9 +341,9 @@
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-22T13:14:38.445Z
-    hippostdpubwf:lastModificationDate: 2018-02-26T09:34:50.640Z
+    hippostdpubwf:lastModificationDate: 2018-02-23T16:09:07.787Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2018-02-26T09:34:52.821Z
+    hippostdpubwf:publicationDate: 2018-02-23T16:09:10.121Z
     hippotranslation:id: 8760f929-796c-426e-bd55-826b9362a5ae
     hippotranslation:locale: en
     jcr:mixinTypes:

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/results.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/results.ftl
@@ -100,15 +100,15 @@
 </#macro>
 
 <#macro indicator item>
-    <div class="push-double--bottom" data-uipath="ps.search-results.result">
-        <h3 class="flush zeta" data-uipath="ps.search-results.result.type" style="font-weight:bold">Indicator</h3>
+    <div class="push-double--bottom" data-uipath="nil.search-results.result">
+        <h3 class="flush zeta" data-uipath="nil.search-results.result.type" style="font-weight:bold">Indicator</h3>
         <p class="flush">
-            <a href="<@hst.link hippobean=item.selfLinkBean/>" title="${item.title}" data-uipath="ps.search-results.result.title">
+            <a href="<@hst.link hippobean=item.selfLinkBean/>" title="${item.topbar.title}" data-uipath="nil.search-results.result.title">
                 ${item.topbar.title}
             </a>
         </p>
-        <p class="flush zeta" data-uipath="ps.search-results.result.date"><@fmt.message key="headers.assuranceDate"/> ${item.topbar.assuranceDate.time?string[dateFormat]}</p>
-        <#if item.topbar.publishedBy?has_content><p class="flush zeta" data-uipath="ps.search-results.result.date"><@fmt.message key="headers.publishedBy"/>: ${item.topbar.publishedBy}</p></#if>
+        <#if item.topbar.assuredStatus><p class="flush zeta" data-uipath="nil.search-results.result.assured-status">Independently Assured by IGB (conditional)</p></#if>
+        <p class="flush zeta" data-uipath="nil.search-results.result.publisher-and-date" style="font-weight:bold"><@fmt.message key="headers.publishedBy"/>: ${item.topbar.publishedBy}, <@fmt.message key="headers.assured"/>: ${item.topbar.assuranceDate.time?string[dateFormat]}</p>
         <p class="flush" data-uipath="nil.search-results.result.brief-description">${item.details.briefDescription}</p>        
     </div>
 </#macro>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/nationalindicatorlibrary/indicator.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/nationalindicatorlibrary/indicator.ftl
@@ -9,9 +9,7 @@
       <div class="document-header__inner">
         <h1 class="layout-5-6 push--bottom">${indicator.topbar.title}</h1>
 
-        <div class="document-header__divider">&nbsp;</div>
-
-        <h2>Independently assured by IGB</h2>
+        <#if indicator.topbar.assuredStatus><h2 style="text-decoration:underline">Independently assured by IGB</h2></#if>
 
         <div class="layout">
             <div class="layout__item layout-1-2">
@@ -60,7 +58,7 @@
         </section>
 
 
-        <h1><details id="methodology" class="push-double--bottom collapse">
+        <h2><details id="methodology" class="push-double--bottom">
             <summary><span>How this indicator is calculated</span></summary></br>
             <h2><@fmt.message key="headers.methodology"/></h2>
 
@@ -76,7 +74,7 @@
             <h6><strong><@fmt.message key="headers.calculation"/></strong></h6>
             <#outputformat "undefined"><p>${indicator.details.methodology.calculation.content}</p></#outputformat>
 
-        </details></h1>
+        </details></h2>
 
         <section id="caveats" class="push-double--bottom">
             <h2><strong><@fmt.message key="headers.caveats"/></strong></h2>


### PR DESCRIPTION
Alters layout for assurance date and publisher in results macro.
Adds 'Assured' to nationalindicatorlibrary:headers.
Doesn't show description as that is in NIL-119
Displayed assurance status on indicator summary page and search results
is now conditional on assurance