### PR TITLE
[NIL-90] NIL search facets and supporting changes

### DIFF
--- a/acceptance-tests/src/test/resources/features/site/facets.feature
+++ b/acceptance-tests/src/test/resources/features/site/facets.feature
@@ -35,6 +35,25 @@ Feature: Faceted search
             | 2018 (2) |
             | 2017 (1) |
 
+    Scenario: All expected NIL facets are displayed
+        Given I navigate to the "home" page
+        When I search for "NilTaxonomySearchTerm"
+        Then I should see the list with title "DOCUMENT TYPE" containing:
+            | Indicator (3) |
+        And I should see the list with title "CATEGORY" containing:
+            | Acceptance Tests (3)             |
+            | NilTaxonomySearchTerm test (3)   |
+        And I should see the list with title "GEOGRAPHICAL COVERAGE" containing:
+            | England (3)  |            
+        And I should see the list with title "ASSURED" containing:
+            | Yes (2)  |
+            | No (1)   |      
+        And I should see the list with title "PUBLISHED BY" containing:
+            | NHS Digital (3)  |
+        And I should see the list with title "REPORTING LEVEL" containing:
+            | CCG (1)                                           |       
+            | CCG and National (1)                              |  
+            | CCG and National GP registered population (1)     |                                    
 
     Scenario: Months are not shown initially
         Given I navigate to the "home" page

--- a/conf/query/lucene/indexing_configuration.xml
+++ b/conf/query/lucene/indexing_configuration.xml
@@ -28,7 +28,9 @@ https://wiki.apache.org/jackrabbit/IndexingConfiguration
         boost="4.0"
     >
         <property boost="2.0">nationalindicatorlibrary:title</property>
-        <property boost="1.5">nationalindicatorlibrary:assuranceDate</property>
+        <property boost="1.5">nationalindicatorlibrary:definition</property>
+        <property boost="1.0">nationalindicatorlibrary:purpose</property>        
+        <property>common:SearchableTags</property>
         <property isRegexp="true" nodeScopeIndex="false">.*:.*</property>
     </index-rule>
 

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/details.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/details.yaml
@@ -104,15 +104,6 @@ definitions:
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
             wicket.id: ${cluster.id}.right.item
-          /classifiable:
-            /cluster.options:
-              caption: Taxonomy
-              jcr:primaryType: frontend:pluginconfig
-              taxonomy.name: publication_taxonomy
-            jcr:primaryType: frontend:plugin
-            mixin: hippotaxonomy:classifiable
-            plugin.class: org.hippoecm.frontend.editor.plugins.mixin.MixinLoaderPlugin
-            wicket.id: ${cluster.id}.right.item
           /briefDescription:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
@@ -208,7 +199,6 @@ definitions:
           hipposysedit:supertype:
           - hippo:compound
           - hippostd:relaxed
-          - hippotaxonomy:classifiable
           hipposysedit:uri: http://digital.nhs.uk/jcr/nationalindicatorlibrary/nt/1.0
           jcr:mixinTypes:
           - mix:referenceable
@@ -245,8 +235,6 @@ definitions:
           /nationalindicatorlibrary:purpose:
             hippostd:content: ''
             jcr:primaryType: hippostd:html
-          jcr:mixinTypes:
-          - hippotaxonomy:classifiable
           jcr:primaryType: nationalindicatorlibrary:details
           nationalindicatorlibrary:briefDescription: ''
           nationalindicatorlibrary:iapCode: ''

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/indicator.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/indicator.yaml
@@ -33,6 +33,77 @@ definitions:
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
             wicket.id: ${cluster.id}.right
+          /title:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Title
+            field: title
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.left.item
+          /topbar:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Top Bar
+            field: topbar
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.right.item
+          /assuredStatus:
+            /cluster.options:
+              falseLabel: Not Assured
+              jcr:primaryType: frontend:pluginconfig
+              trueLabel: Assured
+            caption: Assured Status
+            field: assuredStatus
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.left.item
+          /publishedBy:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Published By
+            field: publishedBy
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.left.item
+          /reportingLevel:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Reporting Level
+            field: reportingLevel
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.left.item
+          /classifiable:
+            /cluster.options:
+              caption: Taxonomy
+              jcr:primaryType: frontend:pluginconfig
+              taxonomy.name: publication_taxonomy
+            essentials-taxonomy-name: publication_taxonomy
+            jcr:primaryType: frontend:plugin
+            mixin: hippotaxonomy:classifiable
+            plugin.class: org.hippoecm.frontend.editor.plugins.mixin.MixinLoaderPlugin
+            wicket.id: ${cluster.id}.left.item
+          /GeographicCoverage:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+              selectable.options: England,England and Northern Ireland,England and
+                Scotland,England and Wales,England Scotland and Northern Ireland,England
+                Wales and Northern Ireland,Great Britain,International,Northern Ireland,Scotland,UK,Wales
+            caption: Geographic Coverage
+            field: geographic_coverage
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.css:
+            - geographic-coverage
+            wicket.id: ${cluster.id}.left.item
           /details:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
@@ -52,18 +123,17 @@ definitions:
             wicket.css:
             - attachments
             wicket.id: ${cluster.id}.left.item
-          /topbar:
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-            caption: Top Bar
-            field: topbar
-            hint: ''
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
-            wicket.id: ${cluster.id}.right.item
         jcr:primaryType: editor:templateset
       /hipposysedit:nodetype:
         /hipposysedit:nodetype:
+          /assuredStatus:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:assuredStatus
+            hipposysedit:primary: false
+            hipposysedit:type: selection:BooleanRadioGroup
+            jcr:primaryType: hipposysedit:field
           /attachments:
             hipposysedit:mandatory: false
             hipposysedit:multiple: true
@@ -80,6 +150,47 @@ definitions:
             hipposysedit:primary: false
             hipposysedit:type: nationalindicatorlibrary:details
             jcr:primaryType: hipposysedit:field
+          /geographic_coverage:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:GeographicCoverage
+            hipposysedit:primary: false
+            hipposysedit:type: StaticDropdown
+            jcr:primaryType: hipposysedit:field
+          /publishedBy:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:publishedBy
+            hipposysedit:primary: false
+            hipposysedit:type: String
+            hipposysedit:validators:
+            - non-empty
+            - required
+            jcr:primaryType: hipposysedit:field
+          /reportingLevel:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:reportingLevel
+            hipposysedit:primary: false
+            hipposysedit:type: String
+            hipposysedit:validators:
+            - non-empty
+            - required
+            jcr:primaryType: hipposysedit:field
+          /title:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:title
+            hipposysedit:primary: false
+            hipposysedit:type: String
+            hipposysedit:validators:
+            - non-empty
+            - required
+            jcr:primaryType: hipposysedit:field
           /topbar:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
@@ -91,6 +202,7 @@ definitions:
           hipposysedit:node: true
           hipposysedit:supertype:
           - nationalindicatorlibrary:basedocument
+          - hippotaxonomy:classifiable
           - hippostd:relaxed
           - hippotranslation:translated
           hipposysedit:uri: http://digital.nhs.uk/jcr/nationalindicatorlibrary/nt/1.0
@@ -133,6 +245,7 @@ definitions:
             jcr:mixinTypes:
             - hippotaxonomy:classifiable
             jcr:primaryType: nationalindicatorlibrary:details
