### PR TITLE
[NIL-144] URL change for NIL

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
@@ -128,7 +128,7 @@ public class TestContentUrls {
             "/data-and-information/publications/lorem-ipsum-content/morbi-tempor-euismod-vehicula");
 
         // National Indicator Library
-        add("nihub", "/data-and-information/methodologies/nihub");
+        add("nihub", "/data-and-information/national-indicator-library/nihub");
 
         // Legacy publication
         add("legacy publication",

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
@@ -53,7 +53,7 @@ definitions:
           - hst:pages/componentlist
           hst:relativecontentpath: data-and-information/content
           jcr:primaryType: hst:sitemapitem
-        /methodologies:
+        /national-indicator-library:
           /_any_:
             hst:componentconfigurationid: hst:pages/404
             hst:componentconfigurationmappingnames:


### PR DESCRIPTION
Changes URL for 'methodologies' to 'national-indicator-library'