### PR TITLE
[RPS-419] Add S3 publish and unpublish scxml action

### DIFF
--- a/cms/pom.xml
+++ b/cms/pom.xml
@@ -169,7 +169,6 @@
             <artifactId>hippo-plugin-content-blocks</artifactId>
             <scope>compile</scope>
         </dependency>
-
     </dependencies>
     <build>
         <finalName>cms</finalName>

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/modules/S3ConnectorServiceRegistrationModule.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/modules/S3ConnectorServiceRegistrationModule.java
@@ -1,11 +1,11 @@
-package uk.nhs.digital.ps.modules;
+package uk.nhs.digital.externalstorage.modules;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
-import com.amazonaws.regions.Region;
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.onehippo.cms7.services.HippoServiceRegistry;
 import org.onehippo.repository.modules.AbstractReconfigurableDaemonModule;
 import org.onehippo.repository.modules.ProvidesService;
@@ -48,17 +48,15 @@ public class S3ConnectorServiceRegistrationModule extends AbstractReconfigurable
     }
 
     private AmazonS3 getAmazonS3() {
-        Region reg = Region.getRegion(Regions.fromName(s3Region));
         AWSCredentialsProvider provider = new SystemPropertiesCredentialsProvider();
-        AmazonS3 s3 = new AmazonS3Client(provider);
-        s3.setRegion(reg);
+        AmazonS3ClientBuilder s3Builder = AmazonS3ClientBuilder.standard()
+            .withCredentials(provider)
+            .withRegion(Regions.fromName(s3Region));
 
-        String endpoint = reg.getServiceEndpoint("s3");
         if (!s3Endpoint.isEmpty()) {
-            endpoint = s3Endpoint;
+            s3Builder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(s3Endpoint, s3Region));
         }
-        s3.setEndpoint(endpoint);
 
-        return s3;
+        return s3Builder.build();
     }
 }

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/resource/ImageDisplayPlugin.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/resource/ImageDisplayPlugin.java
@@ -5,7 +5,6 @@ import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Fragment;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
-import org.hippoecm.frontend.editor.compare.StreamComparer;
 import org.hippoecm.frontend.model.IModelReference;
 import org.hippoecm.frontend.plugin.IPluginContext;
 import org.hippoecm.frontend.plugin.config.IPluginConfig;
@@ -14,8 +13,8 @@ import org.hippoecm.frontend.service.IEditor;
 import org.hippoecm.frontend.service.render.RenderPlugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import uk.nhs.digital.externalstorage.ExternalStorageConstants;
 
