### PR TITLE
[NIL-127] Display taxonomy tags on Indicator as clickable

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/nationalindicatorlibrary/indicator.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/nationalindicatorlibrary/indicator.ftl
@@ -110,8 +110,9 @@
 
         <section class="push-double--bottom">
             <h2><strong><@fmt.message key="headers.categories"/></strong></h2>
-            <#list indicator.taxonomyList as taxonomy>
-                <p class="filter-list__item__link" data-uipath="ps.indicator.taxonomy-${taxonomy}">${taxonomy}</p>
+
+            <#list indicator.taxonomyList?keys as key>
+                <p class="filter-list__item__link" data-uipath="ps.indicator.taxonomy-${key}"><a title="Search for ${indicator.taxonomyList[key]}" href="../search/category/${key}">${indicator.taxonomyList[key]}</a></p>
             </#list>   
         </section>     
 

--- a/repository-data/webfiles/src/main/resources/site/less/style.less
+++ b/repository-data/webfiles/src/main/resources/site/less/style.less
@@ -472,6 +472,10 @@ div.breadcrumb a {
     display: inline-block;
     margin-top: 5px;
 }
+.filter-list__item__link a {
+  text-decoration: none;
+  color: inherit;
+}
 
 
 /* BASIC LAYOUT */

--- a/site/src/main/java/uk/nhs/digital/nil/beans/Indicator.java
+++ b/site/src/main/java/uk/nhs/digital/nil/beans/Indicator.java
@@ -11,7 +11,7 @@ import uk.nhs.digital.ps.beans.HippoBeanHelper;
 
 import java.util.Calendar;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 @HippoEssentialsGenerated(internalName = "nationalindicatorlibrary:indicator")
 @Node(jcrType = "nationalindicatorlibrary:indicator")
@@ -61,9 +61,8 @@ public class Indicator extends BaseDocument {
         return getProperty(PropertyKeys.TAXONOMY);
     }
 
-    public List<String> getTaxonomyList() {
-        List<List<String>> allTaxonomies = HippoBeanHelper.getTaxonomyList(getKeys());
-        return allTaxonomies.stream().flatMap(x -> x.stream()).distinct().collect(Collectors.toList());
+    public Map<String,String> getTaxonomyList() {
+        return HippoBeanHelper.getTaxonomyKeysAndNames(getKeys());
     }
 
     @HippoEssentialsGenerated(internalName = PropertyKeys.ASSURANCE_DATE)


### PR DESCRIPTION
The NIL Indicators already have their 'tagged' taxonomies displayed. This addresses the requirement to make them clickable - i.e. direct to a search for that term.

(Note, I will be adding more acceptance tests under a separate PR)