### PR TITLE
[RPS-394] HotFix for missing hidden fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ cache:
     - "$HOME/.m2"
 
 install:
-  - make commit-msg-check
+  - make check.commit-msg
+  - make check.yaml
 
 script:
   - make test.unit

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ export HIPPO_MAVEN_USERNAME
 export HOME
 
 ifneq ($(HIPPO_MAVEN_USERNAME),)
-MVN_OPTS ?= $(MVN_OPTS) --global-settings "$(PWD)/.mvn.settings.xml"
+MVN_OPTS = --global-settings "$(PWD)/.mvn.settings.xml"
 endif
 
 ## Prints this help

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -19,7 +19,7 @@
     <properties>
         <cucumber.version>1.2.5</cucumber.version>
         <spring.version>5.0.4.RELEASE</spring.version>
-        <selenium.version>3.9.1</selenium.version>
+        <selenium.version>3.10.0</selenium.version>
     </properties>
 
     <dependencies>

--- a/ci-cd/Makefile
+++ b/ci-cd/Makefile
@@ -115,7 +115,7 @@ ondemand.upload-migration:
 #        make ondemand.deploy ENV=uat
 #        make ondemand.deploy ENV=prd
 ondemand.deploy: vendor/rd
-	source rd.conf && vendor/rd run -p nhs -j "jobs/$(OD_ENV)/Deploy" -- \
+	source $(RD_CONF) && vendor/rd run -p nhs -j "jobs/$(OD_ENV)/Deploy" -- \
 		-bootstrap full \
 		-distribution "$(VERSION).tar.gz"
 
@@ -146,10 +146,20 @@ version.pprint:
 	@echo "- - -"
 
 ## Ensure that commit message contains JIRA id
-commit-msg-check:
+check.commit-msg:
 	@git log -n1 --no-merges --pretty=%B > .commit-msg
 	@grep -E "^\[[A-Z]+-[0-9]+\]" .commit-msg || (echo "Missing JIRA id in the coomit message. Expecitng '[ABC-123] ...' but got" && cat .commit-msg && exit 1)
 	@rm .commit-msg
+
+check.yaml:
+	cd .. && make format-yaml
+	@git status | grep ".yaml" | grep "modified" \
+		&& (\
+			echo "Modified yaml files found. Run 'make format-yaml' before submiting pull request." && exit 1 \
+		)\
+		|| (\
+			echo "No YAML changes." \
+		)
 
 ## Clean up
 clean:

--- a/cms/src/main/java/uk/nhs/digital/ps/modules/AbstractDaemonModule.java
+++ b/cms/src/main/java/uk/nhs/digital/ps/modules/AbstractDaemonModule.java
@@ -52,7 +52,7 @@ public abstract class AbstractDaemonModule implements DaemonModule {
         }
     }
 