-import java.io.InputStream;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 
@@ -43,14 +42,11 @@ public class ImageDisplayPlugin extends RenderPlugin<Node> {
                 Node currentNode = getModel().getObject();
                 if (baseNode != null && currentNode != null) {
                     try {
-                        InputStream baseStream = baseNode.getProperty("jcr:data").getStream();
-                        InputStream currentStream = currentNode.getProperty("jcr:data").getStream();
-                        StreamComparer comparer = new StreamComparer();
-                        if (!comparer.areEqual(baseStream, currentStream)) {
-                            doCompare = true;
-                        }
+                        String baseNodeReference = baseNode.getProperty(ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_REFERENCE).getString();
+                        String currentNodeReference = currentNode.getProperty(ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_REFERENCE).getString();
+                        doCompare = baseNodeReference != currentNodeReference;
                     } catch (RepositoryException ex) {
-                        log.error("Could not compare streams", ex);
+                        log.error("Could not compare references", ex);
                     }
                 }
             }

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/AbstractExternalFileTask.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/AbstractExternalFileTask.java
@@ -1,0 +1,98 @@
+package uk.nhs.digital.externalstorage.workflow;
+
+import org.hippoecm.frontend.session.UserSession;
+import org.hippoecm.repository.api.WorkflowException;
+import org.onehippo.cms7.services.HippoServiceRegistry;
+import org.onehippo.cms7.services.eventbus.HippoEventBus;
+import org.onehippo.repository.documentworkflow.DocumentVariant;
+import org.onehippo.repository.documentworkflow.task.AbstractDocumentTask;
+import org.onehippo.repository.events.HippoWorkflowEvent;
+import uk.nhs.digital.externalstorage.ExternalStorageConstants;
+import uk.nhs.digital.externalstorage.s3.S3Connector;
+
+import java.rmi.RemoteException;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryResult;
+
+public abstract class AbstractExternalFileTask extends AbstractDocumentTask {
+
+    private String variantState;
+
+    private S3Connector s3Connector;
+
+    public AbstractExternalFileTask() {
+        super();
+    }
+
+    public void setS3Connector(S3Connector s3Connector) {
+        this.s3Connector = s3Connector;
+    }
+
+    public void setVariantState(String state) {
+        variantState = state;
+    }
+
+    private DocumentVariant getVariant() {
+        return getDocumentHandle().getDocuments().get(variantState);
+    }
+
+    @Override
+    public Object doExecute() throws WorkflowException, RepositoryException, RemoteException {
+
+        if (getVariant() == null || !getVariant().hasNode()) {
+            throw new WorkflowException("No variant provided");
+        }
+
+        Node variantNode = getVariant().getNode(getWorkflowContext().getInternalWorkflowSession());
+
+        for (NodeIterator i = findResourceNodes(variantNode); i.hasNext(); ) {
+            Node doc = i.nextNode();
+            if (doc.hasProperty(ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_REFERENCE)) {
+                String externalResource = doc
+                    .getProperty(ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_REFERENCE)
+                    .getString();
+                setTargetStatus(s3Connector, externalResource);
+            }
+        }
+
+        return null;
+    }
+
+    private NodeIterator findResourceNodes(Node node) throws RepositoryException {
+        String documentPath = node.getPath();
+
+        //variantNode.
+        String query = "SELECT * FROM [" + ExternalStorageConstants.NODE_TYPE_EXTERNAL_RESOURCE + "] "
+            + "WHERE ISDESCENDANTNODE ([" + documentPath + "])";
+
+        QueryResult res = node.getSession()
+            .getWorkspace()
+            .getQueryManager()
+            .createQuery(query, Query.JCR_SQL2)
+            .execute();
+
+        return res.getNodes();
+    }
+
+    protected abstract void setTargetStatus(S3Connector s3, final String objectKey);
+
+    public void logInCmsActivityStream(final String documentPath, final String message) {
+        final HippoEventBus eventBus = HippoServiceRegistry.getService(HippoEventBus.class);
+        final String currentUser = UserSession.get().getJcrSession().getUserID();
+
+        if (eventBus != null) {
+            eventBus.post(new HippoWorkflowEvent()
+                .className(AbstractExternalFileTask.class.getName())
+                .methodName("errorOnPublish")
+                .application("cms")
+                .timestamp(System.currentTimeMillis())
+                .user(currentUser)
+                .set("documentPath", documentPath)
+                .message(message)
+            );
+        }
+    }
+}

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFilePublish/ExternalFilePublishAction.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFilePublish/ExternalFilePublishAction.java
@@ -1,0 +1,24 @@
+package uk.nhs.digital.externalstorage.workflow.externalFilePublish;
+
+import org.apache.commons.scxml2.SCXMLExpressionException;
+import org.apache.commons.scxml2.model.ModelException;
+import org.hippoecm.repository.HippoStdNodeType;
+import org.onehippo.cms7.services.HippoServiceRegistry;
+import org.onehippo.repository.documentworkflow.action.AbstractDocumentTaskAction;
+
+import uk.nhs.digital.externalstorage.s3.S3Connector;
+
+public class ExternalFilePublishAction extends AbstractDocumentTaskAction<ExternalFilePublishTask> {
+
+    @Override
+    protected ExternalFilePublishTask createWorkflowTask() {
+        return new ExternalFilePublishTask();
+    }
+
+    @Override
+    protected void initTask(ExternalFilePublishTask task) throws ModelException, SCXMLExpressionException {
+        super.initTask(task);
+        task.setS3Connector(HippoServiceRegistry.getService(S3Connector.class));
+        task.setVariantState(HippoStdNodeType.UNPUBLISHED);
+    }
+}

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFilePublish/ExternalFilePublishTask.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFilePublish/ExternalFilePublishTask.java
@@ -1,0 +1,11 @@
+package uk.nhs.digital.externalstorage.workflow.externalFilePublish;
+
+import uk.nhs.digital.externalstorage.s3.S3Connector;
+import uk.nhs.digital.externalstorage.workflow.AbstractExternalFileTask;
+
+public class ExternalFilePublishTask extends AbstractExternalFileTask {
+
+    protected void setTargetStatus(S3Connector s3Connector, final String resource) {
+        s3Connector.publishResource(resource);
+    }
+}

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFileUnpublish/ExternalFileUnpublishAction.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFileUnpublish/ExternalFileUnpublishAction.java
@@ -1,0 +1,23 @@
+package uk.nhs.digital.externalstorage.workflow.externalFileUnpublish;
+
+import org.apache.commons.scxml2.SCXMLExpressionException;
+import org.apache.commons.scxml2.model.ModelException;
+import org.hippoecm.repository.HippoStdNodeType;
+import org.onehippo.cms7.services.HippoServiceRegistry;
+import org.onehippo.repository.documentworkflow.action.AbstractDocumentTaskAction;
+import uk.nhs.digital.externalstorage.s3.S3Connector;
+
+public class ExternalFileUnpublishAction extends AbstractDocumentTaskAction<ExternalFileUnpublishTask> {
+
+    @Override
+    protected ExternalFileUnpublishTask createWorkflowTask() {
+        return new ExternalFileUnpublishTask();
+    }
+
+    @Override
+    protected void initTask(ExternalFileUnpublishTask task) throws ModelException, SCXMLExpressionException {
+        super.initTask(task);
+        task.setS3Connector(HippoServiceRegistry.getService(S3Connector.class));
+        task.setVariantState(HippoStdNodeType.PUBLISHED);
+    }
+}

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFileUnpublish/ExternalFileUnpublishTask.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFileUnpublish/ExternalFileUnpublishTask.java
@@ -1,0 +1,11 @@
+package uk.nhs.digital.externalstorage.workflow.externalFileUnpublish;
+
+import uk.nhs.digital.externalstorage.s3.S3Connector;
+import uk.nhs.digital.externalstorage.workflow.AbstractExternalFileTask;
+
+public class ExternalFileUnpublishTask extends AbstractExternalFileTask {
+
+    protected void setTargetStatus(S3Connector s3Connector, final String resource) {
+        s3Connector.unpublishResource(resource);
+    }
+}