+            nationalindicatorlibrary:briefDescription: ''
             nationalindicatorlibrary:iapCode: ''
             nationalindicatorlibrary:indicatorSet: ''
             nationalindicatorlibrary:rating: ''
@@ -143,13 +256,9 @@ definitions:
               nationalindicatorlibrary:contactAuthorName: ''
             jcr:primaryType: nationalindicatorlibrary:topbar
             nationalindicatorlibrary:assuranceDate: 0001-01-01T12:00:00Z
-            nationalindicatorlibrary:assuredStatus: false
             nationalindicatorlibrary:basedOn: ''
-            nationalindicatorlibrary:publishedBy: ''
-            nationalindicatorlibrary:reportingLevel: ''
             nationalindicatorlibrary:reportingPeriod: ''
             nationalindicatorlibrary:reviewDate: 0001-01-01T12:00:00Z
-            nationalindicatorlibrary:title: ''
           common:FacetType: indicator
           common:searchable: true
           hippostd:holder: holder
@@ -161,8 +270,13 @@ definitions:
           hippotranslation:id: document-type-locale-id
           hippotranslation:locale: document-type-locale
           jcr:mixinTypes:
+          - hippotaxonomy:classifiable
           - mix:referenceable
           jcr:primaryType: nationalindicatorlibrary:indicator
+          nationalindicatorlibrary:assuredStatus: false
+          nationalindicatorlibrary:publishedBy: ''
+          nationalindicatorlibrary:reportingLevel: ''
+          nationalindicatorlibrary:title: ''
         jcr:primaryType: hipposysedit:prototypeset
       jcr:mixinTypes:
       - editor:editable

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/topbar.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/topbar.yaml
@@ -19,32 +19,6 @@ definitions:
             item: ${cluster.id}.field
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
-          /title:
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-            caption: Title
-            field: title
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.field
-          /assuredStatus:
-            /cluster.options:
-              falseLabel: Not Assured
-              jcr:primaryType: frontend:pluginconfig
-              trueLabel: Assured
-            caption: Assured Status
-            field: assuredStatus
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.field
-          /publishedBy:
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-            caption: Published By
-            field: publishedBy
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.field
           /reportingPeriod:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
@@ -58,15 +32,6 @@ definitions:
               jcr:primaryType: frontend:pluginconfig
             caption: Based on data from
             field: text
-            hint: ''
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.field
-          /reportingLevel:
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-            caption: Reporting Level
-            field: reportingLevel
             hint: ''
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
@@ -109,16 +74,6 @@ definitions:
             hipposysedit:validators:
             - required
             jcr:primaryType: hipposysedit:field
-          /assuredStatus:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: nationalindicatorlibrary:assuredStatus
-            hipposysedit:primary: false
-            hipposysedit:type: selection:BooleanRadioGroup
-            hipposysedit:validators:
-            - required
-            jcr:primaryType: hipposysedit:field
           /contactAuthor:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
@@ -126,25 +81,6 @@ definitions:
             hipposysedit:path: nationalindicatorlibrary:contactAuthor
             hipposysedit:primary: false
             hipposysedit:type: nationalindicatorlibrary:contactAuthor
-            jcr:primaryType: hipposysedit:field
-          /publishedBy:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: nationalindicatorlibrary:publishedBy
-            hipposysedit:primary: false
-            hipposysedit:type: Text
-            hipposysedit:validators:
-            - non-empty
-            - required
-            jcr:primaryType: hipposysedit:field
-          /reportingLevel:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: nationalindicatorlibrary:reportingLevel
-            hipposysedit:primary: false
-            hipposysedit:type: Text
             jcr:primaryType: hipposysedit:field
           /reportingPeriod:
             hipposysedit:mandatory: false
@@ -178,17 +114,6 @@ definitions:
             - non-empty
             - required
             jcr:primaryType: hipposysedit:field
-          /title:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: nationalindicatorlibrary:title
-            hipposysedit:primary: false
-            hipposysedit:type: Text
-            hipposysedit:validators:
-            - non-empty
-            - required
-            jcr:primaryType: hipposysedit:field
           hipposysedit:node: true
           hipposysedit:supertype:
           - hippo:compound
@@ -209,13 +134,9 @@ definitions:
             nationalindicatorlibrary:contactAuthorName: ''
           jcr:primaryType: nationalindicatorlibrary:topbar
           nationalindicatorlibrary:assuranceDate: 0001-01-01T12:00:00Z
-          nationalindicatorlibrary:assuredStatus: false
           nationalindicatorlibrary:basedOn: ''
-          nationalindicatorlibrary:publishedBy: ''
-          nationalindicatorlibrary:reportingLevel: ''
           nationalindicatorlibrary:reportingPeriod: ''
           nationalindicatorlibrary:reviewDate: 0001-01-01T12:00:00Z
-          nationalindicatorlibrary:title: ''
         jcr:primaryType: hipposysedit:prototypeset
       jcr:mixinTypes:
       - editor:editable

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/facet-headers.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/facet-headers.yaml
@@ -29,6 +29,9 @@
     - year
     - month
     - timeframe
+    - assuredStatus
+    - publishedBy
+    - reportingLevel
     resourcebundle:messages:
     - DOCUMENT TYPE
     - CATEGORY
@@ -38,6 +41,9 @@
     - YEAR
     - MONTH
     - TIMEFRAME
+    - ASSURED
+    - PUBLISHED BY
+    - REPORTING LEVEL
   /facet-headers[2]:
     hippo:availability:
     - preview
@@ -69,6 +75,9 @@
     - year
     - month
     - timeframe
+    - assuredStatus
+    - publishedBy
+    - reportingLevel
     resourcebundle:messages:
     - DOCUMENT TYPE
     - CATEGORY
@@ -78,6 +87,9 @@
     - YEAR
     - MONTH
     - TIMEFRAME
+    - ASSURED
+    - PUBLISHED BY
+    - REPORTING LEVEL
   /facet-headers[3]:
     hippo:availability:
     - live
@@ -109,6 +121,9 @@
     - year
     - month
     - timeframe
+    - assuredStatus
+    - publishedBy
+    - reportingLevel
     resourcebundle:messages:
     - DOCUMENT TYPE
     - CATEGORY
@@ -118,6 +133,9 @@
     - YEAR
     - MONTH
     - TIMEFRAME
+    - ASSURED
+    - PUBLISHED BY
+    - REPORTING LEVEL
   hippo:name: facet headers
   jcr:mixinTypes:
   - hippo:named

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/national-indicator-library/headers.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/national-indicator-library/headers.yaml
@@ -40,6 +40,7 @@
     - headers.basedOn
     - headers.caveats
     - headers.contactAuthor
+    - headers.geographicCoverage
     - headers.definition
     - headers.iapCode
     - headers.indicatorSet
@@ -66,6 +67,7 @@
     - Based on data from
     - Caveats
     - Contact Author
+    - Geographic Coverage
     - Definition
     - IAP Code
     - Indicator Set
@@ -129,6 +131,7 @@
     - headers.basedOn
     - headers.caveats
     - headers.contactAuthor
+    - headers.geographicCoverage
     - headers.definition
     - headers.iapCode
     - headers.indicatorSet
