### PR TITLE
[NIL-91] Move assurance date and include in sort

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/SearchSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/SearchSteps.java
@@ -184,4 +184,41 @@ public class SearchSteps extends AbstractSpringSteps {
             "Search Test Archive Summary"
         );
     }
+
+    @Then("^I should see the NIL weight search test results ordered by (relevance|date)$")
+    public void iShouldSeeTheNilWeightSearchTestResultsOrderedBy(String sort) throws Throwable {
+        // check the results are actually sorted correctly
+        assertSearchResultsStartWith(getSortedNilWeightSearchResults(sort));
+
+        assertEquals("Sort mode is displayed in selector", capitalize(sort), searchPage.getSortSelection());
+
+        assertThat("Sort mode is displayed in result description", searchPage.getResultDescription(), endsWith("sorted by " + sort + "."));
+    }
+
+    private static List<String> getSortedNilWeightSearchResults(String sort) {
+        switch (sort) {
+            case "relevance":
+                return getNilWeightSearchResultsSortedByRelevance();
+            case "date":
+                return getNilWeightSearchResultsOrderedByDate();
+            default:
+                throw new RuntimeException("Unknown sort mode: " + sort);
+        }
+    }
+
+    private static List<String> getNilWeightSearchResultsSortedByRelevance() {
+        return asList(
+            // title takes precedence over definition
+            "Search Test Indicator Title",
+            "Search Test Indicator Definition"
+        );
+    }
+
+    private static List<String> getNilWeightSearchResultsOrderedByDate() {
+        return asList(
+            // These are in assurance date order
+            "Search Test Indicator Definition",
+            "Search Test Indicator Title"
+        );
+    }    
 }

--- a/acceptance-tests/src/test/resources/features/site/search.feature
+++ b/acceptance-tests/src/test/resources/features/site/search.feature
@@ -99,6 +99,15 @@ Feature: Basic search
         When I can click on the "Order by date" link
         Then I should see the weight search test results ordered by date
 
+    Scenario: Using the sort by options with NIL content
+        Given I navigate to the "home" page
+        When I search for "NilSortSearchTerm"
+        Then I should see the NIL weight search test results ordered by date
+        When I can click on the "Order by relevance" link
+        Then I should see the NIL weight search test results ordered by relevance
+        When I can click on the "Order by date" link
+        Then I should see the NIL weight search test results ordered by date
+
     Scenario: Search results description is shown correctly with and without search terms
         When I navigate to the "search" page
         Then I can see the search description matching "\d+ results sorted by date\."

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/indicator.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/indicator.yaml
@@ -104,6 +104,15 @@ definitions:
             wicket.css:
             - geographic-coverage
             wicket.id: ${cluster.id}.left.item
+          /assuranceDate:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Assurance Date
+            field: assuranceDate
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.left.item
           /details:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
@@ -126,6 +135,14 @@ definitions:
         jcr:primaryType: editor:templateset
       /hipposysedit:nodetype:
         /hipposysedit:nodetype:
+          /assuranceDate:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: nationalindicatorlibrary:assuranceDate
+            hipposysedit:primary: false
+            hipposysedit:type: Date
+            jcr:primaryType: hipposysedit:field
           /assuredStatus:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
@@ -255,7 +272,6 @@ definitions:
               nationalindicatorlibrary:contactAuthorEmail: ''
               nationalindicatorlibrary:contactAuthorName: ''
             jcr:primaryType: nationalindicatorlibrary:topbar
-            nationalindicatorlibrary:assuranceDate: 0001-01-01T12:00:00Z
             nationalindicatorlibrary:basedOn: ''
             nationalindicatorlibrary:reportingPeriod: ''
             nationalindicatorlibrary:reviewDate: 0001-01-01T12:00:00Z
@@ -273,6 +289,7 @@ definitions:
           - hippotaxonomy:classifiable
           - mix:referenceable
           jcr:primaryType: nationalindicatorlibrary:indicator
+          nationalindicatorlibrary:assuranceDate: 0001-01-01T12:00:00Z
           nationalindicatorlibrary:assuredStatus: false
           nationalindicatorlibrary:publishedBy: ''
           nationalindicatorlibrary:reportingLevel: ''

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/topbar.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/topbar.yaml
@@ -36,14 +36,6 @@ definitions:
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
-          /assuranceDate:
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-            caption: Assurance Date
-            field: assuranceDate
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.field
           /reviewDate:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
@@ -64,16 +56,6 @@ definitions:
         jcr:primaryType: editor:templateset
       /hipposysedit:nodetype:
         /hipposysedit:nodetype:
-          /assuranceDate:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: nationalindicatorlibrary:assuranceDate
-            hipposysedit:primary: false
-            hipposysedit:type: Date
-            hipposysedit:validators:
-            - required
-            jcr:primaryType: hipposysedit:field
           /contactAuthor:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
@@ -133,7 +115,6 @@ definitions:
             nationalindicatorlibrary:contactAuthorEmail: ''
             nationalindicatorlibrary:contactAuthorName: ''
           jcr:primaryType: nationalindicatorlibrary:topbar
-          nationalindicatorlibrary:assuranceDate: 0001-01-01T12:00:00Z
           nationalindicatorlibrary:basedOn: ''
           nationalindicatorlibrary:reportingPeriod: ''
           nationalindicatorlibrary:reviewDate: 0001-01-01T12:00:00Z

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/national-indicator-library/headers.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/national-indicator-library/headers.yaml
@@ -62,6 +62,7 @@
     - headers.topicsAZ
     - headers.indicatorsAndAssurance
     - headers.assured
+    - headers.unassured
     - headers.igbAssurance
     resourcebundle:messages:
     - Assurance Date
@@ -90,6 +91,7 @@
     - Indicator topics A-Z
     - Indicators and assurance
     - Assured
+    - Date
     - Indicator Governance Board (IGB) Assurance
   /headers[2]:
     hippo:availability:
@@ -155,6 +157,7 @@
     - headers.topicsAZ
     - headers.indicatorsAndAssurance
     - headers.assured
+    - headers.unassured
     - headers.igbAssurance
     resourcebundle:messages:
     - Assurance Date
@@ -183,6 +186,7 @@
     - Indicator topics A-Z
     - Indicators and assurance
     - Assured
