### PR TITLE
NIL 129 tabbed search

### DIFF
--- a/acceptance-tests/src/test/resources/features/site/search.feature
+++ b/acceptance-tests/src/test/resources/features/site/search.feature
@@ -145,6 +145,34 @@ Feature: Basic search
             | Series / Collection ( ... |
             | Methodology ( ...         |
 
+    Scenario: Clicking on the 'All' tab displays the results page with full, unfiltered result set
+        Given I navigate to the "search" page
+        When I can click on the "All" link
+        Then I should see the list with title "DOCUMENT TYPE" including:
+            | Publication ( ...         |
+            | Data set ( ...            |
+            | Series / Collection ( ... |
+            | Methodology ( ...         |
+
+    Scenario: Clicking on the 'Data and Information' tab displays the results page with publications, data sets, series and methodologies
+        Given I navigate to the "search" page
+        When I can click on the "Data and Information" link
+        Then I should see the list with title "DOCUMENT TYPE" including:
+            | Publication ( ...         |
+            | Data set ( ...            |
+            | Series / Collection ( ... |
+            | Methodology ( ...         |
+
+    Scenario: Clicking on the 'Systems and Services' tab displays no results because we don't yet include them in the search component
+        Given I navigate to the "search" page
+        When I can click on the "Systems and Services" link
+        Then I can see the search description matching "No results for filters"
+
+    Scenario: Clicking on the 'News and Events' tab displays no results because we don't yet include them in the search component
+        Given I navigate to the "search" page
+        When I can click on the "News and Events" link
+        Then I can see the search description matching "No results for filters"
+
     Scenario: Each document type label is correctly displayed in search results
         Given I navigate to the "home" page
         When I search for "Bare Minimum"

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/pages/search.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/pages/search.yaml
@@ -16,5 +16,9 @@ definitions:
         - 'true'
         hst:template: searchresults
         jcr:primaryType: hst:component
+      /tabs:
+        hst:componentclassname: uk.nhs.digital.common.components.SearchTabsComponent
+        hst:template: searchtabs
+        jcr:primaryType: hst:component
       hst:referencecomponent: hst:abstractpages/basepage
       jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates.yaml
@@ -83,6 +83,9 @@ definitions:
       /searchresults:
         hst:renderpath: webfile:/freemarker/common/searchresults.ftl
         jcr:primaryType: hst:template
+      /searchtabs:
+        hst:renderpath: webfile:/freemarker/common/searchtabs.ftl
+        jcr:primaryType: hst:template
       /series:
         hst:renderpath: webfile:/freemarker/publicationsystem/series.ftl
         jcr:primaryType: hst:template

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/feature-toggles.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/feature-toggles.yaml
@@ -1,0 +1,71 @@
+---
+/content/documents/administration/publication-system/feature-toggles:
+  /feature-toggles[1]:
+    hippo:availability: []
+    hippostd:state: draft
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-01-17T15:49:40.466Z
+    hippostdpubwf:lastModificationDate: 2018-03-08T11:00:17.976Z
+    hippostdpubwf:lastModifiedBy: admin
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: resourcebundle:resourcebundle
+    resourcebundle:descriptions:
+    - ''
+    - ''
+    - ''
+    - ''
+    resourcebundle:id: feature-toggles
+    resourcebundle:keys:
+    - feature.tabs
+    resourcebundle:messages:
+    - 'true'
+  /feature-toggles[2]:
+    hippo:availability:
+    - preview
+    hippostd:state: unpublished
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-01-17T15:49:40.466Z
+    hippostdpubwf:lastModificationDate: 2018-03-08T11:00:26.168Z
+    hippostdpubwf:lastModifiedBy: admin
+    jcr:mixinTypes:
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: resourcebundle:resourcebundle
+    resourcebundle:descriptions:
+    - ''
+    - ''
+    - ''
+    - ''
+    resourcebundle:id: feature-toggles
+    resourcebundle:keys:
+    - feature.tabs
+    resourcebundle:messages:
+    - 'true'
+  /feature-toggles[3]:
+    hippo:availability:
+    - live
+    hippostd:state: published
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-01-17T15:49:40.466Z
+    hippostdpubwf:lastModificationDate: 2018-03-08T11:00:26.168Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippostdpubwf:publicationDate: 2018-03-08T11:00:27.440Z
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: resourcebundle:resourcebundle
+    resourcebundle:descriptions:
+    - ''
+    - ''
+    - ''
+    - ''
+    resourcebundle:id: feature-toggles
+    resourcebundle:keys:
+    - feature.tabs
+    resourcebundle:messages:
+    - 'true'
+  hippo:name: Feature Toggles
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/searchtab-labels.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/searchtab-labels.yaml
@@ -1,0 +1,89 @@
+---
+/content/documents/administration/publication-system/searchtab-labels:
+  /searchtab-labels[1]:
+    hippo:availability: []
+    hippostd:state: draft
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-01-17T15:49:40.466Z
+    hippostdpubwf:lastModificationDate: 2018-03-08T11:00:17.976Z
+    hippostdpubwf:lastModifiedBy: admin
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: resourcebundle:resourcebundle
+    resourcebundle:descriptions:
+    - ''
+    - ''
+    - ''
+    - ''
+    resourcebundle:id: searchtab-labels
+    resourcebundle:keys:
+    - searchtab.all
+    - searchtab.data
+    - searchtab.services
+    - searchtab.news
+    resourcebundle:messages:
+    - All
+    - Data and Information
+    - Systems and Services
+    - News and Events
+  /searchtab-labels[2]:
+    hippo:availability:
+    - preview
+    hippostd:state: unpublished
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-01-17T15:49:40.466Z
+    hippostdpubwf:lastModificationDate: 2018-03-08T11:00:26.168Z
+    hippostdpubwf:lastModifiedBy: admin
+    jcr:mixinTypes:
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: resourcebundle:resourcebundle
+    resourcebundle:descriptions:
+    - ''
+    - ''
+    - ''
+    - ''
+    resourcebundle:id: searchtab-labels
+    resourcebundle:keys:
+    - searchtab.all
+    - searchtab.data
+    - searchtab.services
+    - searchtab.news
+    resourcebundle:messages:
+    - All
+    - Data and Information
+    - Systems and Services
+    - News and Events
+  /searchtab-labels[3]:
+    hippo:availability:
+    - live
+    hippostd:state: published
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-01-17T15:49:40.466Z
+    hippostdpubwf:lastModificationDate: 2018-03-08T11:00:26.168Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippostdpubwf:publicationDate: 2018-03-08T11:00:27.440Z
+    jcr:mixinTypes:
+    - mix:referenceable
+    jcr:primaryType: resourcebundle:resourcebundle
+    resourcebundle:descriptions:
+    - ''
+    - ''
+    - ''
+    - ''
+    resourcebundle:id: searchtab-labels
+    resourcebundle:keys:
+    - searchtab.all
+    - searchtab.data
+    - searchtab.services
+    - searchtab.news
+    resourcebundle:messages:
+    - All
+    - Data and Information
+    - Systems and Services
+    - News and Events
+  hippo:name: Search Tab Labels
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/base-layout.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/base-layout.ftl
@@ -1,7 +1,8 @@
 <#ftl output_format="HTML">
 <!DOCTYPE html>
 <#include "../include/imports.ftl">
-<@hst.setBundle basename="emails"/>
+<#include "macro/searchTabsComponent.ftl">
+<@hst.setBundle basename="emails, feature-toggles"/>
 
 <html lang="en">
   <head>
@@ -88,11 +89,14 @@
           </div>
         </div><!--
         --><div class="layout__item layout-2-3">
+          <@searchTabsComponent contentNames=hstResponseChildContentNames></@searchTabsComponent>
+                  
           <@hst.include ref="main"/>
         </div>
       </div>
     </section>
     <#else>
+      <@searchTabsComponent contentNames=hstResponseChildContentNames></@searchTabsComponent>
 
       <@hst.include ref="main"/>
 

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/searchTabsComponent.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/searchTabsComponent.ftl
@@ -1,0 +1,10 @@
+<#ftl output_format="HTML">
+<@hst.setBundle basename="feature-toggles"/>
+<#macro searchTabsComponent contentNames>
+    <@fmt.message key="feature.tabs" var="featureTabs"/>
+    <#if contentNames?seq_contains("tabs") && featureTabs?boolean>
+        <div class="nav-tabs">
+            <@hst.include ref="tabs"/>
+        </div>
+    </#if>
+</#macro>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/searchresults.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/searchresults.ftl
@@ -14,7 +14,7 @@
             --><div class="layout__item layout-1-3" style="text-align:right">
                 <label for="sortBy">Sort by:</label>
                 <select id="sortBy" onChange="window.location.href=this.value" data-uipath="ps.search-results.sort-selector">
-                    <#assign sortLink = searchLink + query???then('?query=${query}&', '?') + 'sort='>
+                    <#assign sortLink = searchLink + query???then('?query=${query}&', '?') +'area=${area}&' + 'sort='>
                     <option title="Order by date" value="${sortLink}date"
                         <#if sort?? && sort == 'date'>selected</#if>>Date</option>
                     <option title="Order by relevance" value="${sortLink}relevance"

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/searchtabs.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/searchtabs.ftl
@@ -1,0 +1,13 @@
+<#ftl output_format="HTML">
+<#include "../include/imports.ftl">
+<@hst.setBundle basename="month-names,facet-headers,facet-labels,searchtab-labels"/>
+
+<div data-uipath="ps.search-tabs">
+    <#assign tabLink = searchLink + query???then('?query=${query}&', '?') + 'sort=${sort}&' +'area=' >
+    
+    <ul class="tabs-nav" role="tablist">
+        <#list tabs as tab>    
+            <li class="${(area=='${tab}')?string("active", "")}"><a tabindex="${tab?index}" href="${tabLink}${tab}" title="<@fmt.message key="searchtab.${tab}"/>"><@fmt.message key="searchtab.${tab}"/></a></li>
+        </#list>
+    </ul>
+</div>

--- a/repository-data/webfiles/src/main/resources/site/less/style.less
+++ b/repository-data/webfiles/src/main/resources/site/less/style.less
@@ -797,8 +797,83 @@ div.nihubSection {
 div.nihubSection ul {
   list-style: none;
 }
+
 .pointer:hover {
   cursor: pointer;
+}
+
+/* TOP TABS */
+/* ########################################################## */
+.nav-tabs {
+  margin-bottom:20px;
+}
+
+.nav-tabs:after {
+  content: "";
+  display: table;
+  clear: both;
+}
+
+.nav-tabs ul, .nav-tabs .tabs-nav {
+  float: left;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  position: relative;
+  z-index: 5;
+}
+
+.nav-tabs li, .nav-tabs .tabs-nav li {
+    font-size: 16px;
+    line-height: 1.25;
+}
+
+.nav-tabs li, .nav-tabs .tabs-nav li {
+    font-family: "nta", Arial, sans-serif;
+    font-weight: 400;
+    text-transform: none;
+    font-size: 14px;
+    line-height: 1.1428571429;
+    padding: 0;
+    margin: 0;
+    float: left;
+}
+
+.nav-tabs li:first-child a, .nav-tabs .tabs-nav li:first-child a {
+  margin-left: 0;
+}
+.nav-tabs li.active a, .nav-tabs .tabs-nav li.active a {
+  background-color: #fff;
+  border: solid 1px #bfc1c3;
+  border-bottom: solid 1px #fff;
+  color: #0b0c0c;
+  position: relative;
+  text-decoration: none;
+  z-index: 5;
+}
+.nav-tabs li a, .nav-tabs .tabs-nav li a {
+  border: solid 1px #fff;
+  border-bottom: none;
+  float: left;
+  height: 2.25em;
+  line-height: 2.25em;
+  margin-bottom: -1px;
+  padding: 0 1em 0 1em;
+  position: relative;
+  text-align: center;
+  top: 0;
+}
+.nav-tabs li a, .nav-tabs .tabs-nav li a {
+  border: solid 1px #fff;
+  border-bottom: none;
+  float: left;
+  height: 2.25em;
+  line-height: 2.25em;
+  margin-bottom: -1px;
+  padding: 0 1em 0 1em;
+  position: relative;
+  text-align: center;
+  top: 0;
 }
 
 

--- a/site/src/main/java/uk/nhs/digital/common/components/SearchTabsComponent.java
+++ b/site/src/main/java/uk/nhs/digital/common/components/SearchTabsComponent.java
@@ -1,0 +1,26 @@
+package uk.nhs.digital.common.components;
+
+import org.hippoecm.hst.core.component.HstRequest;
+import org.hippoecm.hst.core.component.HstResponse;
+import org.hippoecm.hst.core.parameters.ParametersInfo;
+import org.onehippo.cms7.essentials.components.info.EssentialsListComponentInfo;
+import uk.nhs.digital.common.enums.SearchArea;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@ParametersInfo(type = EssentialsListComponentInfo.class)
+public class SearchTabsComponent extends SearchComponent {
+
+    @Override
+    public void doBeforeRender(HstRequest request, HstResponse response) {
+        super.doBeforeRender(request, response);
+
+        List<String> tabs = Stream.of(SearchArea.values())
+                               .map(Enum::toString)
+                               .collect(Collectors.toList());
+
+        request.setAttribute("tabs", tabs);
+    }
+}

--- a/site/src/main/java/uk/nhs/digital/common/enums/SearchArea.java
+++ b/site/src/main/java/uk/nhs/digital/common/enums/SearchArea.java
@@ -1,0 +1,13 @@
+package uk.nhs.digital.common.enums;
+
+public enum SearchArea {
+    ALL,
+    DATA,
+    SERVICES,
+    NEWS;
+
+    @Override
+    public String toString() {
+        return name().toLowerCase();
+    }
+}


### PR DESCRIPTION
This is ready for formal review now.

This PR provides tabbed search using 'scope' to determine which content will be surfaced. Scope derivation is now more elegant than the first iteration.

Tab structure/style follows the Gov site as has been agreed.

Note as there is no (as yet) 'services' or 'news' content, the acceptance test asserts this.