@@ -155,6 +158,7 @@
     - Based on data from
     - Caveats
     - Contact Author
+    - Geographic Coverage
     - Definition
     - IAP Code
     - Indicator Set
@@ -218,6 +222,7 @@
     - headers.basedOn
     - headers.caveats
     - headers.contactAuthor
+    - headers.geographicCoverage
     - headers.definition
     - headers.iapCode
     - headers.indicatorSet
@@ -244,6 +249,7 @@
     - Based on data from
     - Caveats
     - Contact Author
+    - Geographic Coverage
     - Definition
     - IAP Code
     - Indicator Set

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/facet.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/facet.yaml
@@ -10,6 +10,9 @@
   - year${sortby:'facetvalue', sortorder:'descending'}
   - month${after:'year', sortby:'facetvalue', sortorder:'descending',hide:'year'}
   - timeframe
+  - assuredStatus
+  - publishedBy
+  - reportingLevel
   hippofacnav:facets:
   - common:FacetType
   - common:FullTaxonomy
@@ -23,5 +26,8 @@
     begin:0, end:1},{name:'this month', resolution:'month', begin:0, end:1},{name:'this
     year', resolution:'year', begin:0, end:1}, {name:'before this year', resolution:'year',
     end:0}]
+  - nationalindicatorlibrary:assuredStatus
+  - nationalindicatorlibrary:publishedBy
+  - nationalindicatorlibrary:reportingLevel
   hippofacnav:limit: 100
   jcr:primaryType: hippofacnav:facetnavigation

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/acceptance-tests/bare-minimum-indicator.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/acceptance-tests/bare-minimum-indicator.yaml
@@ -28,9 +28,8 @@
       /nationalindicatorlibrary:purpose:
         hippostd:content: <p>Purpose</p>
         jcr:primaryType: hippostd:html
-      jcr:mixinTypes:
-      - hippotaxonomy:classifiable
       jcr:primaryType: nationalindicatorlibrary:details
+      nationalindicatorlibrary:briefDescription: Bare Minimum Indicator
       nationalindicatorlibrary:iapCode: ''
       nationalindicatorlibrary:indicatorSet: ''
       nationalindicatorlibrary:rating: ''
@@ -41,26 +40,35 @@
         nationalindicatorlibrary:contactAuthorName: Test
       jcr:primaryType: nationalindicatorlibrary:topbar
       nationalindicatorlibrary:assuranceDate: 2018-02-23T13:57:00Z
-      nationalindicatorlibrary:assuredStatus: true
       nationalindicatorlibrary:basedOn: Test
-      nationalindicatorlibrary:publishedBy: Test
-      nationalindicatorlibrary:reportingLevel: ''
       nationalindicatorlibrary:reportingPeriod: Now
       nationalindicatorlibrary:reviewDate: 2018-02-23T13:57:00Z
-      nationalindicatorlibrary:title: Bare Minimum Indicator
     common:FacetType: indicator
+    common:FullTaxonomy:
+    - nil-taxonomy-test
+    - acceptance-tests
+    common:SearchableTags:
+    - NilTaxonomySearchTerm test
     common:searchable: true
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-23T13:57:04.917Z
-    hippostdpubwf:lastModificationDate: 2018-02-23T14:12:38.988Z
+    hippostdpubwf:lastModificationDate: 2018-03-07T08:14:36.344Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - nil-taxonomy-test
     hippotranslation:id: 6052313f-da95-4a53-84ee-8d2d9e69d1e0
     hippotranslation:locale: en
     jcr:mixinTypes:
+    - hippotaxonomy:classifiable
     - mix:referenceable
     jcr:primaryType: nationalindicatorlibrary:indicator
+    nationalindicatorlibrary:assuredStatus: true
+    nationalindicatorlibrary:publishedBy: NHS Digital
+    nationalindicatorlibrary:reportingLevel: CCG
+    nationalindicatorlibrary:title: Bare Minimum Indicator
+    publicationsystem:GeographicCoverage: England
   /bare-minimum-indicator[2]:
     /nationalindicatorlibrary:details:
       /nationalindicatorlibrary:caveats:
@@ -89,9 +97,8 @@
       /nationalindicatorlibrary:purpose:
         hippostd:content: <p>Purpose</p>
         jcr:primaryType: hippostd:html
-      jcr:mixinTypes:
-      - hippotaxonomy:classifiable
       jcr:primaryType: nationalindicatorlibrary:details
+      nationalindicatorlibrary:briefDescription: Bare Minimum Indicator
       nationalindicatorlibrary:iapCode: ''
       nationalindicatorlibrary:indicatorSet: ''
       nationalindicatorlibrary:rating: ''
@@ -102,28 +109,37 @@
         nationalindicatorlibrary:contactAuthorName: Test
       jcr:primaryType: nationalindicatorlibrary:topbar
       nationalindicatorlibrary:assuranceDate: 2018-02-23T13:57:00Z
-      nationalindicatorlibrary:assuredStatus: true
       nationalindicatorlibrary:basedOn: Test
-      nationalindicatorlibrary:publishedBy: Test
-      nationalindicatorlibrary:reportingLevel: ''
       nationalindicatorlibrary:reportingPeriod: Now
       nationalindicatorlibrary:reviewDate: 2018-02-23T13:57:00Z
-      nationalindicatorlibrary:title: Bare Minimum Indicator
     common:FacetType: indicator
+    common:FullTaxonomy:
+    - nil-taxonomy-test
+    - acceptance-tests
+    common:SearchableTags:
+    - NilTaxonomySearchTerm test
     common:searchable: true
     hippo:availability:
     - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-23T13:57:04.917Z
-    hippostdpubwf:lastModificationDate: 2018-02-23T13:57:58.300Z
+    hippostdpubwf:lastModificationDate: 2018-03-07T08:14:43.394Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - nil-taxonomy-test
     hippotranslation:id: 6052313f-da95-4a53-84ee-8d2d9e69d1e0
     hippotranslation:locale: en
     jcr:mixinTypes:
+    - hippotaxonomy:classifiable
     - mix:referenceable
     - mix:versionable
     jcr:primaryType: nationalindicatorlibrary:indicator
+    nationalindicatorlibrary:assuredStatus: true
+    nationalindicatorlibrary:publishedBy: NHS Digital
+    nationalindicatorlibrary:reportingLevel: CCG
+    nationalindicatorlibrary:title: Bare Minimum Indicator
+    publicationsystem:GeographicCoverage: England
   /bare-minimum-indicator[3]:
     /nationalindicatorlibrary:details:
       /nationalindicatorlibrary:caveats:
@@ -152,9 +168,8 @@
       /nationalindicatorlibrary:purpose:
         hippostd:content: <p>Purpose</p>
         jcr:primaryType: hippostd:html
-      jcr:mixinTypes:
-      - hippotaxonomy:classifiable
       jcr:primaryType: nationalindicatorlibrary:details
+      nationalindicatorlibrary:briefDescription: Bare Minimum Indicator
       nationalindicatorlibrary:iapCode: ''
       nationalindicatorlibrary:indicatorSet: ''
       nationalindicatorlibrary:rating: ''
@@ -165,28 +180,37 @@
         nationalindicatorlibrary:contactAuthorName: Test
       jcr:primaryType: nationalindicatorlibrary:topbar
       nationalindicatorlibrary:assuranceDate: 2018-02-23T13:57:00Z