+    - Date
     - Indicator Governance Board (IGB) Assurance
   /headers[3]:
     hippo:availability:
@@ -248,6 +252,7 @@
     - headers.topicsAZ
     - headers.indicatorsAndAssurance
     - headers.assured
+    - headers.unassured
     - headers.igbAssurance
     resourcebundle:messages:
     - Assurance Date
@@ -276,6 +281,7 @@
     - Indicator topics A-Z
     - Indicators and assurance
     - Assured
+    - Date
     - Indicator Governance Board (IGB) Assurance
   hippo:name: Headers
   jcr:mixinTypes:

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/national-indicator-library/labels.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/national-indicator-library/labels.yaml
@@ -17,9 +17,11 @@
     resourcebundle:keys:
     - labels.indicator
     - labels.assured
+    - labels.unassured
     resourcebundle:messages:
     - Methodology
     - Independently Assured by IGB
+    - Unassured
   /labels[2]:
     hippo:availability:
     - preview
@@ -39,9 +41,11 @@
     resourcebundle:keys:
     - labels.indicator
     - labels.assured
+    - labels.unassured
     resourcebundle:messages:
     - Methodology
     - Independently Assured by IGB
+    - Unassured
   /labels[3]:
     hippo:availability:
     - live
@@ -61,9 +65,11 @@
     resourcebundle:keys:
     - labels.indicator
     - labels.assured
+    - labels.unassured
     resourcebundle:messages:
     - Methodology
     - Independently Assured by IGB
+    - Unassured
   hippo:name: Labels
   jcr:mixinTypes:
   - hippo:named

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/acceptance-tests/national-indicator.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/acceptance-tests/national-indicator.yaml
@@ -39,7 +39,6 @@
         nationalindicatorlibrary:contactAuthorEmail: ''
         nationalindicatorlibrary:contactAuthorName: Author
       jcr:primaryType: nationalindicatorlibrary:topbar
-      nationalindicatorlibrary:assuranceDate: 2018-02-23T13:53:00Z
       nationalindicatorlibrary:basedOn: Test
       nationalindicatorlibrary:reportingPeriod: Now
       nationalindicatorlibrary:reviewDate: 2018-02-23T13:53:00Z
@@ -54,7 +53,7 @@
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-23T13:52:36.010Z
-    hippostdpubwf:lastModificationDate: 2018-03-07T08:14:54.168Z
+    hippostdpubwf:lastModificationDate: 2018-03-09T13:25:15.233Z
     hippostdpubwf:lastModifiedBy: admin
     hippotaxonomy:keys:
     - nil-taxonomy-test
@@ -64,6 +63,7 @@
     - hippotaxonomy:classifiable
     - mix:referenceable
     jcr:primaryType: nationalindicatorlibrary:indicator
+    nationalindicatorlibrary:assuranceDate: 2018-03-02T00:00:00Z
     nationalindicatorlibrary:assuredStatus: true
     nationalindicatorlibrary:publishedBy: NHS Digital
     nationalindicatorlibrary:reportingLevel: CCG and National
@@ -108,7 +108,6 @@
         nationalindicatorlibrary:contactAuthorEmail: ''
         nationalindicatorlibrary:contactAuthorName: Author
       jcr:primaryType: nationalindicatorlibrary:topbar
-      nationalindicatorlibrary:assuranceDate: 2018-02-23T13:53:00Z
       nationalindicatorlibrary:basedOn: Test
       nationalindicatorlibrary:reportingPeriod: Now
       nationalindicatorlibrary:reviewDate: 2018-02-23T13:53:00Z
@@ -124,7 +123,7 @@
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-23T13:52:36.010Z
-    hippostdpubwf:lastModificationDate: 2018-03-07T08:15:01.791Z
+    hippostdpubwf:lastModificationDate: 2018-03-09T13:25:27.784Z
     hippostdpubwf:lastModifiedBy: admin
     hippotaxonomy:keys:
     - nil-taxonomy-test
@@ -135,6 +134,7 @@
     - mix:referenceable
     - mix:versionable
     jcr:primaryType: nationalindicatorlibrary:indicator
+    nationalindicatorlibrary:assuranceDate: 2018-03-02T00:00:00Z
     nationalindicatorlibrary:assuredStatus: true
     nationalindicatorlibrary:publishedBy: NHS Digital
     nationalindicatorlibrary:reportingLevel: CCG and National
@@ -179,7 +179,6 @@
         nationalindicatorlibrary:contactAuthorEmail: ''
         nationalindicatorlibrary:contactAuthorName: Author
       jcr:primaryType: nationalindicatorlibrary:topbar
-      nationalindicatorlibrary:assuranceDate: 2018-02-23T13:53:00Z
       nationalindicatorlibrary:basedOn: Test
       nationalindicatorlibrary:reportingPeriod: Now
       nationalindicatorlibrary:reviewDate: 2018-02-23T13:53:00Z
@@ -195,9 +194,9 @@
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-23T13:52:36.010Z
-    hippostdpubwf:lastModificationDate: 2018-03-07T08:15:01.791Z
+    hippostdpubwf:lastModificationDate: 2018-03-09T13:25:27.784Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2018-03-07T08:15:05.868Z
+    hippostdpubwf:publicationDate: 2018-03-09T13:25:32.572Z
     hippotaxonomy:keys:
     - nil-taxonomy-test
     hippotranslation:id: e1403a71-7217-4752-88ee-a83266332aa9
@@ -206,6 +205,7 @@
     - hippotaxonomy:classifiable
     - mix:referenceable
     jcr:primaryType: nationalindicatorlibrary:indicator
+    nationalindicatorlibrary:assuranceDate: 2018-03-02T00:00:00Z
     nationalindicatorlibrary:assuredStatus: true
     nationalindicatorlibrary:publishedBy: NHS Digital
     nationalindicatorlibrary:reportingLevel: CCG and National

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/acceptance-tests/search-test-definition-indicator.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/acceptance-tests/search-test-definition-indicator.yaml
@@ -1,12 +1,12 @@
 ---
-/content/documents/corporate-website/national-indicator-library/acceptance-tests/bare-minimum-indicator:
-  /bare-minimum-indicator[1]:
+/content/documents/corporate-website/national-indicator-library/acceptance-tests/search-test-definition-indicator:
+  /search-test-definition-indicator[1]:
     /nationalindicatorlibrary:details:
       /nationalindicatorlibrary:caveats:
         hippostd:content: ''
         jcr:primaryType: hippostd:html
       /nationalindicatorlibrary:definition:
