### PR TITLE
[RPS-446] Add related link component to repeating body section

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/data/ExpectedTestDataProvider.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/data/ExpectedTestDataProvider.java
@@ -12,6 +12,7 @@ import uk.nhs.digital.ps.test.acceptance.models.InformationType;
 import uk.nhs.digital.ps.test.acceptance.models.PublicationBuilder;
 import uk.nhs.digital.ps.test.acceptance.models.PublicationSeriesBuilder;
 import uk.nhs.digital.ps.test.acceptance.models.section.ImageSection;
+import uk.nhs.digital.ps.test.acceptance.models.section.RelatedLinkSection;
 import uk.nhs.digital.ps.test.acceptance.models.section.TextSection;
 
 import java.time.Instant;
@@ -167,7 +168,11 @@ public class ExpectedTestDataProvider {
             new ImageSection("sectioned publication snowman",
                 "Snowman",
                 null,
-                null)
+                null),
+            new RelatedLinkSection("BBC Homepage",
+            "https://www.bbc.co.uk/"),
+            new RelatedLinkSection("Sky website",
+                "http://www.sky.com/")
         );
 
 

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/section/RelatedLinkSection.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/section/RelatedLinkSection.java
@@ -1,0 +1,41 @@
+package uk.nhs.digital.ps.test.acceptance.models.section;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import uk.nhs.digital.ps.test.acceptance.pages.widgets.SectionWidget;
+import uk.nhs.digital.ps.test.acceptance.pages.widgets.RelatedLinkSectionWidget;
+
+public class RelatedLinkSection extends BodySection {
+    private final String linkText;
+    private final String linkUrl;
+
+    public RelatedLinkSection(String text, String url) {
+        this.linkText = text;
+        this.linkUrl = url;
+    }
+
+    public String getText() {
+        return linkText;
+    }
+
+    public String getUrl() {
+        return linkUrl;
+    }
+
+    public Matcher<? super SectionWidget> getMatcher() {
+        return new TypeSafeDiagnosingMatcher<SectionWidget>(RelatedLinkSectionWidget.class) {
+            @Override
+            protected boolean matchesSafely(SectionWidget item, Description desc) {
+                RelatedLinkSectionWidget widget = (RelatedLinkSectionWidget) item;
+                return compare(linkText, widget.getLinkText(), desc)
+                    && compare(linkUrl, widget.getLinkUrl(), desc);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendValue(RelatedLinkSection.this);
+            }
+        };
+    }
+}

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ps/PublicationPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ps/PublicationPage.java
@@ -14,6 +14,7 @@ import uk.nhs.digital.ps.test.acceptance.pages.widgets.AttachmentWidget;
 import uk.nhs.digital.ps.test.acceptance.pages.widgets.ImageSectionWidget;
 import uk.nhs.digital.ps.test.acceptance.pages.widgets.SectionWidget;
 import uk.nhs.digital.ps.test.acceptance.pages.widgets.TextSectionWidget;
+import uk.nhs.digital.ps.test.acceptance.pages.widgets.RelatedLinkSectionWidget;
 import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverProvider;
 
 import java.util.Collection;
@@ -120,6 +121,8 @@ public class PublicationPage extends AbstractSitePage {
                 return new ImageSectionWidget(webElement);
             case TextSectionWidget.UIPATH:
                 return new TextSectionWidget(webElement);
+            case RelatedLinkSectionWidget.UIPATH:
+                return new RelatedLinkSectionWidget(webElement);
             default:
                 throw new RuntimeException("Unknown uipath: " + uipath);
         }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/widgets/RelatedLinkSectionWidget.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/widgets/RelatedLinkSectionWidget.java
@@ -1,0 +1,35 @@
+package uk.nhs.digital.ps.test.acceptance.pages.widgets;
+
+import static java.lang.String.format;
+
+import org.openqa.selenium.WebElement;
+
+public class RelatedLinkSectionWidget extends SectionWidget {
+    public static final String UIPATH = "ps.publication.body.relatedlink-section";
+
+    public RelatedLinkSectionWidget(final WebElement rootElement) {
+        super(rootElement);
+    }
+
+    @Override
+    protected String getUiPath() {
+        return UIPATH;
+    }
+
+    public String getLinkText() {
+        WebElement text = findElement("text");
+        return text != null ? text.getText() : null;
+    }
+
+    public String getLinkUrl() {
+        return findElement("text").getAttribute("href");
+    }
+
+    @Override
+    public String toString() {
+        return format("linkText=%s,linkUrl=%s",
+            getLinkText(),
+            getLinkUrl()
+        );
+    }
+}

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
@@ -217,7 +217,7 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
             caption: Body