-      nationalindicatorlibrary:assuredStatus: true
       nationalindicatorlibrary:basedOn: Test
-      nationalindicatorlibrary:publishedBy: Test
-      nationalindicatorlibrary:reportingLevel: ''
       nationalindicatorlibrary:reportingPeriod: Now
       nationalindicatorlibrary:reviewDate: 2018-02-23T13:57:00Z
-      nationalindicatorlibrary:title: Bare Minimum Indicator
     common:FacetType: indicator
+    common:FullTaxonomy:
+    - nil-taxonomy-test
+    - acceptance-tests
+    common:SearchableTags:
+    - NilTaxonomySearchTerm test
     common:searchable: true
     hippo:availability:
     - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-23T13:57:04.917Z
-    hippostdpubwf:lastModificationDate: 2018-02-23T13:57:58.300Z
+    hippostdpubwf:lastModificationDate: 2018-03-07T08:14:43.394Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2018-02-23T14:12:22.725Z
+    hippostdpubwf:publicationDate: 2018-03-07T08:14:47.777Z
+    hippotaxonomy:keys:
+    - nil-taxonomy-test
     hippotranslation:id: 6052313f-da95-4a53-84ee-8d2d9e69d1e0
     hippotranslation:locale: en
     jcr:mixinTypes:
+    - hippotaxonomy:classifiable
     - mix:referenceable
     jcr:primaryType: nationalindicatorlibrary:indicator
+    nationalindicatorlibrary:assuredStatus: true
+    nationalindicatorlibrary:publishedBy: NHS Digital
+    nationalindicatorlibrary:reportingLevel: CCG
+    nationalindicatorlibrary:title: Bare Minimum Indicator
+    publicationsystem:GeographicCoverage: England
   hippo:name: bare minimum indicator
   jcr:mixinTypes:
   - hippo:named

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/acceptance-tests/unassured-indicator.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/acceptance-tests/unassured-indicator.yaml
@@ -1,12 +1,12 @@
 ---
-/content/documents/corporate-website/national-indicator-library/acceptance-tests/national-indicator:
-  /national-indicator[1]:
+/content/documents/corporate-website/national-indicator-library/acceptance-tests/unassured-indicator:
+  /unassured-indicator[1]:
     /nationalindicatorlibrary:details:
       /nationalindicatorlibrary:caveats:
         hippostd:content: <p>Caveats</p>
         jcr:primaryType: hippostd:html
       /nationalindicatorlibrary:definition:
-        hippostd:content: <p>SearchableNationalIndicatorDefinition</p>
+        hippostd:content: <p>Definition</p>
         jcr:primaryType: hippostd:html
       /nationalindicatorlibrary:interpretationGuidelines:
         hippostd:content: <p>Interpretation Guidelines</p>
@@ -26,10 +26,10 @@
           jcr:primaryType: hippostd:html
         jcr:primaryType: nationalindicatorlibrary:methodology
       /nationalindicatorlibrary:purpose:
-        hippostd:content: <p>SearchableNationalIndicatorPurpose</p>
+        hippostd:content: <p>Purpose</p>
         jcr:primaryType: hippostd:html
       jcr:primaryType: nationalindicatorlibrary:details
-      nationalindicatorlibrary:briefDescription: National Indicator
+      nationalindicatorlibrary:briefDescription: Unassured Indicator
       nationalindicatorlibrary:iapCode: IAPCODE1
       nationalindicatorlibrary:indicatorSet: ''
       nationalindicatorlibrary:rating: ''
@@ -40,9 +40,11 @@
         nationalindicatorlibrary:contactAuthorName: Author
       jcr:primaryType: nationalindicatorlibrary:topbar
       nationalindicatorlibrary:assuranceDate: 2018-02-23T13:53:00Z
+      nationalindicatorlibrary:assuredStatus: false
       nationalindicatorlibrary:basedOn: Test
       nationalindicatorlibrary:reportingPeriod: Now
       nationalindicatorlibrary:reviewDate: 2018-02-23T13:53:00Z
+      nationalindicatorlibrary:title: Unassured Indicator
     common:FacetType: indicator
     common:FullTaxonomy:
     - nil-taxonomy-test
@@ -54,7 +56,7 @@
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-23T13:52:36.010Z
-    hippostdpubwf:lastModificationDate: 2018-03-07T08:14:54.168Z
+    hippostdpubwf:lastModificationDate: 2018-03-07T08:15:10.327Z
     hippostdpubwf:lastModifiedBy: admin
     hippotaxonomy:keys:
     - nil-taxonomy-test
@@ -64,18 +66,20 @@
     - hippotaxonomy:classifiable
     - mix:referenceable
     jcr:primaryType: nationalindicatorlibrary:indicator
-    nationalindicatorlibrary:assuredStatus: true
+    nationalindicatorlibrary:assuredStatus: false
+    nationalindicatorlibrary:assuredStatus2: false
     nationalindicatorlibrary:publishedBy: NHS Digital
-    nationalindicatorlibrary:reportingLevel: CCG and National
-    nationalindicatorlibrary:title: National Indicator
+    nationalindicatorlibrary:reportingLevel: CCG and National GP registered population
+    nationalindicatorlibrary:title: Unassured Indicator
+    nationalindicatorlibrary:title2: Unassured Indicator
     publicationsystem:GeographicCoverage: England
-  /national-indicator[2]:
+  /unassured-indicator[2]:
     /nationalindicatorlibrary:details:
       /nationalindicatorlibrary:caveats:
         hippostd:content: <p>Caveats</p>
         jcr:primaryType: hippostd:html
       /nationalindicatorlibrary:definition:
-        hippostd:content: <p>SearchableNationalIndicatorDefinition</p>
+        hippostd:content: <p>Definition</p>
         jcr:primaryType: hippostd:html
       /nationalindicatorlibrary:interpretationGuidelines:
         hippostd:content: <p>Interpretation Guidelines</p>
@@ -95,10 +99,10 @@
           jcr:primaryType: hippostd:html
         jcr:primaryType: nationalindicatorlibrary:methodology
       /nationalindicatorlibrary:purpose:
-        hippostd:content: <p>SearchableNationalIndicatorPurpose</p>
+        hippostd:content: <p>Purpose</p>
         jcr:primaryType: hippostd:html
       jcr:primaryType: nationalindicatorlibrary:details
-      nationalindicatorlibrary:briefDescription: National Indicator
+      nationalindicatorlibrary:briefDescription: Unassured Indicator
       nationalindicatorlibrary:iapCode: IAPCODE1
       nationalindicatorlibrary:indicatorSet: ''
       nationalindicatorlibrary:rating: ''
@@ -109,9 +113,11 @@
         nationalindicatorlibrary:contactAuthorName: Author
       jcr:primaryType: nationalindicatorlibrary:topbar
       nationalindicatorlibrary:assuranceDate: 2018-02-23T13:53:00Z
+      nationalindicatorlibrary:assuredStatus: false
       nationalindicatorlibrary:basedOn: Test
       nationalindicatorlibrary:reportingPeriod: Now
       nationalindicatorlibrary:reviewDate: 2018-02-23T13:53:00Z
+      nationalindicatorlibrary:title: Unassured Indicator
     common:FacetType: indicator
     common:FullTaxonomy:
     - nil-taxonomy-test