-        hippostd:content: <p>Definition</p>
+        hippostd:content: <p>NilSortSearchTerm</p>
         jcr:primaryType: hippostd:html
       /nationalindicatorlibrary:interpretationGuidelines:
         hippostd:content: ''
@@ -26,10 +26,12 @@
           jcr:primaryType: hippostd:html
         jcr:primaryType: nationalindicatorlibrary:methodology
       /nationalindicatorlibrary:purpose:
-        hippostd:content: <p>Purpose</p>
+        hippostd:content: <p>test</p>
         jcr:primaryType: hippostd:html
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
       jcr:primaryType: nationalindicatorlibrary:details
-      nationalindicatorlibrary:briefDescription: Bare Minimum Indicator
+      nationalindicatorlibrary:briefDescription: test
       nationalindicatorlibrary:iapCode: ''
       nationalindicatorlibrary:indicatorSet: ''
       nationalindicatorlibrary:rating: ''
@@ -37,27 +39,20 @@
       /nationalindicatorlibrary:contactAuthor:
         jcr:primaryType: nationalindicatorlibrary:contactAuthor
         nationalindicatorlibrary:contactAuthorEmail: ''
-        nationalindicatorlibrary:contactAuthorName: Test
+        nationalindicatorlibrary:contactAuthorName: test
       jcr:primaryType: nationalindicatorlibrary:topbar
-      nationalindicatorlibrary:basedOn: Test
-      nationalindicatorlibrary:reportingPeriod: Now
-      nationalindicatorlibrary:reviewDate: 2018-02-23T13:57:00Z
+      nationalindicatorlibrary:basedOn: set
+      nationalindicatorlibrary:reportingPeriod: test
+      nationalindicatorlibrary:reviewDate: 2018-03-09T16:08:00Z
     common:FacetType: indicator
-    common:FullTaxonomy:
-    - nil-taxonomy-test
-    - acceptance-tests
-    common:SearchableTags:
-    - NilTaxonomySearchTerm test
     common:searchable: true
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2018-02-23T13:57:04.917Z
-    hippostdpubwf:lastModificationDate: 2018-03-09T13:24:47.119Z
+    hippostdpubwf:creationDate: 2018-03-09T16:04:55.089Z
+    hippostdpubwf:lastModificationDate: 2018-03-09T16:04:55.089Z
     hippostdpubwf:lastModifiedBy: admin
-    hippotaxonomy:keys:
-    - nil-taxonomy-test
-    hippotranslation:id: 6052313f-da95-4a53-84ee-8d2d9e69d1e0
+    hippotranslation:id: 627c93d4-42c0-448e-b275-2d795dca50b1
     hippotranslation:locale: en
     jcr:mixinTypes:
     - hippotaxonomy:classifiable
@@ -65,17 +60,16 @@
     jcr:primaryType: nationalindicatorlibrary:indicator
     nationalindicatorlibrary:assuranceDate: 2018-03-01T00:00:00Z
     nationalindicatorlibrary:assuredStatus: true
-    nationalindicatorlibrary:publishedBy: NHS Digital
-    nationalindicatorlibrary:reportingLevel: CCG
-    nationalindicatorlibrary:title: Bare Minimum Indicator
-    publicationsystem:GeographicCoverage: England
-  /bare-minimum-indicator[2]:
+    nationalindicatorlibrary:publishedBy: test
+    nationalindicatorlibrary:reportingLevel: test
+    nationalindicatorlibrary:title: Search Test Indicator Definition
+  /search-test-definition-indicator[2]:
     /nationalindicatorlibrary:details:
       /nationalindicatorlibrary:caveats:
         hippostd:content: ''
         jcr:primaryType: hippostd:html
       /nationalindicatorlibrary:definition:
-        hippostd:content: <p>Definition</p>
+        hippostd:content: <p>NilSortSearchTerm</p>
         jcr:primaryType: hippostd:html
       /nationalindicatorlibrary:interpretationGuidelines:
         hippostd:content: ''
@@ -95,10 +89,12 @@
           jcr:primaryType: hippostd:html
         jcr:primaryType: nationalindicatorlibrary:methodology
       /nationalindicatorlibrary:purpose:
-        hippostd:content: <p>Purpose</p>
+        hippostd:content: <p>test</p>
         jcr:primaryType: hippostd:html
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
       jcr:primaryType: nationalindicatorlibrary:details
-      nationalindicatorlibrary:briefDescription: Bare Minimum Indicator
+      nationalindicatorlibrary:briefDescription: test
       nationalindicatorlibrary:iapCode: ''
       nationalindicatorlibrary:indicatorSet: ''
       nationalindicatorlibrary:rating: ''
@@ -106,28 +102,21 @@
       /nationalindicatorlibrary:contactAuthor:
         jcr:primaryType: nationalindicatorlibrary:contactAuthor
         nationalindicatorlibrary:contactAuthorEmail: ''
-        nationalindicatorlibrary:contactAuthorName: Test
+        nationalindicatorlibrary:contactAuthorName: test
       jcr:primaryType: nationalindicatorlibrary:topbar
-      nationalindicatorlibrary:basedOn: Test
-      nationalindicatorlibrary:reportingPeriod: Now
-      nationalindicatorlibrary:reviewDate: 2018-02-23T13:57:00Z
+      nationalindicatorlibrary:basedOn: set
+      nationalindicatorlibrary:reportingPeriod: test
+      nationalindicatorlibrary:reviewDate: 2018-03-09T16:08:00Z
     common:FacetType: indicator
-    common:FullTaxonomy:
-    - nil-taxonomy-test
-    - acceptance-tests
-    common:SearchableTags:
-    - NilTaxonomySearchTerm test
     common:searchable: true
     hippo:availability:
     - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2018-02-23T13:57:04.917Z
-    hippostdpubwf:lastModificationDate: 2018-03-09T13:25:05.329Z
+    hippostdpubwf:creationDate: 2018-03-09T16:04:55.089Z
+    hippostdpubwf:lastModificationDate: 2018-03-09T16:09:28.188Z
     hippostdpubwf:lastModifiedBy: admin
