### PR TITLE
[NIL-122] Display tagged taxonomy on Indicator summary

### DIFF
--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/national-indicator-library/headers.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/national-indicator-library/headers.yaml
@@ -45,6 +45,7 @@
     - headers.iapCode
     - headers.indicatorSet
     - headers.interpretationGuidelines
+    - headers.categories
     - headers.resources
     - headers.methodology
     - headers.publishedBy
@@ -72,6 +73,7 @@
     - IAP Code
     - Indicator Set
     - Interpretation Guidelines
+    - Categories
     - Resources
     - Methodology
     - Published by
@@ -136,6 +138,7 @@
     - headers.iapCode
     - headers.indicatorSet
     - headers.interpretationGuidelines
+    - headers.categories
     - headers.resources
     - headers.methodology
     - headers.publishedBy
@@ -163,6 +166,7 @@
     - IAP Code
     - Indicator Set
     - Interpretation Guidelines
+    - Categories
     - Resources
     - Methodology
     - Published by
@@ -227,6 +231,7 @@
     - headers.iapCode
     - headers.indicatorSet
     - headers.interpretationGuidelines
+    - headers.categories
     - headers.resources
     - headers.methodology
     - headers.publishedBy
@@ -254,6 +259,7 @@
     - IAP Code
     - Indicator Set
     - Interpretation Guidelines
+    - Categories
     - Resources
     - Methodology
     - Published by

--- a/repository-data/webfiles/src/main/resources/site/freemarker/nationalindicatorlibrary/indicator.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/nationalindicatorlibrary/indicator.ftl
@@ -107,7 +107,13 @@
             <#outputformat "undefined">${indicator.details.interpretationGuidelines.content}</#outputformat>
         </section>
 
-        
+        <section class="push-double--bottom">
+            <h2><strong><@fmt.message key="headers.categories"/></strong></h2>
+            <#list indicator.taxonomyList as taxonomy>
+                <p class="filter-list__item__link" data-uipath="ps.indicator.taxonomy-${taxonomy}">${taxonomy}</p>
+            </#list>   
+        </section>     
+
         <#if indicator.attachments?has_content>
             <section id="resources" class="push-double--bottom">
                 <h2><strong><@fmt.message key="headers.resources"/></strong></h2>

--- a/site/src/main/java/uk/nhs/digital/nil/beans/Indicator.java
+++ b/site/src/main/java/uk/nhs/digital/nil/beans/Indicator.java
@@ -4,8 +4,10 @@ import org.hippoecm.hst.content.beans.Node;
 import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
 
 import uk.nhs.digital.ps.beans.Attachment;
+import uk.nhs.digital.ps.beans.HippoBeanHelper;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:indicator")
 @Node(jcrType = "nationalindicatorlibrary:indicator")
@@ -50,7 +52,18 @@ public class Indicator extends BaseDocument {
         return getProperty(PropertyKeys.GEOGRAPHIC_COVERAGE);
     }
 
+    @HippoEssentialsGenerated(internalName = PropertyKeys.TAXONOMY)
+    public String[] getKeys() {
+        return getProperty(PropertyKeys.TAXONOMY);
+    }
+
+    public List<String> getTaxonomyList() {
+        List<List<String>> allTaxonomies = HippoBeanHelper.getTaxonomyList(getKeys());
+        return allTaxonomies.stream().flatMap(x -> x.stream()).distinct().collect(Collectors.toList());
+    }
+
     interface PropertyKeys {
+        String TAXONOMY = "hippotaxonomy:keys";
         String ATTACHMENTS = "nationalindicatorlibrary:attachments";
         String DETAILS = "nationalindicatorlibrary:details";
         String TOPBAR = "nationalindicatorlibrary:topbar";


### PR DESCRIPTION
Simple display of taxonomy 'categories' on the NIL Indicator summary page - as per the prototype.