@@ -124,7 +130,7 @@
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-23T13:52:36.010Z
-    hippostdpubwf:lastModificationDate: 2018-03-07T08:15:01.791Z
+    hippostdpubwf:lastModificationDate: 2018-03-07T08:15:16.856Z
     hippostdpubwf:lastModifiedBy: admin
     hippotaxonomy:keys:
     - nil-taxonomy-test
@@ -135,18 +141,20 @@
     - mix:referenceable
     - mix:versionable
     jcr:primaryType: nationalindicatorlibrary:indicator
-    nationalindicatorlibrary:assuredStatus: true
+    nationalindicatorlibrary:assuredStatus: false
+    nationalindicatorlibrary:assuredStatus2: false
     nationalindicatorlibrary:publishedBy: NHS Digital
-    nationalindicatorlibrary:reportingLevel: CCG and National
-    nationalindicatorlibrary:title: National Indicator
+    nationalindicatorlibrary:reportingLevel: CCG and National GP registered population
+    nationalindicatorlibrary:title: Unassured Indicator
+    nationalindicatorlibrary:title2: Unassured Indicator
     publicationsystem:GeographicCoverage: England
-  /national-indicator[3]:
+  /unassured-indicator[3]:
     /nationalindicatorlibrary:details:
       /nationalindicatorlibrary:caveats:
         hippostd:content: <p>Caveats</p>
         jcr:primaryType: hippostd:html
       /nationalindicatorlibrary:definition:
-        hippostd:content: <p>SearchableNationalIndicatorDefinition</p>
+        hippostd:content: <p>Definition</p>
         jcr:primaryType: hippostd:html
       /nationalindicatorlibrary:interpretationGuidelines:
         hippostd:content: <p>Interpretation Guidelines</p>
@@ -166,10 +174,10 @@
           jcr:primaryType: hippostd:html
         jcr:primaryType: nationalindicatorlibrary:methodology
       /nationalindicatorlibrary:purpose:
-        hippostd:content: <p>SearchableNationalIndicatorPurpose</p>
+        hippostd:content: <p>Purpose</p>
         jcr:primaryType: hippostd:html
       jcr:primaryType: nationalindicatorlibrary:details
-      nationalindicatorlibrary:briefDescription: National Indicator
+      nationalindicatorlibrary:briefDescription: Unassured Indicator
       nationalindicatorlibrary:iapCode: IAPCODE1
       nationalindicatorlibrary:indicatorSet: ''
       nationalindicatorlibrary:rating: ''
@@ -180,9 +188,11 @@
         nationalindicatorlibrary:contactAuthorName: Author
       jcr:primaryType: nationalindicatorlibrary:topbar
       nationalindicatorlibrary:assuranceDate: 2018-02-23T13:53:00Z
+      nationalindicatorlibrary:assuredStatus: false
       nationalindicatorlibrary:basedOn: Test
       nationalindicatorlibrary:reportingPeriod: Now
       nationalindicatorlibrary:reviewDate: 2018-02-23T13:53:00Z
+      nationalindicatorlibrary:title: Unassured Indicator
     common:FacetType: indicator
     common:FullTaxonomy:
     - nil-taxonomy-test
@@ -195,9 +205,9 @@
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-23T13:52:36.010Z
-    hippostdpubwf:lastModificationDate: 2018-03-07T08:15:01.791Z
+    hippostdpubwf:lastModificationDate: 2018-03-07T08:15:16.856Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2018-03-07T08:15:05.868Z
+    hippostdpubwf:publicationDate: 2018-03-07T08:15:21.924Z
     hippotaxonomy:keys:
     - nil-taxonomy-test
     hippotranslation:id: e1403a71-7217-4752-88ee-a83266332aa9
@@ -206,12 +216,14 @@
     - hippotaxonomy:classifiable
     - mix:referenceable
     jcr:primaryType: nationalindicatorlibrary:indicator
-    nationalindicatorlibrary:assuredStatus: true
+    nationalindicatorlibrary:assuredStatus: false
+    nationalindicatorlibrary:assuredStatus2: false
     nationalindicatorlibrary:publishedBy: NHS Digital
-    nationalindicatorlibrary:reportingLevel: CCG and National
-    nationalindicatorlibrary:title: National Indicator
+    nationalindicatorlibrary:reportingLevel: CCG and National GP registered population
+    nationalindicatorlibrary:title: Unassured Indicator
+    nationalindicatorlibrary:title2: Unassured Indicator
     publicationsystem:GeographicCoverage: England
-  hippo:name: national indicator
+  hippo:name: unassured indicator
   jcr:mixinTypes:
   - hippo:named
   - mix:referenceable

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/sample-indicator.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/sample-indicator.yaml
@@ -76,11 +76,6 @@
           are included in the indicator to take into account the process of recognising
           the stroke has occurred and the systems in place for in-hospital pathways.</p>
         jcr:primaryType: hippostd:html
-      hippotaxonomy:keys:
-      - conditions
-      - cancer
-      jcr:mixinTypes:
-      - hippotaxonomy:classifiable
       jcr:primaryType: nationalindicatorlibrary:details
       nationalindicatorlibrary:briefDescription: Brief Search description
       nationalindicatorlibrary:iapCode: IAP923845
@@ -93,28 +88,40 @@
         nationalindicatorlibrary:contactAuthorName: Hugo
       jcr:primaryType: nationalindicatorlibrary:topbar
       nationalindicatorlibrary:assuranceDate: 2015-12-14T00:00:00Z
-      nationalindicatorlibrary:assuredStatus: true
       nationalindicatorlibrary:basedOn: Royal College of Physicians’ Sentinel Stroke
         National Audit Programme (SSNAP)
       nationalindicatorlibrary:publishedBy: Publisher
-      nationalindicatorlibrary:reportingLevel: CCG
       nationalindicatorlibrary:reportingPeriod: Annually
       nationalindicatorlibrary:reviewDate: 2018-12-14T00:00:00Z
-      nationalindicatorlibrary:title: People with stroke admitted to an acute stroke
-        unit within 4 hours of arrival at hospital
     common:FacetType: indicator
+    common:FullTaxonomy:
+    - cancer
+    - conditions
+    common:SearchableTags:
+    - Conditions
+    - Cancer
     common:searchable: true
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-22T13:14:38.445Z
-    hippostdpubwf:lastModificationDate: 2018-02-26T09:34:34.912Z
+    hippostdpubwf:lastModificationDate: 2018-03-07T08:57:37.172Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - conditions
+    - cancer
     hippotranslation:id: 8760f929-796c-426e-bd55-826b9362a5ae
     hippotranslation:locale: en
     jcr:mixinTypes:
+    - hippotaxonomy:classifiable
     - mix:referenceable
     jcr:primaryType: nationalindicatorlibrary:indicator
+    nationalindicatorlibrary:assuredStatus: true
+    nationalindicatorlibrary:publishedBy: NHS Digital
+    nationalindicatorlibrary:reportingLevel: CCG
+    nationalindicatorlibrary:title: People with stroke admitted to an acute stroke
+      unit within 4 hours of arrival at hospital
+    publicationsystem:GeographicCoverage: England
   /sample-indicator[2]:
     /nationalindicatorlibrary:details:
       /nationalindicatorlibrary:caveats:
