### PR TITLE
[NIL-98] Add resources to Indicator document type

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/indicator.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/indicator.yaml
@@ -42,6 +42,16 @@ definitions:
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
             wicket.id: ${cluster.id}.left.item
+          /attachments:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Attachments
+            field: attachments
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.css:
+            - attachments
+            wicket.id: ${cluster.id}.left.item
           /topbar:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
@@ -54,6 +64,14 @@ definitions:
         jcr:primaryType: editor:templateset
       /hipposysedit:nodetype:
         /hipposysedit:nodetype:
+          /attachments:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: true
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:attachments
+            hipposysedit:primary: false
+            hipposysedit:type: publicationsystem:attachment
+            jcr:primaryType: hipposysedit:field
           /details:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/national-indicator-library/headers.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/national-indicator-library/headers.yaml
@@ -44,6 +44,7 @@
     - headers.iapCode
     - headers.indicatorSet
     - headers.interpretationGuidelines
+    - headers.resources
     - headers.methodology
     - headers.publishedBy
     - headers.purpose
@@ -69,6 +70,7 @@
     - IAP Code
     - Indicator Set
     - Interpretation Guidelines
+    - Resources
     - Methodology
     - Published by
     - Purpose
@@ -131,6 +133,7 @@
     - headers.iapCode
     - headers.indicatorSet
     - headers.interpretationGuidelines
+    - headers.resources
     - headers.methodology
     - headers.publishedBy
     - headers.purpose
@@ -156,6 +159,7 @@
     - IAP Code
     - Indicator Set
     - Interpretation Guidelines
+    - Resources
     - Methodology
     - Published by
     - Purpose
@@ -218,6 +222,7 @@
     - headers.iapCode
     - headers.indicatorSet
     - headers.interpretationGuidelines
+    - headers.resources
     - headers.methodology
     - headers.publishedBy
     - headers.purpose
@@ -243,6 +248,7 @@
     - IAP Code
     - Indicator Set
     - Interpretation Guidelines
+    - Resources
     - Methodology
     - Published by
     - Purpose

--- a/repository-data/webfiles/src/main/resources/site/freemarker/nationalindicatorlibrary/indicator.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/nationalindicatorlibrary/indicator.ftl
@@ -89,13 +89,16 @@
         
 
         <section id="resources" class="push-double--bottom">
-            <h3>Resources</h3>
-            <ul>
-                <li><a href="#">Sample file</a></li>
-                <li><a href="#">Sample file</a></li>
-                <li><a href="#">Sample file</a></li>
-                <li><a href="#">Sample file</a></li>
-            </ul>
+            <h2><strong><@fmt.message key="headers.resources"/></strong></h2>
+            <#if indicator.attachments?has_content>
+                 <ul data-uipath="nil.indicator.resources">
+                    <#list indicator.attachments as attachment>
+                        <li class="attachment">
+                            <a title="${attachment.text}" href="<@hst.link hippobean=attachment.resource/>" onClick="logGoogleAnalyticsEvent('Download attachment','Indicator','${attachment.resource.filename}');">${attachment.text}</a>
+                        </li>
+                    </#list>
+                </ul>
+            </#if>
         </section>
 
         <section id="compare" class="push-double--bottom">

--- a/site/src/main/java/uk/nhs/digital/nil/beans/Indicator.java
+++ b/site/src/main/java/uk/nhs/digital/nil/beans/Indicator.java
@@ -3,17 +3,31 @@ package uk.nhs.digital.nil.beans;
 import org.hippoecm.hst.content.beans.Node;
 import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
 
+import uk.nhs.digital.ps.beans.Attachment;
+
+import java.util.List;
 
 @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:indicator")
 @Node(jcrType = "nationalindicatorlibrary:indicator")
 public class Indicator extends BaseDocument {
-    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:topbar")
+    @HippoEssentialsGenerated(internalName = PropertyKeys.TOPBAR)
     public Topbar getTopbar() {
-        return getBean("nationalindicatorlibrary:topbar", Topbar.class);
+        return getBean(PropertyKeys.TOPBAR, Topbar.class);
     }
 
-    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:details")
+    @HippoEssentialsGenerated(internalName = PropertyKeys.DETAILS)
     public Details getDetails() {
-        return getBean("nationalindicatorlibrary:details", Details.class);
+        return getBean(PropertyKeys.DETAILS, Details.class);
+    }
+
+    @HippoEssentialsGenerated(internalName = PropertyKeys.ATTACHMENTS)
+    public List<Attachment> getAttachments() {
+        return getChildBeansByName(PropertyKeys.ATTACHMENTS, Attachment.class);
+    }
+
+    interface PropertyKeys {
+        String ATTACHMENTS = "nationalindicatorlibrary:attachments";
+        String DETAILS = "nationalindicatorlibrary:details";
+        String TOPBAR = "nationalindicatorlibrary:topbar";
     }
 }


### PR DESCRIPTION
Basic addition of resources to the Indicator document type. No further requirements at this stage hence the existing plugin is sufficient.