-            compoundList: publicationsystem:imageSection,publicationsystem:textSection
+            compoundList: publicationsystem:imageSection,publicationsystem:textSection,publicationsystem:relatedlink
             contentPickerType: links
             field: body
             hint: ''

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/sectioned-publication.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/sectioned-publication.yaml
@@ -63,6 +63,14 @@
         publicationsystem:altText: Snowman
         publicationsystem:caption: ''
         publicationsystem:link: ''
+      /publicationsystem:bodySections[6]:
+        jcr:primaryType: publicationsystem:relatedlink
+        publicationsystem:linkText: BBC Homepage
+        publicationsystem:linkUrl: https://www.bbc.co.uk
+      /publicationsystem:bodySections[7]:
+        jcr:primaryType: publicationsystem:relatedlink
+        publicationsystem:linkText: Sky website
+        publicationsystem:linkUrl: http://www.sky.com
       common:FacetType: publication
       common:searchable: true
       hippo:availability: []
@@ -147,6 +155,14 @@
         publicationsystem:altText: Snowman
         publicationsystem:caption: ''
         publicationsystem:link: ''
+      /publicationsystem:bodySections[6]:
+        jcr:primaryType: publicationsystem:relatedlink
+        publicationsystem:linkText: BBC Homepage
+        publicationsystem:linkUrl: https://www.bbc.co.uk
+      /publicationsystem:bodySections[7]:
+        jcr:primaryType: publicationsystem:relatedlink
+        publicationsystem:linkText: Sky website
+        publicationsystem:linkUrl: http://www.sky.com
       common:FacetType: publication
       common:searchable: true
       hippo:availability:
@@ -233,6 +249,14 @@
         publicationsystem:altText: Snowman
         publicationsystem:caption: ''
         publicationsystem:link: ''
+      /publicationsystem:bodySections[6]:
+        jcr:primaryType: publicationsystem:relatedlink
+        publicationsystem:linkText: BBC Homepage
+        publicationsystem:linkUrl: https://www.bbc.co.uk
+      /publicationsystem:bodySections[7]:
+        jcr:primaryType: publicationsystem:relatedlink
+        publicationsystem:linkText: Sky website
+        publicationsystem:linkUrl: http://www.sky.com
       common:FacetType: publication
       common:searchable: true
       hippo:availability:

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/macro/sections/related-linkSection.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/macro/sections/related-linkSection.ftl
@@ -1,0 +1,8 @@
+<#ftl output_format="HTML">
+
+<#macro relatedLinkSection section>
+    <div data-uipath="ps.publication.body.relatedlink-section">
+        <a data-uipath="ps.publication.body.relatedlink-section.text" target="_blank"
+           href="${section.linkUrl}" onClick="logGoogleAnalyticsEvent('Link click','Publication','${section.linkUrl}');">${section.linkText}</a>
+    </div>
+</#macro>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/macro/sections/sections.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/macro/sections/sections.ftl
@@ -1,6 +1,7 @@
 <#ftl output_format="HTML">
 <#include "textSection.ftl">
 <#include "imageSection.ftl">
+<#include "related-linkSection.ftl">
 
 <#macro sections sections>
     <div data-uipath="ps.publication.body">
@@ -9,6 +10,8 @@
                 <@textSection section=section />
             <#elseif section.sectionType == 'image'>
                 <@imageSection section=section />
+            <#elseif section.sectionType == 'relatedLink'>
+                <@relatedLinkSection section=section />
             </#if>
         </#list>
     </div>

--- a/site/src/main/java/uk/nhs/digital/ps/beans/RelatedLink.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/RelatedLink.java
@@ -16,4 +16,8 @@ public class RelatedLink extends HippoCompound {
     public String getLinkUrl() {
         return getProperty("publicationsystem:linkUrl");
     }
+
+    public String getSectionType() {
+        return "relatedLink";
+    }
 }


### PR DESCRIPTION
Repeating Body section of publication now includes another option
to add a Related Link (alongside image and text).