@@ -191,11 +198,6 @@
           are included in the indicator to take into account the process of recognising
           the stroke has occurred and the systems in place for in-hospital pathways.</p>
         jcr:primaryType: hippostd:html
-      hippotaxonomy:keys:
-      - conditions
-      - cancer
-      jcr:mixinTypes:
-      - hippotaxonomy:classifiable
       jcr:primaryType: nationalindicatorlibrary:details
       nationalindicatorlibrary:briefDescription: Brief Search description
       nationalindicatorlibrary:iapCode: IAP923845
@@ -208,30 +210,42 @@
         nationalindicatorlibrary:contactAuthorName: Hugo
       jcr:primaryType: nationalindicatorlibrary:topbar
       nationalindicatorlibrary:assuranceDate: 2015-12-14T00:00:00Z
-      nationalindicatorlibrary:assuredStatus: true
       nationalindicatorlibrary:basedOn: Royal College of Physicians’ Sentinel Stroke
         National Audit Programme (SSNAP)
       nationalindicatorlibrary:publishedBy: Publisher
-      nationalindicatorlibrary:reportingLevel: CCG
       nationalindicatorlibrary:reportingPeriod: Annually
       nationalindicatorlibrary:reviewDate: 2018-12-14T00:00:00Z
-      nationalindicatorlibrary:title: People with stroke admitted to an acute stroke
-        unit within 4 hours of arrival at hospital
     common:FacetType: indicator
+    common:FullTaxonomy:
+    - cancer
+    - conditions
+    common:SearchableTags:
+    - Conditions
+    - Cancer
     common:searchable: true
     hippo:availability:
     - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-22T13:14:38.445Z
-    hippostdpubwf:lastModificationDate: 2018-02-26T09:34:50.640Z
+    hippostdpubwf:lastModificationDate: 2018-03-07T08:14:15.542Z
     hippostdpubwf:lastModifiedBy: admin
+    hippotaxonomy:keys:
+    - conditions
+    - cancer
     hippotranslation:id: 8760f929-796c-426e-bd55-826b9362a5ae
     hippotranslation:locale: en
     jcr:mixinTypes:
+    - hippotaxonomy:classifiable
     - mix:referenceable
     - mix:versionable
     jcr:primaryType: nationalindicatorlibrary:indicator
+    nationalindicatorlibrary:assuredStatus: true
+    nationalindicatorlibrary:publishedBy: NHS Digital
+    nationalindicatorlibrary:reportingLevel: CCG
+    nationalindicatorlibrary:title: People with stroke admitted to an acute stroke
+      unit within 4 hours of arrival at hospital
+    publicationsystem:GeographicCoverage: England
   /sample-indicator[3]:
     /nationalindicatorlibrary:details:
       /nationalindicatorlibrary:caveats:
@@ -308,11 +322,6 @@
           are included in the indicator to take into account the process of recognising
           the stroke has occurred and the systems in place for in-hospital pathways.</p>
         jcr:primaryType: hippostd:html
-      hippotaxonomy:keys:
-      - conditions
-      - cancer
-      jcr:mixinTypes:
-      - hippotaxonomy:classifiable
       jcr:primaryType: nationalindicatorlibrary:details
       nationalindicatorlibrary:briefDescription: Brief Search description
       nationalindicatorlibrary:iapCode: IAP923845
@@ -325,30 +334,43 @@
         nationalindicatorlibrary:contactAuthorName: Hugo
       jcr:primaryType: nationalindicatorlibrary:topbar
       nationalindicatorlibrary:assuranceDate: 2015-12-14T00:00:00Z
-      nationalindicatorlibrary:assuredStatus: true
       nationalindicatorlibrary:basedOn: Royal College of Physicians’ Sentinel Stroke
         National Audit Programme (SSNAP)
       nationalindicatorlibrary:publishedBy: Publisher
-      nationalindicatorlibrary:reportingLevel: CCG
       nationalindicatorlibrary:reportingPeriod: Annually
       nationalindicatorlibrary:reviewDate: 2018-12-14T00:00:00Z
-      nationalindicatorlibrary:title: People with stroke admitted to an acute stroke
-        unit within 4 hours of arrival at hospital
     common:FacetType: indicator
+    common:FullTaxonomy:
+    - cancer
+    - conditions
+    common:SearchableTags:
+    - Conditions
+    - Cancer
     common:searchable: true
     hippo:availability:
     - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-22T13:14:38.445Z
-    hippostdpubwf:lastModificationDate: 2018-02-23T16:09:07.787Z
+    hippostdpubwf:lastModificationDate: 2018-03-07T08:14:15.542Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2018-02-23T16:09:10.121Z
+    hippostdpubwf:publicationDate: 2018-03-07T08:14:27.666Z
+    hippotaxonomy:keys:
+    - conditions
+    - cancer
     hippotranslation:id: 8760f929-796c-426e-bd55-826b9362a5ae
     hippotranslation:locale: en
     jcr:mixinTypes:
+    - hippotaxonomy:classifiable
     - mix:referenceable
+    - mix:versionable
     jcr:primaryType: nationalindicatorlibrary:indicator
+    nationalindicatorlibrary:assuredStatus: true
+    nationalindicatorlibrary:publishedBy: NHS Digital
+    nationalindicatorlibrary:reportingLevel: CCG
+    nationalindicatorlibrary:title: People with stroke admitted to an acute stroke
+      unit within 4 hours of arrival at hospital
+    publicationsystem:GeographicCoverage: England
   hippo:name: sample indicator
   jcr:mixinTypes:
   - hippo:named

--- a/repository-data/development/src/main/resources/hcm-content/content/taxonomies/publication_taxonomy.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/taxonomies/publication_taxonomy.yaml
@@ -7,6 +7,14 @@
           hippotaxonomy:name: Acceptance Tests
           jcr:primaryType: hippotaxonomy:categoryinfo
         jcr:primaryType: hippotaxonomy:categoryinfos
+      /niltaxonomysearchterm-test:
+        /hippotaxonomy:categoryinfos:
+          /en:
+            hippotaxonomy:name: NilTaxonomySearchTerm test
+            jcr:primaryType: hippotaxonomy:categoryinfo
+          jcr:primaryType: hippotaxonomy:categoryinfos
+        hippotaxonomy:key: nil-taxonomy-test
+        jcr:primaryType: hippotaxonomy:category
       /synonym-test:
         /hippotaxonomy:categoryinfos:
           /en:
@@ -449,6 +457,14 @@
           hippotaxonomy:name: Acceptance Tests
           jcr:primaryType: hippotaxonomy:categoryinfo
         jcr:primaryType: hippotaxonomy:categoryinfos
+      /niltaxonomysearchterm-test:
+        /hippotaxonomy:categoryinfos:
+          /en:
+            hippotaxonomy:name: NilTaxonomySearchTerm test
+            jcr:primaryType: hippotaxonomy:categoryinfo
+          jcr:primaryType: hippotaxonomy:categoryinfos
+        hippotaxonomy:key: nil-taxonomy-test
+        jcr:primaryType: hippotaxonomy:category
       /synonym-test:
         /hippotaxonomy:categoryinfos:
           /en:

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/facets.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/facets.ftl
@@ -38,7 +38,9 @@
                     <#elseif facet.name="category">
                         <#assign valueName=taxonomy.getValueName(value.name)/>
                     <#elseif facet.name="document-type">
