### PR TITLE
[NIL-151] Suppress search tabs waste warning

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/pages/search.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/pages/search.yaml
@@ -18,6 +18,7 @@ definitions:
         jcr:primaryType: hst:component
       /tabs:
         hst:componentclassname: uk.nhs.digital.common.components.SearchTabsComponent
+        hst:suppresswastemessage: true
         hst:template: searchtabs
         jcr:primaryType: hst:component
       hst:referencecomponent: hst:abstractpages/basepage


### PR DESCRIPTION
Suppress the waste warning - this is occurring when the search tabs feature is toggled off but we know this is temporary.