--- a/cms/src/test/java/uk/nhs/digital/externalstorage/s3/S3ConnectorImplTest.java
+++ b/cms/src/test/java/uk/nhs/digital/externalstorage/s3/S3ConnectorImplTest.java
@@ -1,0 +1,49 @@
+package uk.nhs.digital.externalstorage.s3;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectResult;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.io.ByteArrayInputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class S3ConnectorImplTest {
+
+    @Mock
+    private AmazonS3 s3;
+    private String bucketName = "test.bucket.name";
+
+    @Test
+    public void shouldGenerateObjectKey() {
+        initMocks(this);
+
+        given(s3.putObject(any()))
+            .willReturn(new PutObjectResult());
+        given(s3.getObjectMetadata(anyString(), anyString()))
+            .willReturn(new ObjectMetadata());
+
+        String fileName = "test.pdf";
+        S3ConnectorImpl subject = new S3ConnectorImpl(s3, bucketName);
+        S3ObjectMetadata metadata = subject.uploadFile(
+            new ByteArrayInputStream("sample text".getBytes()),
+            fileName,
+            "application/pdf"
+        );
+
+        String actualKey = metadata.getReference();
+        Path path = Paths.get(actualKey);
+        assertThat("path contains filename at the end.", path.getName(2).toString(), equalTo(fileName));
+        assertThat("path's second part is 6 characters long.", path.getName(1).toString().length(), equalTo(6));
+        assertThat("path's first part is 2 characters long.", path.getName(0).toString().length(), equalTo(2));
+    }
+}

