### PR TITLE
NIL-146 Adds Nihub to methodologies root

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
@@ -66,6 +66,10 @@ definitions:
             - hst:pages/indicator
             hst:relativecontentpath: national-indicator-library/${1}
             jcr:primaryType: hst:sitemapitem
+          /_index_:
+            hst:componentconfigurationid: hst:pages/nihub
+            hst:relativecontentpath: national-indicator-library/nihub
+            jcr:primaryType: hst:sitemapitem
           hst:componentconfigurationid: hst:pages/404
           jcr:primaryType: hst:sitemapitem
         /publications:

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/nihub.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/national-indicator-library/nihub.yaml
@@ -1,6 +1,5 @@
 ---
 /content/documents/corporate-website/national-indicator-library/nihub:
-  .meta:order-before: add
   /nihub[1]:
     /nationalindicatorlibrary:igbHubLink:
       jcr:primaryType: nationalindicatorlibrary:nihublink


### PR DESCRIPTION
[NIL-146] Moves nihub.yaml to application and adds nihub to methodologies root on the sitemap