### PR TITLE
[DW-145] Moving YamlFormatter execution in a separate profile

### DIFF
--- a/HIPPO.md
+++ b/HIPPO.md
@@ -21,6 +21,10 @@ Access the Hippo Essentials at http://localhost:8080/essentials.
 After your project is set up, access the CMS at http://localhost:8080/cms and the site at http://localhost:8080/site.
 Logs are located in target/tomcat8x/logs
 
+Moreover, YamlFormatter.groovy can be automatically executed while building. The *format* profile can be used:
+
+  mvn clean verify -Pformat
+
 Building distributions
 ======================
 

--- a/repository-data/development/pom.xml
+++ b/repository-data/development/pom.xml
@@ -37,30 +37,40 @@
                     </archive>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.codehaus.gmaven</groupId>
-                <artifactId>groovy-maven-plugin</artifactId>
-                <version>2.0</version>
-                <executions>
-                    <execution>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>execute</goal>
-                        </goals>
-                        <configuration>
-                            <source>${website.basedir}/repository-data/development/src/main/script/YamlFormatter.groovy</source>
-                        </configuration>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.yaml</groupId>
-                        <artifactId>snakeyaml</artifactId>
-                        <version>1.19</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>format</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.gmaven</groupId>
+                        <artifactId>groovy-maven-plugin</artifactId>
+                        <version>2.0</version>
+                        <executions>
+                            <execution>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>execute</goal>
+                                </goals>
+                                <configuration>
+                                    <source>${website.basedir}/repository-data/development/src/main/script/YamlFormatter.groovy</source>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.yaml</groupId>
+                                <artifactId>snakeyaml</artifactId>
+                                <version>1.19</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
Hello guys, I've moved the execution of the YamlFormatter.groovy in separate profile. The reasons are:

1. The script is removing uuids and references between documents, if they exist, are broken in the next execution
2. The script is ordering yaml file, but we found issues while importing value list file

My proposal is to format yaml file only if explicitly requested by users. You can use  
`mvn clean verify -Pformat`