--- a/cms/src/test/java/uk/nhs/digital/externalstorage/workflow/externalFilePublish/ExternalFilePublishTaskTest.java
+++ b/cms/src/test/java/uk/nhs/digital/externalstorage/workflow/externalFilePublish/ExternalFilePublishTaskTest.java
@@ -1,0 +1,91 @@
+package uk.nhs.digital.externalstorage.workflow.externalFilePublish;
+
+import static org.hippoecm.repository.HippoStdNodeType.UNPUBLISHED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import org.apache.sling.testing.mock.jcr.MockJcr;
+import org.hippoecm.repository.api.WorkflowContext;
+import org.hippoecm.repository.api.WorkflowException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.onehippo.repository.documentworkflow.DocumentHandle;
+import uk.nhs.digital.externalstorage.ExternalStorageConstants;
+import uk.nhs.digital.externalstorage.s3.S3Connector;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.jcr.Node;
+import javax.jcr.Repository;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+public class ExternalFilePublishTaskTest {
+
+    @Mock private S3Connector s3Connector;
+    @Mock private WorkflowContext workflowContext;
+
+    private ExternalFilePublishTask externalFilePublishTask;
+    private Session session;
+
+    private Node rootNode;
+
+    @Before
+    public void setUp() throws RepositoryException {
+        initMocks(this);
+        given(s3Connector.publishResource(any(String.class)))
+            .willReturn(true);
+
+        Repository repository = MockJcr.newRepository();
+        session = repository.login();
+        rootNode = session.getRootNode();
+        externalFilePublishTask = new ExternalFilePublishTask();
+
+        given(workflowContext.getInternalWorkflowSession()).willReturn(session);
+        externalFilePublishTask.setWorkflowContext(workflowContext);
+    }
+
+    @Test
+    public void shouldCallS3() throws WorkflowException, RepositoryException {
+        Node docNode = rootNode.addNode("test-document");
+        addSubDocument(docNode, UNPUBLISHED);
+        MockJcr.setQueryResult(session, getQueryResults());
+
+        executeTask(docNode, externalFilePublishTask);
+
+        then(s3Connector).should().publishResource("the/one");
+    }
+
+    private void executeTask(Node document, ExternalFilePublishTask task) throws WorkflowException {
+        DocumentHandle documentHandle = new DocumentHandle(document);
+        documentHandle.initialize();
+        task.setDocumentHandle(documentHandle);
+        task.setS3Connector(s3Connector);
+        task.setVariantState(UNPUBLISHED);
+
+        task.execute();
+    }
+
+    private Node addSubDocument(Node documentNode, String state) throws RepositoryException {
+        String name = documentNode.getName();
+        Node document = documentNode.addNode(name);
+        document.setProperty("hippostd:state", state);
+
+        return document;
+    }
+
+    private List<Node> getQueryResults() throws RepositoryException {
+        List<Node> nodes = new ArrayList<>();
+
+        Node r = rootNode.addNode("resources");
+
+        Node o = r.addNode("one");
+        o.setProperty(ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_REFERENCE, "the/one");
+        nodes.add(o);
+
+        return nodes;
+    }
+}

--- a/cms/src/test/java/uk/nhs/digital/externalstorage/workflow/externalFileUnpublish/ExternalFileUnpublishTaskTest.java
+++ b/cms/src/test/java/uk/nhs/digital/externalstorage/workflow/externalFileUnpublish/ExternalFileUnpublishTaskTest.java
@@ -1,0 +1,92 @@
+package uk.nhs.digital.externalstorage.workflow.externalFileUnpublish;
+
+import static org.hippoecm.repository.HippoStdNodeType.PUBLISHED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import org.apache.sling.testing.mock.jcr.MockJcr;
+import org.hippoecm.repository.api.WorkflowContext;
+import org.hippoecm.repository.api.WorkflowException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.onehippo.repository.documentworkflow.DocumentHandle;
+import uk.nhs.digital.externalstorage.ExternalStorageConstants;
+import uk.nhs.digital.externalstorage.s3.S3Connector;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.jcr.Node;
+import javax.jcr.Repository;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+public class ExternalFileUnpublishTaskTest {
+
+    @Mock private S3Connector s3Connector;
+    @Mock private WorkflowContext workflowContext;
+
+    private ExternalFileUnpublishTask externalFileUnpublishTask;
+    private Session session;
+
+    private Node rootNode;
+
+    @Before
+    public void setUp() throws RepositoryException {
+        initMocks(this);
+        given(s3Connector.unpublishResource(any(String.class)))
+            .willReturn(true);
+
+        Repository repository = MockJcr.newRepository();
+        session = repository.login();
+        rootNode = session.getRootNode();
+        externalFileUnpublishTask = new ExternalFileUnpublishTask();
+        externalFileUnpublishTask.setS3Connector(s3Connector);
+
+        given(workflowContext.getInternalWorkflowSession()).willReturn(session);
+        externalFileUnpublishTask.setWorkflowContext(workflowContext);
+    }
+
+    @Test
+    public void shouldCallS3() throws WorkflowException, RepositoryException {
+        Node docNode = rootNode.addNode("test-document");
+        addSubDocument(docNode, PUBLISHED);
+        MockJcr.setQueryResult(session, getQueryResults());
+
+        executeTask(docNode, externalFileUnpublishTask);
+
+        then(s3Connector).should().unpublishResource("the/one");
+    }
+
+    private void executeTask(Node document, ExternalFileUnpublishTask task) throws WorkflowException {
+        DocumentHandle documentHandle = new DocumentHandle(document);
+        documentHandle.initialize();
+        task.setDocumentHandle(documentHandle);
+        task.setS3Connector(s3Connector);
+        task.setVariantState(PUBLISHED);
+
+        task.execute();
+    }
+
+    private Node addSubDocument(Node documentNode, String state) throws RepositoryException {
+        String name = documentNode.getName();
+        Node document = documentNode.addNode(name);
+        document.setProperty("hippostd:state", state);
+
+        return document;
+    }
+
+    private List<Node> getQueryResults() throws RepositoryException {
+        List<Node> nodes = new ArrayList<>();
+
+        Node r = rootNode.addNode("resources");
+
+        Node o = r.addNode("one");
+        o.setProperty(ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_REFERENCE, "the/one");
+        nodes.add(o);
+
+        return nodes;
+    }
+}

