### PR TITLE
[RPS-423] Fix for broken preview

### DIFF
--- a/conf/maven-version-rules.xml
+++ b/conf/maven-version-rules.xml
@@ -17,5 +17,11 @@
                 <ignoreVersion type="regex">2\.0\..*</ignoreVersion>
             </ignoreVersions>
         </rule>
+        <rule groupId="com.fasterxml.jackson.core" comparisonMethod="maven">
+            <ignoreVersions>
+                <!-- CMS preview breaks if we go above 2.8.9, so don't -->
+                <ignoreVersion type="regex">^(?!2\.8\.9).*$</ignoreVersion>
+            </ignoreVersions>
+        </rule>
     </rules>
 </ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -225,23 +225,10 @@
                 <version>1.3.2</version>
                 <scope>test</scope>
             </dependency>
-
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>2.9.4</version>
-            </dependency>
-
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>2.9.4</version>
-            </dependency>
-
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk</artifactId>
-                <version>1.9.6</version>
+                <version>1.11.291</version>
             </dependency>
 
             <!-- Although we don't explicitly use these dependencys, there are conflicts
@@ -259,7 +246,17 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.9.4</version>
+                <version>2.8.9</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>2.8.9</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>2.8.9</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
Preview doesn't work with the latest version of `com.fasterxml.jackson.core` so I've stuck to the version that works.