-    public final Session getSession() {
+    public Session getSession() {
         return session;
     }
 

--- a/cms/src/main/java/uk/nhs/digital/ps/modules/FullTaxonomyModule.java
+++ b/cms/src/main/java/uk/nhs/digital/ps/modules/FullTaxonomyModule.java
@@ -62,7 +62,7 @@ public class FullTaxonomyModule extends AbstractDaemonModule {
         createSearchableTagsProperty(node);
     }
 
-    private void createSearchableTagsProperty(Node document) {
+    protected void createSearchableTagsProperty(Node document) {
         Value[] values = getRepoValue(() -> document.getProperty(TAXONOMY_KEYS_PROPERTY).getValues());
         Set<String> keys = Arrays.stream(values)
             .map(value -> getRepoValue(value::getString))
@@ -106,7 +106,7 @@ public class FullTaxonomyModule extends AbstractDaemonModule {
         });
     }
 
-    private void createFullTaxonomyProperty(Node document) {
+    protected void createFullTaxonomyProperty(Node document) {
         Set<String> fullTaxonomyKeys = getFullTaxonomyKeys(document);
         Value[] fullTaxonomy = stringsToValues(fullTaxonomyKeys);
 

--- a/essentials/pom.xml
+++ b/essentials/pom.xml
@@ -21,13 +21,13 @@
         <dependency>
             <groupId>org.onehippo.cms7</groupId>
             <artifactId>hippo-essentials-dashboard</artifactId>
-            <version>4.1.2</version>
+            <version>12.2.0</version>
             <type>war</type>
         </dependency>
         <dependency>
             <groupId>org.onehippo.cms7</groupId>
             <artifactId>hippo-essentials-dashboard-dependencies</artifactId>
-            <version>4.1.2</version>
+            <version>12.2.0</version>
             <type>pom</type>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.onehippo.cms7</groupId>
         <artifactId>hippo-cms7-enterprise-release</artifactId>
-        <version>12.1.2</version>
+        <version>12.2.0</version>
     </parent>
 
     <name>NHS Digital Website</name>
@@ -116,7 +116,7 @@
             <dependency>
                 <groupId>org.onehippo.cms7</groupId>
                 <artifactId>hippo-essentials-plugin-sdk-api</artifactId>
-                <version>4.1.2</version>
+                <version>12.2.0</version>
             </dependency>
 
             <dependency>
@@ -220,6 +220,18 @@
                 <artifactId>org.apache.sling.testing.jcr-mock</artifactId>
                 <version>1.3.2</version>
                 <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.9.4</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.9.4</version>
             </dependency>
 
             <!-- Although we don't explicitly use these dependencys, there are conflicts

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/HotFixSearchableAndFullTaxonomy.groovy
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/HotFixSearchableAndFullTaxonomy.groovy
@@ -1,0 +1,100 @@
+package uk.nhs.digital.ps.modules
+
+import org.onehippo.repository.update.BaseNodeUpdateVisitor
+
+import javax.jcr.*
+import javax.jcr.Node
+
+/**
+ * This migration updates "SearchableTaxonomy" and "FullTaxonomy" fields
+ */
+class HotFixSearchableAndFullTaxonomy extends BaseNodeUpdateVisitor {
+    def allowedTypes = [
+        "publicationsystem:publication",
+        "publicationsystem:dataset"
+    ]
+
+    TaxonomyDaemonCopy daemonCopy
+    Session session
+
+    private static final String TAXONOMY_KEYS_PROPERTY = "hippotaxonomy:keys"
+
+    boolean doUpdate(Node node) {
+        session = node.getSession()
+        daemonCopy = new TaxonomyDaemonCopy(session)
+
+        try {
+            // make sure it's "handle"
+            if (!"hippo:handle".equals(node.getPrimaryNodeType().getName())) {
+                return skipNodeWrongType(node)
+            }
+
+            // make sure it's allowed Type
+            if (!allowedTypes.contains(node.getNode(node.getName()).getPrimaryNodeType().getName())) {
+                return skipNodeWrongPrimaryType(node)
+            }
+
+            NodeIterator i = node.getNodes()
+            Node n
+
+            log.info("Updating " + node.getPath())
+            while(i.hasNext()) {
+                n = i.nextNode()
+
+                if (! n.hasProperty(TAXONOMY_KEYS_PROPERTY)) {
+                    log.info("No taxonomy keys, skipping")
+                    continue
+                }
+
+                log.warn("SearchableTaxonomy " + n.getProperty("hippostd:state").getString())
+                daemonCopy.hookCreateSearchableTagsProperty(n)
+
+                log.warn("FullTaxonomy " + n.getProperty("hippostd:state").getString())
+                daemonCopy.hookCreateFullTaxonomyProperty(n)
+            }
+
+            return true
+        } catch (e) {
+            log.error("Failed to process record.", e)
+        }
+
+        return false
+    }
+
+    boolean undoUpdate(Node node) {
+        log.error("UNDO is not available")
+        return false
+    }
+
+    boolean skipNodeWrongType(Node node) {
+        log.warn("Wrong type, skipping document " + node.getPath() + ", of type " + node.getPrimaryNodeType().getName());
+
+        return false
+    }
+
+    boolean skipNodeWrongPrimaryType(Node node) {
+        log.warn("Wrong primary type, skipping document " + node.getPath() + ", of type " + node.getPrimaryNodeType().getName());
+
+        return false
+    }
+
+    class TaxonomyDaemonCopy extends FullTaxonomyModule {
+        Session session
+
+        TaxonomyDaemonCopy(Session session) {
+            this.session = session
+        }
+
+        public Session getSession() {
+            return session
+        }
+
+        public void hookCreateSearchableTagsProperty(Node document) {
+            createSearchableTagsProperty(document)
+        }
+
+        public void hookCreateFullTaxonomyProperty(Node document) {
+            createFullTaxonomyProperty(document)
+        }
+    }
+}

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/HotFixSearchableAndFullTaxonomy.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/HotFixSearchableAndFullTaxonomy.yaml
@@ -1,0 +1,16 @@
+---
+definitions:
+  config:
+    /hippo:configuration/hippo:update/hippo:registry/HotFix-Searchable-and-Full-Taxonomy:
+      hipposys:batchsize: 1
+      hipposys:description: Update two hidden fields based on taxonomy. SearchableTaxonomy
+        and FullTaxonomy
+      hipposys:dryrun: false
+      hipposys:parameters: ''
+      hipposys:query: /jcr:root/content/documents/corporate-website/publication-system//*[@jcr:primaryType='publicationsystem:publication'
+        or @jcr:primaryType='publicationsystem:dataset']/..
+      hipposys:script:
+        resource: /configuration/update/HotFixSearchableAndFullTaxonomy.groovy
+        type: string
+      hipposys:throttle: 1000
+      jcr:primaryType: hipposys:updaterinfo

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/website/general-type.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/website/general-type.yaml
@@ -1,42 +1,6 @@
 ---
 /content/documents/administration/website/general-type:
   /general-type:
-    /selection:listitem[1]:
-      jcr:primaryType: selection:listitem
-      selection:key: board-meeting-minutes-agenda
-      selection:label: Board meeting / minutes / agenda
-    /selection:listitem[2]:
-      jcr:primaryType: selection:listitem
-      selection:key: clinical-audit-dataset
-      selection:label: Clinical audit / dataset
-    /selection:listitem[3]:
-      jcr:primaryType: selection:listitem
-      selection:key: corporate-publication
-      selection:label: Corporate publication
-    /selection:listitem[4]:
-      jcr:primaryType: selection:listitem
-      selection:key: corporate-report
-      selection:label: Corporate report
-    /selection:listitem[5]:
-      jcr:primaryType: selection:listitem
-      selection:key: data-collection
-      selection:label: Data collection
-    /selection:listitem[6]:
-      jcr:primaryType: selection:listitem
-      selection:key: data-hub
-      selection:label: Data hub
-    /selection:listitem[7]:
-      jcr:primaryType: selection:listitem
-      selection:key: data-provision-notice
-      selection:label: Data provision notice
-    /selection:listitem[8]:
-      jcr:primaryType: selection:listitem
-      selection:key: data-report
-      selection:label: Data report
-    /selection:listitem[9]:
-      jcr:primaryType: selection:listitem
-      selection:key: direction
-      selection:label: Direction
     /selection:listitem[10]:
       jcr:primaryType: selection:listitem
       selection:key: document-download-page
@@ -73,6 +37,42 @@
       jcr:primaryType: selection:listitem
       selection:key: tool
       selection:label: Tool
+    /selection:listitem[1]:
+      jcr:primaryType: selection:listitem
+      selection:key: board-meeting-minutes-agenda
+      selection:label: Board meeting / minutes / agenda
+    /selection:listitem[2]:
+      jcr:primaryType: selection:listitem
+      selection:key: clinical-audit-dataset
+      selection:label: Clinical audit / dataset
+    /selection:listitem[3]:
+      jcr:primaryType: selection:listitem
+      selection:key: corporate-publication
+      selection:label: Corporate publication
+    /selection:listitem[4]:
+      jcr:primaryType: selection:listitem
+      selection:key: corporate-report
+      selection:label: Corporate report
+    /selection:listitem[5]:
+      jcr:primaryType: selection:listitem
+      selection:key: data-collection
+      selection:label: Data collection
+    /selection:listitem[6]:
+      jcr:primaryType: selection:listitem
+      selection:key: data-hub
+      selection:label: Data hub
+    /selection:listitem[7]:
+      jcr:primaryType: selection:listitem
+      selection:key: data-provision-notice
+      selection:label: Data provision notice
+    /selection:listitem[8]:
+      jcr:primaryType: selection:listitem
+      selection:key: data-report
+      selection:label: Data report
+    /selection:listitem[9]:
+      jcr:primaryType: selection:listitem
+      selection:key: direction
+      selection:label: Direction
     hippo:availability:
     - live
     - preview


### PR DESCRIPTION
This is a bit dirty, but:

* Content migrator package is the same as the "Taxonomy" daemon package.
* Private class "TaxonomyDaemonCopy" extends "FullTaxonomyModule" in
  order to do stay in sync with the current implementation.
* Minimal change to "AbstractDaemonModule" to allow injection of the
  JCR session object.