--- a/repository-data/application/src/main/resources/hcm-config/configuration/modules/documentworkflow.scxml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/modules/documentworkflow.scxml
@@ -15,10 +15,12 @@
   limitations under the License.
   -->
 <scxml version="1.0"
-       xmlns="http://www.w3.org/2005/07/scxml"
-       xmlns:hippo="http://www.onehippo.org/cms7/repository/scxml"
-       xmlns:cs="http://commons.apache.org/scxml"
-       xmlns:nhsdigital="http://digital.nhs.uk/repository/scxml">
+    xmlns="http://www.w3.org/2005/07/scxml"
+    xmlns:hippo="http://www.onehippo.org/cms7/repository/scxml"
+    xmlns:cs="http://commons.apache.org/scxml"
+    xmlns:nhsdigital="http://digital.nhs.uk/repository/scxml"
+    xmlns:externalstorage="http://digital.nhs.uk/externalstorage/scxml"
+>
 
     <script>
         def getScxmlId() { workflowContext.scxmlId }
@@ -356,6 +358,9 @@
 
                 <!-- target-less transition to publish the document when no event payload parameter targetDate is provided -->
                 <transition event="publish" cond="!_event.data?.targetDate">
+                    <!-- Trigger publication of external files -->
+                    <externalstorage:externalFilePublish/>
+
                     <!-- copy the content of the unpublished variant to the published variant -->
                     <hippo:copyVariant sourceState="unpublished" targetState="published"/>
                     <!-- mark the published variant as published and set its availability to (only) 'live' -->
@@ -430,6 +435,9 @@
                     <!-- trigger the creation of searchable flag being false on all published datasets on the published version after it's been copied
                          to trigger the published datasets to be updated if applicable -->
                     <nhsdigital:populateSearchableFlag variant="published" depublishing="true"/>
+
+		    <!-- Trigger publication of external files -->
+                    <externalstorage:externalFileUnpublish/>
 
                     <!-- ensure the unpublished variant to be versionable set its availability to (only) 'live' -->
                     <hippo:configVariant variant="unpublished" versionable="true" availabilities="preview"/>

--- a/repository-data/application/src/main/resources/hcm-config/configuration/modules/s3ConnectorRegistrationModule.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/modules/s3ConnectorRegistrationModule.yaml
@@ -6,6 +6,6 @@ definitions:
         jcr:primaryType: hipposys:moduleconfig
         s3Bucket: files.digital.nhs.uk
         s3Region: eu-west-2
-      hipposys:className: uk.nhs.digital.ps.modules.S3ConnectorServiceRegistrationModule
+      hipposys:className: uk.nhs.digital.externalstorage.modules.S3ConnectorServiceRegistrationModule
       hipposys:cmsonly: true
       jcr:primaryType: hipposys:module

--- a/repository-data/application/src/main/resources/hcm-config/configuration/modules/scxmlregistry.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/modules/scxmlregistry.yaml
@@ -2,6 +2,14 @@
 definitions:
   config:
     /hippo:configuration/hippo:modules/scxmlregistry/hippo:moduleconfig/hipposcxml:definitions/documentworkflow:
+      /externalFilePublish:
+        hipposcxml:classname: uk.nhs.digital.externalstorage.workflow.externalFilePublish.ExternalFilePublishAction
+        hipposcxml:namespace: http://digital.nhs.uk/externalstorage/scxml
+        jcr:primaryType: hipposcxml:action
+      /externalFileUnpublish:
+        hipposcxml:classname: uk.nhs.digital.externalstorage.workflow.externalFileUnpublish.ExternalFileUnpublishAction
+        hipposcxml:namespace: http://digital.nhs.uk/externalstorage/scxml
+        jcr:primaryType: hipposcxml:action
       /populateSearchableFlag:
         hipposcxml:classname: uk.nhs.digital.ps.workflow.searchableFlag.SearchableFlagAction
         hipposcxml:namespace: http://digital.nhs.uk/repository/scxml


### PR DESCRIPTION
Two simple actions to add or remove public ACL on S3 objects embedded in
the workflow document.

This version does no handle S3 errors yet.