-    hippotaxonomy:keys:
-    - nil-taxonomy-test
-    hippotranslation:id: 6052313f-da95-4a53-84ee-8d2d9e69d1e0
+    hippotranslation:id: 627c93d4-42c0-448e-b275-2d795dca50b1
     hippotranslation:locale: en
     jcr:mixinTypes:
     - hippotaxonomy:classifiable
@@ -136,17 +125,16 @@
     jcr:primaryType: nationalindicatorlibrary:indicator
     nationalindicatorlibrary:assuranceDate: 2018-03-01T00:00:00Z
     nationalindicatorlibrary:assuredStatus: true
-    nationalindicatorlibrary:publishedBy: NHS Digital
-    nationalindicatorlibrary:reportingLevel: CCG
-    nationalindicatorlibrary:title: Bare Minimum Indicator
-    publicationsystem:GeographicCoverage: England
-  /bare-minimum-indicator[3]:
+    nationalindicatorlibrary:publishedBy: test
+    nationalindicatorlibrary:reportingLevel: test
+    nationalindicatorlibrary:title: Search Test Indicator Definition
+  /search-test-definition-indicator[3]:
     /nationalindicatorlibrary:details:
       /nationalindicatorlibrary:caveats:
         hippostd:content: ''
         jcr:primaryType: hippostd:html
       /nationalindicatorlibrary:definition:
-        hippostd:content: <p>Definition</p>
+        hippostd:content: <p>NilSortSearchTerm</p>
         jcr:primaryType: hippostd:html
       /nationalindicatorlibrary:interpretationGuidelines:
         hippostd:content: ''
@@ -166,10 +154,12 @@
           jcr:primaryType: hippostd:html
         jcr:primaryType: nationalindicatorlibrary:methodology
       /nationalindicatorlibrary:purpose:
-        hippostd:content: <p>Purpose</p>
+        hippostd:content: <p>test</p>
         jcr:primaryType: hippostd:html
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
       jcr:primaryType: nationalindicatorlibrary:details
-      nationalindicatorlibrary:briefDescription: Bare Minimum Indicator
+      nationalindicatorlibrary:briefDescription: test
       nationalindicatorlibrary:iapCode: ''
       nationalindicatorlibrary:indicatorSet: ''
       nationalindicatorlibrary:rating: ''
@@ -177,29 +167,22 @@
       /nationalindicatorlibrary:contactAuthor:
         jcr:primaryType: nationalindicatorlibrary:contactAuthor
         nationalindicatorlibrary:contactAuthorEmail: ''
-        nationalindicatorlibrary:contactAuthorName: Test
+        nationalindicatorlibrary:contactAuthorName: test
       jcr:primaryType: nationalindicatorlibrary:topbar
-      nationalindicatorlibrary:basedOn: Test
-      nationalindicatorlibrary:reportingPeriod: Now
-      nationalindicatorlibrary:reviewDate: 2018-02-23T13:57:00Z
+      nationalindicatorlibrary:basedOn: set
+      nationalindicatorlibrary:reportingPeriod: test
+      nationalindicatorlibrary:reviewDate: 2018-03-09T16:08:00Z
     common:FacetType: indicator
-    common:FullTaxonomy:
-    - nil-taxonomy-test
-    - acceptance-tests
-    common:SearchableTags:
-    - NilTaxonomySearchTerm test
     common:searchable: true
     hippo:availability:
     - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2018-02-23T13:57:04.917Z
-    hippostdpubwf:lastModificationDate: 2018-03-09T13:25:05.329Z
+    hippostdpubwf:creationDate: 2018-03-09T16:04:55.089Z
+    hippostdpubwf:lastModificationDate: 2018-03-09T16:09:28.188Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2018-03-09T13:25:08.924Z
-    hippotaxonomy:keys:
-    - nil-taxonomy-test
-    hippotranslation:id: 6052313f-da95-4a53-84ee-8d2d9e69d1e0
+    hippostdpubwf:publicationDate: 2018-03-09T16:09:34.888Z
+    hippotranslation:id: 627c93d4-42c0-448e-b275-2d795dca50b1
     hippotranslation:locale: en
     jcr:mixinTypes:
     - hippotaxonomy:classifiable
@@ -207,11 +190,10 @@
     jcr:primaryType: nationalindicatorlibrary:indicator
     nationalindicatorlibrary:assuranceDate: 2018-03-01T00:00:00Z
     nationalindicatorlibrary:assuredStatus: true
-    nationalindicatorlibrary:publishedBy: NHS Digital
-    nationalindicatorlibrary:reportingLevel: CCG
-    nationalindicatorlibrary:title: Bare Minimum Indicator
-    publicationsystem:GeographicCoverage: England
-  hippo:name: bare minimum indicator
+    nationalindicatorlibrary:publishedBy: test
+    nationalindicatorlibrary:reportingLevel: test
+    nationalindicatorlibrary:title: Search Test Indicator Definition
+  hippo:name: search test definition indicator
   jcr:mixinTypes:
   - hippo:named
   - mix:referenceable

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/acceptance-tests/search-test-title-indicator.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/acceptance-tests/search-test-title-indicator.yaml
@@ -1,12 +1,12 @@
 ---
-/content/documents/corporate-website/national-indicator-library/acceptance-tests/bare-minimum-indicator:
-  /bare-minimum-indicator[1]:
+/content/documents/corporate-website/national-indicator-library/acceptance-tests/search-test-title-indicator:
+  /search-test-title-indicator[1]:
     /nationalindicatorlibrary:details:
       /nationalindicatorlibrary:caveats:
         hippostd:content: ''
         jcr:primaryType: hippostd:html
       /nationalindicatorlibrary:definition:
-        hippostd:content: <p>Definition</p>
+        hippostd:content: <p>test</p>
         jcr:primaryType: hippostd:html
       /nationalindicatorlibrary:interpretationGuidelines:
         hippostd:content: ''
@@ -26,10 +26,12 @@
           jcr:primaryType: hippostd:html
         jcr:primaryType: nationalindicatorlibrary:methodology
       /nationalindicatorlibrary:purpose:
-        hippostd:content: <p>Purpose</p>
+        hippostd:content: <p>test</p>
         jcr:primaryType: hippostd:html
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
       jcr:primaryType: nationalindicatorlibrary:details