-                        <@fmt.message key="facet."+value.name var="valueName"/>
+                        <@fmt.message key="facet."+value.name var="valueName"/>  
+                    <#elseif facet.name="assuredStatus">
+                        <#assign valueName=value.name?boolean?then('Yes','No')/>                                         
                     <#else>
                         <#assign valueName=value.name/>
                     </#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/results.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/results.ftl
@@ -103,12 +103,12 @@
     <div class="push-double--bottom" data-uipath="ps.search-results.result">
         <h3 class="flush zeta" data-uipath="ps.search-results.result.type" style="font-weight:bold">Indicator</h3>
         <p class="flush">
-            <a href="<@hst.link hippobean=item.selfLinkBean/>" title="${item.topbar.title}" data-uipath="ps.search-results.result.title">
-                ${item.topbar.title}
+            <a href="<@hst.link hippobean=item.selfLinkBean/>" title="${item.title}" data-uipath="ps.search-results.result.title">
+                ${item.title}
             </a>
         </p>
-        <#if item.topbar.assuredStatus><p class="flush zeta" data-uipath="ps.search-results.result.assured-status">Independently Assured by IGB (conditional)</p></#if>
-        <p class="flush zeta" data-uipath="ps.search-results.result.publisher-and-date" style="font-weight:bold"><@fmt.message key="headers.publishedBy"/>: ${item.topbar.publishedBy}, <@fmt.message key="headers.assured"/>: ${item.topbar.assuranceDate.time?string[dateFormat]}</p>
+        <#if item.assuredStatus><p class="flush zeta" data-uipath="ps.search-results.result.assured-status">Independently Assured by IGB (conditional)</p></#if>
+        <p class="flush zeta" data-uipath="ps.search-results.result.publisher-and-date" style="font-weight:bold"><@fmt.message key="headers.publishedBy"/>: ${item.publishedBy}<#if item.assuredStatus>, <@fmt.message key="headers.assured"/>: ${item.topbar.assuranceDate.time?string[dateFormat]}</p></#if>
         <p class="flush" data-uipath="ps.search-results.result.brief-description">${item.details.briefDescription}</p>        
     </div>
 </#macro>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/nationalindicatorlibrary/indicator.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/nationalindicatorlibrary/indicator.ftl
@@ -7,21 +7,33 @@
 
   <section class="document-header push-double--bottom">
       <div class="document-header__inner">
-        <h1 class="layout-5-6 push--bottom" data-uipath="ps.indicator.title">${indicator.topbar.title}</h1>
+        <h1 class="layout-5-6 push--bottom" data-uipath="ps.indicator.title">${indicator.title}</h1>
 
-        <#if indicator.topbar.assuredStatus><h2 style="text-decoration:underline">Independently assured by IGB</h2></#if>
+        <#if indicator.assuredStatus><h2 style="text-decoration:underline">Independently assured by IGB</h2></#if>
 
         <div class="layout">
             <div class="layout__item layout-1-2">
-                <p class="push-half--bottom"><strong><@fmt.message key="headers.publishedBy"/></strong>: ${indicator.topbar.publishedBy}</p>
+                <p class="push-half--bottom"><strong><@fmt.message key="headers.publishedBy"/></strong>: ${indicator.publishedBy}</p>
                 <p class="push-half--bottom"><strong><@fmt.message key="headers.assuranceDate"/></strong>: ${indicator.topbar.assuranceDate.time?string[dateFormat]}</p>
                 <p class="push-half--bottom"><strong><@fmt.message key="headers.reportingPeriod"/></strong>: ${indicator.topbar.reportingPeriod}</p>
                 <p class="push-half--bottom"><strong><@fmt.message key="headers.basedOn"/></strong>: ${indicator.topbar.basedOn}</p>
             </div><!--
             --><div class="layout__item layout-1-2">
                 <p class="push-half--bottom"><strong><@fmt.message key="headers.contactAuthor"/></strong>: <a href="mailto:${indicator.topbar.contactAuthor.contactAuthorEmail}"> ${indicator.topbar.contactAuthor.contactAuthorName}</a></p>
-                <p class="push-half--bottom"><strong><@fmt.message key="headers.reportingLevel"/></strong>: ${indicator.topbar.reportingLevel}</p>
+                <p class="push-half--bottom"><strong><@fmt.message key="headers.reportingLevel"/></strong>: ${indicator.reportingLevel}</p>
                 <p class="push-half--bottom"><strong><@fmt.message key="headers.reviewDate"/></strong>: ${indicator.topbar.reviewDate.time?string[dateFormat]}</p>
+                <#if indicator.geographicCoverage?has_content><div class="flex__item">
+                    <div class="media">
+                        <div class="media__icon media__icon--geographic-coverage"></div>
+                        <dl class="media__body">
+                            <dt id="geographic-coverage"><@fmt.message key="headers.geographicCoverage"/></dt>
+                            <dd data-uipath="ps.indicator.geographic-coverage">
+                                ${indicator.geographicCoverage}
+                            </dd>
+                        </dl>
+                    </div>
+                    </div>
+                </#if>
             </div>
         </div>
       </div>
@@ -39,7 +51,9 @@
                     <li><a href="#methodology"><@fmt.message key="headers.methodology"/></a></li>
                     <li><a href="#caveats"><@fmt.message key="headers.caveats"/></a></li>
                     <li><a href="#interpretations"><@fmt.message key="headers.interpretationGuidelines"/></a></li>
+                    <#if indicator.attachments?has_content>
                     <li><a href="#resources">Resources</a></li>
+                    </#if>
                 </ul>
             </div>
         </div>
@@ -58,23 +72,30 @@
         </section>
 
 
-        <h2><details id="methodology" class="push-double--bottom">
+        <details id="methodology" class="push-double--bottom">
             <summary><span>How this indicator is calculated</span></summary></br>
-            <h2><@fmt.message key="headers.methodology"/></h2>
+            <div class="panel panel--grey">
+                <#if indicator.details.methodology.dataSource?has_content>
+                    <h3><strong><@fmt.message key="headers.dataSource"/></strong></h3>
+                    <#outputformat "undefined">${indicator.details.methodology.dataSource.content}</#outputformat>
+                </#if>
+                
+                <#if indicator.details.methodology.numerator?has_content> 
+                    <h3><strong><@fmt.message key="headers.numerator"/></strong></h3>
+                    <#outputformat "undefined">${indicator.details.methodology.numerator.content}</#outputformat>
+                </#if>
 
-            <h6><strong><@fmt.message key="headers.dataSource"/></strong></h6>
-            <#outputformat "undefined"><p>${indicator.details.methodology.dataSource.content}</p></#outputformat>
+                <#if indicator.details.methodology.denominator?has_content>
+                    <h3><strong><@fmt.message key="headers.denominator"/></strong></h3>
+                    <#outputformat "undefined">${indicator.details.methodology.denominator.content}</#outputformat>
+                </#if>            
 