-      nationalindicatorlibrary:briefDescription: Bare Minimum Indicator
+      nationalindicatorlibrary:briefDescription: test
       nationalindicatorlibrary:iapCode: ''
       nationalindicatorlibrary:indicatorSet: ''
       nationalindicatorlibrary:rating: ''
@@ -37,45 +39,37 @@
       /nationalindicatorlibrary:contactAuthor:
         jcr:primaryType: nationalindicatorlibrary:contactAuthor
         nationalindicatorlibrary:contactAuthorEmail: ''
-        nationalindicatorlibrary:contactAuthorName: Test
+        nationalindicatorlibrary:contactAuthorName: test
       jcr:primaryType: nationalindicatorlibrary:topbar
-      nationalindicatorlibrary:basedOn: Test
-      nationalindicatorlibrary:reportingPeriod: Now
-      nationalindicatorlibrary:reviewDate: 2018-02-23T13:57:00Z
+      nationalindicatorlibrary:basedOn: test
+      nationalindicatorlibrary:reportingPeriod: test
+      nationalindicatorlibrary:reviewDate: 2018-03-09T16:04:00Z
     common:FacetType: indicator
-    common:FullTaxonomy:
-    - nil-taxonomy-test
-    - acceptance-tests
-    common:SearchableTags:
-    - NilTaxonomySearchTerm test
     common:searchable: true
     hippo:availability: []
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2018-02-23T13:57:04.917Z
-    hippostdpubwf:lastModificationDate: 2018-03-09T13:24:47.119Z
+    hippostdpubwf:creationDate: 2018-03-09T16:03:28.182Z
+    hippostdpubwf:lastModificationDate: 2018-03-09T16:03:28.182Z
     hippostdpubwf:lastModifiedBy: admin
-    hippotaxonomy:keys:
-    - nil-taxonomy-test
-    hippotranslation:id: 6052313f-da95-4a53-84ee-8d2d9e69d1e0
+    hippotranslation:id: 7ba16511-bdef-42fd-ad49-8db02dd3a5ec
     hippotranslation:locale: en
     jcr:mixinTypes:
     - hippotaxonomy:classifiable
     - mix:referenceable
     jcr:primaryType: nationalindicatorlibrary:indicator
-    nationalindicatorlibrary:assuranceDate: 2018-03-01T00:00:00Z
+    nationalindicatorlibrary:assuranceDate: 2018-02-01T00:00:00Z
     nationalindicatorlibrary:assuredStatus: true
-    nationalindicatorlibrary:publishedBy: NHS Digital
-    nationalindicatorlibrary:reportingLevel: CCG
-    nationalindicatorlibrary:title: Bare Minimum Indicator
-    publicationsystem:GeographicCoverage: England
-  /bare-minimum-indicator[2]:
+    nationalindicatorlibrary:publishedBy: test
+    nationalindicatorlibrary:reportingLevel: test
+    nationalindicatorlibrary:title: Search Test Indicator Title NilSortSearchTerm
+  /search-test-title-indicator[2]:
     /nationalindicatorlibrary:details:
       /nationalindicatorlibrary:caveats:
         hippostd:content: ''
         jcr:primaryType: hippostd:html
       /nationalindicatorlibrary:definition:
-        hippostd:content: <p>Definition</p>
+        hippostd:content: <p>test</p>
         jcr:primaryType: hippostd:html
       /nationalindicatorlibrary:interpretationGuidelines:
         hippostd:content: ''
@@ -95,10 +89,12 @@
           jcr:primaryType: hippostd:html
         jcr:primaryType: nationalindicatorlibrary:methodology
       /nationalindicatorlibrary:purpose:
-        hippostd:content: <p>Purpose</p>
+        hippostd:content: <p>test</p>
         jcr:primaryType: hippostd:html
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
       jcr:primaryType: nationalindicatorlibrary:details
-      nationalindicatorlibrary:briefDescription: Bare Minimum Indicator
+      nationalindicatorlibrary:briefDescription: test
       nationalindicatorlibrary:iapCode: ''
       nationalindicatorlibrary:indicatorSet: ''
       nationalindicatorlibrary:rating: ''
@@ -106,47 +102,39 @@
       /nationalindicatorlibrary:contactAuthor:
         jcr:primaryType: nationalindicatorlibrary:contactAuthor
         nationalindicatorlibrary:contactAuthorEmail: ''
-        nationalindicatorlibrary:contactAuthorName: Test
+        nationalindicatorlibrary:contactAuthorName: test
       jcr:primaryType: nationalindicatorlibrary:topbar
-      nationalindicatorlibrary:basedOn: Test
-      nationalindicatorlibrary:reportingPeriod: Now
-      nationalindicatorlibrary:reviewDate: 2018-02-23T13:57:00Z
+      nationalindicatorlibrary:basedOn: test
+      nationalindicatorlibrary:reportingPeriod: test
+      nationalindicatorlibrary:reviewDate: 2018-03-09T16:04:00Z
     common:FacetType: indicator
-    common:FullTaxonomy:
-    - nil-taxonomy-test
-    - acceptance-tests
-    common:SearchableTags:
-    - NilTaxonomySearchTerm test
     common:searchable: true
     hippo:availability:
     - preview
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2018-02-23T13:57:04.917Z
-    hippostdpubwf:lastModificationDate: 2018-03-09T13:25:05.329Z
+    hippostdpubwf:creationDate: 2018-03-09T16:03:28.182Z
+    hippostdpubwf:lastModificationDate: 2018-03-09T16:04:27.806Z
     hippostdpubwf:lastModifiedBy: admin
-    hippotaxonomy:keys:
-    - nil-taxonomy-test
-    hippotranslation:id: 6052313f-da95-4a53-84ee-8d2d9e69d1e0
+    hippotranslation:id: 7ba16511-bdef-42fd-ad49-8db02dd3a5ec
     hippotranslation:locale: en
     jcr:mixinTypes:
     - hippotaxonomy:classifiable
     - mix:referenceable
     - mix:versionable
     jcr:primaryType: nationalindicatorlibrary:indicator
-    nationalindicatorlibrary:assuranceDate: 2018-03-01T00:00:00Z
+    nationalindicatorlibrary:assuranceDate: 2018-02-01T00:00:00Z
     nationalindicatorlibrary:assuredStatus: true
-    nationalindicatorlibrary:publishedBy: NHS Digital
-    nationalindicatorlibrary:reportingLevel: CCG
-    nationalindicatorlibrary:title: Bare Minimum Indicator
-    publicationsystem:GeographicCoverage: England
-  /bare-minimum-indicator[3]:
+    nationalindicatorlibrary:publishedBy: test
+    nationalindicatorlibrary:reportingLevel: test
+    nationalindicatorlibrary:title: Search Test Indicator Title NilSortSearchTerm
+  /search-test-title-indicator[3]:
     /nationalindicatorlibrary:details:
       /nationalindicatorlibrary:caveats:
         hippostd:content: ''
         jcr:primaryType: hippostd:html
       /nationalindicatorlibrary:definition:
-        hippostd:content: <p>Definition</p>
+        hippostd:content: <p>test</p>
         jcr:primaryType: hippostd:html
       /nationalindicatorlibrary:interpretationGuidelines:
         hippostd:content: ''
@@ -166,10 +154,12 @@
           jcr:primaryType: hippostd:html
         jcr:primaryType: nationalindicatorlibrary:methodology
       /nationalindicatorlibrary:purpose:
-        hippostd:content: <p>Purpose</p>
+        hippostd:content: <p>test</p>
         jcr:primaryType: hippostd:html
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
       jcr:primaryType: nationalindicatorlibrary:details
-      nationalindicatorlibrary:briefDescription: Bare Minimum Indicator
+      nationalindicatorlibrary:briefDescription: test
       nationalindicatorlibrary:iapCode: ''
       nationalindicatorlibrary:indicatorSet: ''
       nationalindicatorlibrary:rating: ''
@@ -177,41 +167,33 @@
       /nationalindicatorlibrary:contactAuthor:
         jcr:primaryType: nationalindicatorlibrary:contactAuthor
         nationalindicatorlibrary:contactAuthorEmail: ''
-        nationalindicatorlibrary:contactAuthorName: Test
+        nationalindicatorlibrary:contactAuthorName: test
       jcr:primaryType: nationalindicatorlibrary:topbar
-      nationalindicatorlibrary:basedOn: Test
-      nationalindicatorlibrary:reportingPeriod: Now
-      nationalindicatorlibrary:reviewDate: 2018-02-23T13:57:00Z
+      nationalindicatorlibrary:basedOn: test
+      nationalindicatorlibrary:reportingPeriod: test
+      nationalindicatorlibrary:reviewDate: 2018-03-09T16:04:00Z
     common:FacetType: indicator
-    common:FullTaxonomy:
-    - nil-taxonomy-test
-    - acceptance-tests
-    common:SearchableTags:
-    - NilTaxonomySearchTerm test
     common:searchable: true
     hippo:availability:
     - live
     hippostd:state: published
     hippostdpubwf:createdBy: admin
-    hippostdpubwf:creationDate: 2018-02-23T13:57:04.917Z
-    hippostdpubwf:lastModificationDate: 2018-03-09T13:25:05.329Z
+    hippostdpubwf:creationDate: 2018-03-09T16:03:28.182Z
+    hippostdpubwf:lastModificationDate: 2018-03-09T16:04:27.806Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2018-03-09T13:25:08.924Z
-    hippotaxonomy:keys:
-    - nil-taxonomy-test
-    hippotranslation:id: 6052313f-da95-4a53-84ee-8d2d9e69d1e0
+    hippostdpubwf:publicationDate: 2018-03-09T16:04:35.260Z
+    hippotranslation:id: 7ba16511-bdef-42fd-ad49-8db02dd3a5ec
     hippotranslation:locale: en
     jcr:mixinTypes:
     - hippotaxonomy:classifiable
     - mix:referenceable
     jcr:primaryType: nationalindicatorlibrary:indicator
-    nationalindicatorlibrary:assuranceDate: 2018-03-01T00:00:00Z
+    nationalindicatorlibrary:assuranceDate: 2018-02-01T00:00:00Z
     nationalindicatorlibrary:assuredStatus: true
-    nationalindicatorlibrary:publishedBy: NHS Digital
-    nationalindicatorlibrary:reportingLevel: CCG
-    nationalindicatorlibrary:title: Bare Minimum Indicator
-    publicationsystem:GeographicCoverage: England
-  hippo:name: bare minimum indicator
+    nationalindicatorlibrary:publishedBy: test
+    nationalindicatorlibrary:reportingLevel: test
+    nationalindicatorlibrary:title: Search Test Indicator Title NilSortSearchTerm
+  hippo:name: search test title indicator
   jcr:mixinTypes:
   - hippo:named
   - mix:referenceable

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/acceptance-tests/unassured-indicator.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/acceptance-tests/unassured-indicator.yaml
@@ -56,7 +56,7 @@
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-23T13:52:36.010Z
-    hippostdpubwf:lastModificationDate: 2018-03-07T08:15:10.327Z
+    hippostdpubwf:lastModificationDate: 2018-03-09T13:25:37.282Z
     hippostdpubwf:lastModifiedBy: admin
     hippotaxonomy:keys:
     - nil-taxonomy-test
@@ -66,6 +66,7 @@
     - hippotaxonomy:classifiable
     - mix:referenceable
     jcr:primaryType: nationalindicatorlibrary:indicator
+    nationalindicatorlibrary:assuranceDate: 2018-03-03T00:00:00Z
     nationalindicatorlibrary:assuredStatus: false
     nationalindicatorlibrary:assuredStatus2: false
     nationalindicatorlibrary:publishedBy: NHS Digital
@@ -130,7 +131,7 @@
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-23T13:52:36.010Z
-    hippostdpubwf:lastModificationDate: 2018-03-07T08:15:16.856Z
+    hippostdpubwf:lastModificationDate: 2018-03-09T13:25:46.679Z
     hippostdpubwf:lastModifiedBy: admin
     hippotaxonomy:keys:
     - nil-taxonomy-test
@@ -141,6 +142,7 @@
     - mix:referenceable
     - mix:versionable
     jcr:primaryType: nationalindicatorlibrary:indicator
+    nationalindicatorlibrary:assuranceDate: 2018-03-03T00:00:00Z
     nationalindicatorlibrary:assuredStatus: false
     nationalindicatorlibrary:assuredStatus2: false
     nationalindicatorlibrary:publishedBy: NHS Digital