-            <h6><strong><@fmt.message key="headers.numerator"/></strong></h6>
-            <#outputformat "undefined"><p>${indicator.details.methodology.numerator.content}</p></#outputformat>
-
-            <h6><strong><@fmt.message key="headers.denominator"/></strong></h6>
-            <#outputformat "undefined"><p>${indicator.details.methodology.denominator.content}</p></#outputformat>
-
-            <h6><strong><@fmt.message key="headers.calculation"/></strong></h6>
-            <#outputformat "undefined"><p>${indicator.details.methodology.calculation.content}</p></#outputformat>
-
-        </details></h2>
+                <#if indicator.details.methodology.calculation?has_content>
+                    <h3><strong><@fmt.message key="headers.calculation"/></strong></h3>
+                    <#outputformat "undefined">${indicator.details.methodology.calculation.content}</#outputformat>
+                </#if>              
+            </div>
+        </details>
 
         <section id="caveats" class="push-double--bottom">
             <h2><strong><@fmt.message key="headers.caveats"/></strong></h2>
@@ -87,57 +108,20 @@
         </section>
 
         
-
-        <section id="resources" class="push-double--bottom">
-            <h2><strong><@fmt.message key="headers.resources"/></strong></h2>
-            <#if indicator.attachments?has_content>
-                 <ul data-uipath="nil.indicator.resources">
-                    <#list indicator.attachments as attachment>
-                        <li class="attachment">
-                            <a title="${attachment.text}" href="<@hst.link hippobean=attachment.resource/>" onClick="logGoogleAnalyticsEvent('Download attachment','Indicator','${attachment.resource.filename}');">${attachment.text}</a>
-                        </li>
-                    </#list>
-                </ul>
-            </#if>
-        </section>
-
-        <section id="compare" class="push-double--bottom">
-            <h2>Compare</h2>
-            <table>
-                <tr>
-                    <td>Title</td>
-                    <td>Publisher</td>
-                    <td>Assured Date</td>
-                    <td>Assured Until</td>
-                </tr>
-                <tr>
-                    <td><a href="#">Cancers diagnosed via emergency routes</a></td>
-                    <td>PHE</td>
-                    <td>10 June 2017</td>
-                    <td>10 June 2020</td>
-                </tr>
-                <tr>
-                    <td><a href="#">PHE</a></td>
-                    <td>PHE</td>
-                    <td>10 June 2017</td>
-                    <td>10 June 2020</td>
-                </tr>
-                <tr>
-                    <td><a href="#">Under 75 mortality rate from cancer</a></td>
-                    <td>PHE</td>
-                    <td>10 June 2017</td>
-                    <td>10 June 2020</td>
-                </tr>
-            </table>
-        </section>
-
-        <section id="resources" class="push-double--bottom">
-            <h2>5 comments</h2>
-            <div class="panel panel--grey">
-                <p>TBC</p>
-            </div>
-        </section>
-
+        <#if indicator.attachments?has_content>
+            <section id="resources" class="push-double--bottom">
+                <h2><strong><@fmt.message key="headers.resources"/></strong></h2>
+            
+                    <ul data-uipath="nil.indicator.resources">
+                        <#list indicator.attachments as attachment>
+                            <li class="attachment">
+                                <a title="${attachment.text}" href="<@hst.link hippobean=attachment.resource/>" onClick="logGoogleAnalyticsEvent('Download attachment','Indicator','${attachment.resource.filename}');">${attachment.text}</a>
+                            </li>
+                        </#list>
+                    </ul>
+                
+            </section>
+        </#if>
     </section>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>

--- a/site/src/main/java/uk/nhs/digital/nil/beans/Indicator.java
+++ b/site/src/main/java/uk/nhs/digital/nil/beans/Indicator.java
@@ -25,9 +25,39 @@ public class Indicator extends BaseDocument {
         return getChildBeansByName(PropertyKeys.ATTACHMENTS, Attachment.class);
     }
 
+    @HippoEssentialsGenerated(internalName = PropertyKeys.TITLE)
+    public String getTitle() {
+        return getProperty(PropertyKeys.TITLE);
+    }
+
+    @HippoEssentialsGenerated(internalName = PropertyKeys.ASSUREDSTATUS)
+    public Boolean getAssuredStatus() {
+        return getProperty(PropertyKeys.ASSUREDSTATUS);
+    }
+
+    @HippoEssentialsGenerated(internalName = PropertyKeys.PUBLISHEDBY)
+    public String getPublishedBy() {
+        return getProperty(PropertyKeys.PUBLISHEDBY);
+    }
+
+    @HippoEssentialsGenerated(internalName = PropertyKeys.REPORTINGLEVEL)
+    public String getReportingLevel() {
+        return getProperty(PropertyKeys.REPORTINGLEVEL);
+    }
+
+    @HippoEssentialsGenerated(internalName = PropertyKeys.GEOGRAPHIC_COVERAGE)
+    public String getGeographicCoverage() {
+        return getProperty(PropertyKeys.GEOGRAPHIC_COVERAGE);
+    }
+
     interface PropertyKeys {
         String ATTACHMENTS = "nationalindicatorlibrary:attachments";
         String DETAILS = "nationalindicatorlibrary:details";
         String TOPBAR = "nationalindicatorlibrary:topbar";
+        String TITLE = "nationalindicatorlibrary:title";
+        String ASSUREDSTATUS = "nationalindicatorlibrary:assuredStatus";
+        String PUBLISHEDBY = "nationalindicatorlibrary:publishedBy"; 
+        String REPORTINGLEVEL = "nationalindicatorlibrary:reportingLevel";     
+        String GEOGRAPHIC_COVERAGE = "publicationsystem:GeographicCoverage";                   
     }
 }

--- a/site/src/main/java/uk/nhs/digital/nil/beans/Topbar.java
+++ b/site/src/main/java/uk/nhs/digital/nil/beans/Topbar.java
@@ -14,24 +14,9 @@ public class Topbar extends HippoCompound {
         return getProperty("nationalindicatorlibrary:assuranceDate");
     }
 
-    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:assuredStatus")
-    public Boolean getAssuredStatus() {
-        return getProperty("nationalindicatorlibrary:assuredStatus");
-    }
-
-    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:publishedBy")
-    public String getPublishedBy() {
-        return getProperty("nationalindicatorlibrary:publishedBy");
-    }
-
     @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:reviewDate")
     public Calendar getReviewDate() {
         return getProperty("nationalindicatorlibrary:reviewDate");
-    }
-
-    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:title")
-    public String getTitle() {
-        return getProperty("nationalindicatorlibrary:title");
     }
 
     @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:basedOn")
@@ -42,11 +27,6 @@ public class Topbar extends HippoCompound {
     @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:contactAuthor")
     public ContactAuthor getContactAuthor() {
         return getBean("nationalindicatorlibrary:contactAuthor", ContactAuthor.class);
-    }
-
-    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:reportingLevel")
-    public String getReportingLevel() {
-        return getProperty("nationalindicatorlibrary:reportingLevel");
     }
 
     @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:reportingPeriod")


### PR DESCRIPTION
Addition of 3 new facets which relate to the NIL Indicator document type.

Most of the "noise" here is the moving of 4 searchable fields and taxonomy/classifiable out of the Topbar component and into the main Indicator document. This is required because Lucene requires a flat data-model.

Also added geographical location to Indicator and cleaned up the Indicator.ftl.

(Note, there is no migration script as there is no content to migrate at this point. Also the hippo migration project will be updated separately.)