@@ -205,9 +207,9 @@
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-23T13:52:36.010Z
-    hippostdpubwf:lastModificationDate: 2018-03-07T08:15:16.856Z
+    hippostdpubwf:lastModificationDate: 2018-03-09T13:25:46.679Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2018-03-07T08:15:21.924Z
+    hippostdpubwf:publicationDate: 2018-03-09T13:25:50.783Z
     hippotaxonomy:keys:
     - nil-taxonomy-test
     hippotranslation:id: e1403a71-7217-4752-88ee-a83266332aa9
@@ -216,6 +218,7 @@
     - hippotaxonomy:classifiable
     - mix:referenceable
     jcr:primaryType: nationalindicatorlibrary:indicator
+    nationalindicatorlibrary:assuranceDate: 2018-03-03T00:00:00Z
     nationalindicatorlibrary:assuredStatus: false
     nationalindicatorlibrary:assuredStatus2: false
     nationalindicatorlibrary:publishedBy: NHS Digital

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/sample-indicator.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/sample-indicator.yaml
@@ -87,7 +87,6 @@
         nationalindicatorlibrary:contactAuthorEmail: hugo@email.com
         nationalindicatorlibrary:contactAuthorName: Hugo
       jcr:primaryType: nationalindicatorlibrary:topbar
-      nationalindicatorlibrary:assuranceDate: 2015-12-14T00:00:00Z
       nationalindicatorlibrary:basedOn: Royal College of Physicians’ Sentinel Stroke
         National Audit Programme (SSNAP)
       nationalindicatorlibrary:publishedBy: Publisher
@@ -105,7 +104,7 @@
     hippostd:state: draft
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-22T13:14:38.445Z
-    hippostdpubwf:lastModificationDate: 2018-03-07T08:57:37.172Z
+    hippostdpubwf:lastModificationDate: 2018-03-09T13:24:14.009Z
     hippostdpubwf:lastModifiedBy: admin
     hippotaxonomy:keys:
     - conditions
@@ -116,6 +115,7 @@
     - hippotaxonomy:classifiable
     - mix:referenceable
     jcr:primaryType: nationalindicatorlibrary:indicator
+    nationalindicatorlibrary:assuranceDate: 2017-12-14T00:00:00Z
     nationalindicatorlibrary:assuredStatus: true
     nationalindicatorlibrary:publishedBy: NHS Digital
     nationalindicatorlibrary:reportingLevel: CCG
@@ -209,7 +209,6 @@
         nationalindicatorlibrary:contactAuthorEmail: hugo@email.com
         nationalindicatorlibrary:contactAuthorName: Hugo
       jcr:primaryType: nationalindicatorlibrary:topbar
-      nationalindicatorlibrary:assuranceDate: 2015-12-14T00:00:00Z
       nationalindicatorlibrary:basedOn: Royal College of Physicians’ Sentinel Stroke
         National Audit Programme (SSNAP)
       nationalindicatorlibrary:publishedBy: Publisher
@@ -228,7 +227,7 @@
     hippostd:state: unpublished
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-22T13:14:38.445Z
-    hippostdpubwf:lastModificationDate: 2018-03-07T08:14:15.542Z
+    hippostdpubwf:lastModificationDate: 2018-03-09T13:24:31.777Z
     hippostdpubwf:lastModifiedBy: admin
     hippotaxonomy:keys:
     - conditions
@@ -240,6 +239,7 @@
     - mix:referenceable
     - mix:versionable
     jcr:primaryType: nationalindicatorlibrary:indicator
+    nationalindicatorlibrary:assuranceDate: 2017-12-14T00:00:00Z
     nationalindicatorlibrary:assuredStatus: true
     nationalindicatorlibrary:publishedBy: NHS Digital
     nationalindicatorlibrary:reportingLevel: CCG
@@ -333,7 +333,6 @@
         nationalindicatorlibrary:contactAuthorEmail: hugo@email.com
         nationalindicatorlibrary:contactAuthorName: Hugo
       jcr:primaryType: nationalindicatorlibrary:topbar
-      nationalindicatorlibrary:assuranceDate: 2015-12-14T00:00:00Z
       nationalindicatorlibrary:basedOn: Royal College of Physicians’ Sentinel Stroke
         National Audit Programme (SSNAP)
       nationalindicatorlibrary:publishedBy: Publisher
@@ -352,9 +351,9 @@
     hippostd:state: published
     hippostdpubwf:createdBy: admin
     hippostdpubwf:creationDate: 2018-02-22T13:14:38.445Z
-    hippostdpubwf:lastModificationDate: 2018-03-07T08:14:15.542Z
+    hippostdpubwf:lastModificationDate: 2018-03-09T13:24:31.777Z
     hippostdpubwf:lastModifiedBy: admin
-    hippostdpubwf:publicationDate: 2018-03-07T08:14:27.666Z
+    hippostdpubwf:publicationDate: 2018-03-09T13:24:37.697Z
     hippotaxonomy:keys:
     - conditions
     - cancer
@@ -365,6 +364,7 @@
     - mix:referenceable
     - mix:versionable
     jcr:primaryType: nationalindicatorlibrary:indicator
+    nationalindicatorlibrary:assuranceDate: 2017-12-14T00:00:00Z
     nationalindicatorlibrary:assuredStatus: true
     nationalindicatorlibrary:publishedBy: NHS Digital
     nationalindicatorlibrary:reportingLevel: CCG

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/results.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/results.ftl
@@ -107,8 +107,15 @@
                 ${item.title}
             </a>
         </p>
-        <#if item.assuredStatus><p class="flush zeta" data-uipath="ps.search-results.result.assured-status"><@fmt.message key="labels.assured"/></p></#if>
-        <p class="flush zeta" data-uipath="ps.search-results.result.publisher-and-date" style="font-weight:bold"><@fmt.message key="headers.publishedBy"/>: ${item.publishedBy}<#if item.assuredStatus>, <@fmt.message key="headers.assured"/>: ${item.topbar.assuranceDate.time?string[dateFormat]}</p></#if>
+
+        <#if item.assuredStatus>
+            <p class="flush zeta" data-uipath="ps.search-results.result.assured-status"><@fmt.message key="labels.assured"/></p>
+            <p class="flush zeta" data-uipath="ps.search-results.result.publisher-and-date" style="font-weight:bold"><@fmt.message key="headers.publishedBy"/>: ${item.publishedBy}. <@fmt.message key="headers.assured"/>: ${item.assuranceDate.time?string[dateFormat]}</p>
+        <#else>
+            <p class="flush zeta" data-uipath="ps.search-results.result.assured-status"><@fmt.message key="labels.unassured"/></p>
+            <p class="flush zeta" data-uipath="ps.search-results.result.publisher-and-date" style="font-weight:bold"><@fmt.message key="headers.publishedBy"/>: ${item.publishedBy}. <@fmt.message key="headers.unassured"/>: ${item.assuranceDate.time?string[dateFormat]}</p>
+        </#if>         
+        
         <p class="flush" data-uipath="ps.search-results.result.brief-description">${item.details.briefDescription}</p>        
     </div>
 </#macro>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/nationalindicatorlibrary/indicator.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/nationalindicatorlibrary/indicator.ftl
@@ -2,6 +2,7 @@
 <#include "../include/imports.ftl">
 <#assign formatRestrictableDate="uk.nhs.digital.ps.directives.RestrictableDateFormatterDirective"?new() />
 <#assign formatCoverageDates="uk.nhs.digital.ps.directives.CoverageDatesFormatterDirective"?new() />
+<#assign formatFileSize="uk.nhs.digital.ps.directives.FileSizeFormatterDirective"?new() />
 
 <@hst.setBundle basename="nationalindicatorlibrary.headers"/>
 
@@ -14,7 +15,7 @@
         <div class="layout">
             <div class="layout__item layout-1-2">
                 <p class="push-half--bottom"><strong><@fmt.message key="headers.publishedBy"/></strong>: ${indicator.publishedBy}</p>
-                <p class="push-half--bottom"><strong><@fmt.message key="headers.assuranceDate"/></strong>: ${indicator.topbar.assuranceDate.time?string[dateFormat]}</p>
+                <p class="push-half--bottom"><strong><@fmt.message key="headers.assuranceDate"/></strong>: ${indicator.assuranceDate.time?string[dateFormat]}</p>
                 <p class="push-half--bottom"><strong><@fmt.message key="headers.reportingPeriod"/></strong>: ${indicator.topbar.reportingPeriod}</p>
                 <p class="push-half--bottom"><strong><@fmt.message key="headers.basedOn"/></strong>: ${indicator.topbar.basedOn}</p>
             </div><!--
@@ -122,6 +123,7 @@
                         <#list indicator.attachments as attachment>
                             <li class="attachment">
                                 <a title="${attachment.text}" href="<@hst.link hippobean=attachment.resource/>" onClick="logGoogleAnalyticsEvent('Download attachment','Indicator','${attachment.resource.filename}');">${attachment.text}</a>
+                                <span class="fileSize">(<@formatFileSize bytesCount=attachment.resource.length/>)</span>
                             </li>
                         </#list>
                     </ul>

--- a/site/src/main/java/uk/nhs/digital/common/components/SearchComponent.java
+++ b/site/src/main/java/uk/nhs/digital/common/components/SearchComponent.java
@@ -183,7 +183,8 @@ public class SearchComponent extends CommonComponent {
         String sortParam = getSortOption(request);
         switch (sortParam) {
             case SORT_DATE:
-                queryBuilder.orderByDescending("publicationsystem:NominalDate", "publicationsystem:Title");
+                queryBuilder.orderByDescending("publicationsystem:NominalDate", "nationalindicatorlibrary:assuranceDate", 
+                    "publicationsystem:Title", "nationalindicatorlibrary:title");
                 break;
             case SORT_RELEVANCE:
                 // no op - relevence is the default sort order

--- a/site/src/main/java/uk/nhs/digital/nil/beans/Indicator.java
+++ b/site/src/main/java/uk/nhs/digital/nil/beans/Indicator.java
@@ -6,6 +6,7 @@ import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerat
 import uk.nhs.digital.ps.beans.Attachment;
 import uk.nhs.digital.ps.beans.HippoBeanHelper;
 
+import java.util.Calendar;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -62,6 +63,11 @@ public class Indicator extends BaseDocument {
         return allTaxonomies.stream().flatMap(x -> x.stream()).distinct().collect(Collectors.toList());
     }
 
+    @HippoEssentialsGenerated(internalName = PropertyKeys.ASSURANCE_DATE)
+    public Calendar getAssuranceDate() {
+        return getProperty(PropertyKeys.ASSURANCE_DATE);
+    }
+
     interface PropertyKeys {
         String TAXONOMY = "hippotaxonomy:keys";
         String ATTACHMENTS = "nationalindicatorlibrary:attachments";
@@ -71,6 +77,7 @@ public class Indicator extends BaseDocument {
         String ASSUREDSTATUS = "nationalindicatorlibrary:assuredStatus";
         String PUBLISHEDBY = "nationalindicatorlibrary:publishedBy"; 
         String REPORTINGLEVEL = "nationalindicatorlibrary:reportingLevel";     
-        String GEOGRAPHIC_COVERAGE = "publicationsystem:GeographicCoverage";                   
+        String GEOGRAPHIC_COVERAGE = "publicationsystem:GeographicCoverage";   
+        String ASSURANCE_DATE = "nationalindicatorlibrary:assuranceDate";                
     }
 }

--- a/site/src/main/java/uk/nhs/digital/nil/beans/Topbar.java
+++ b/site/src/main/java/uk/nhs/digital/nil/beans/Topbar.java
@@ -9,10 +9,6 @@ import java.util.Calendar;
 @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:topbar")
 @Node(jcrType = "nationalindicatorlibrary:topbar")
 public class Topbar extends HippoCompound {
-    @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:assuranceDate")
-    public Calendar getAssuranceDate() {
-        return getProperty("nationalindicatorlibrary:assuranceDate");
-    }
 
     @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:reviewDate")
     public Calendar getReviewDate() {


### PR DESCRIPTION
Move the assurance date field out of the "Topbar" component and into the main Indicator document. This is required for sorting which has to be top-level.

Also includes a couple of minor template fixes.

Note, I've kept the acceptance tests separate for NIL to keep them simple.

(I'm not migrating existing content as NIL content is still in a state of flux and will be wiped and re-imported. HOWEVER post approval please let me merge this).