### PR TITLE
[RPS-450] RPS-450 cap S3 concurrent uploads

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
@@ -96,7 +96,7 @@ public class TestContentUrls {
 
         // CI Hub/Landing
         add("SHMI landing", "/data-and-information/publications/ci-hub/summary-hospital-level-mortality-indicator-shmi");
-        add("SHMI timetable attachment",
+        add("SHMI_publication_timetable.xlsx",
             "/binaries/content/documents/corporate-website/publication-system/ci-hub/summary-hospital-level-mortality-indicator-shmi/summary-hospital-level-mortality-indicator-shmi/publicationsystem%3Acilandingasset/publicationsystem%3AAttachments/publicationsystem%3AattachmentResource");
         add("ci hub root", "/data-and-information/publications/ci-hub");
 

--- a/acceptance-tests/src/test/resources/features/site/clinicalIndicatorsHub.feature
+++ b/acceptance-tests/src/test/resources/features/site/clinicalIndicatorsHub.feature
@@ -67,7 +67,7 @@ Feature: Clinical Indicator hub page and sub sections
     Scenario: SHMI resources - attachments
         Given I navigate to the "SHMI landing" page
         And I can download following files:
-            | SHMI publication timetable        | SHMI timetable attachment |
+            | SHMI publication timetable        | SHMI_publication_timetable.xlsx |
 
     Scenario: SHMI resources - links
         Given I navigate to the "SHMI landing" page

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/ExternalStorageConstants.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/ExternalStorageConstants.java
@@ -10,8 +10,4 @@ public interface ExternalStorageConstants {
     String PROPERTY_EXTERNAL_STORAGE_MIME_TYPE = "jcr:mimeType";
     String PROPERTY_EXTERNAL_STORAGE_FILE_NAME = "hippo:filename";
     String PROPERTY_EXTERNAL_STORAGE_LAST_MODIFIED = "jcr:lastModified";
-
-    String SYSTEM_PROPERTY_AWS_BUCKET_NAME = "externalstorage.aws.bucket";
-    String SYSTEM_PROPERTY_AWS_REGION = "externalstorage.aws.region";
-    String SYSTEM_PROPERTY_AWS_S3_ENDPOINT = "externalstorage.aws.s3.endpoint";
 }

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/modules/S3ConnectorServiceRegistrationModule.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/modules/S3ConnectorServiceRegistrationModule.java
@@ -1,8 +1,7 @@
 package uk.nhs.digital.externalstorage.modules;
 
-import static uk.nhs.digital.externalstorage.ExternalStorageConstants.SYSTEM_PROPERTY_AWS_BUCKET_NAME;
-import static uk.nhs.digital.externalstorage.ExternalStorageConstants.SYSTEM_PROPERTY_AWS_REGION;
-import static uk.nhs.digital.externalstorage.ExternalStorageConstants.SYSTEM_PROPERTY_AWS_S3_ENDPOINT;
+import static org.slf4j.LoggerFactory.getLogger;
+import static uk.nhs.digital.externalstorage.modules.S3ConnectorServiceRegistrationModuleParams.*;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
@@ -10,63 +9,174 @@ import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.apache.commons.lang3.Validate;
 import org.onehippo.cms7.services.HippoServiceRegistry;
 import org.onehippo.repository.modules.AbstractReconfigurableDaemonModule;
 import org.onehippo.repository.modules.ProvidesService;
 
-import uk.nhs.digital.externalstorage.s3.S3Connector;
-import uk.nhs.digital.externalstorage.s3.S3ConnectorImpl;
-import uk.nhs.digital.externalstorage.s3.S3ObjectKeyGenerator;
+import org.slf4j.Logger;
+import uk.nhs.digital.externalstorage.s3.*;
 
+import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import javax.jcr.Node;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
-@ProvidesService(types = S3Connector.class)
+
+@ProvidesService(types = SchedulingS3Connector.class)
 public class S3ConnectorServiceRegistrationModule extends AbstractReconfigurableDaemonModule {
 
+    private static final Logger log = getLogger(S3ConnectorServiceRegistrationModule.class);
+
     private final Object configurationLock = new Object();
-    private S3Connector s3Connector;
+
     private String s3Bucket;
     private String s3Region;
     private String s3Endpoint;
 
+    private int downloadsMaxConcurrentCount;
+    private long downloadsShutdownTimeoutInSecs;
+
+    private int uploadsMaxConcurrentCount;
+    private long uploadsShutdownTimeoutInSecs;
+
+    private ExecutorService downloadExecutorService;
+    private ExecutorService uploadExecutorService;
+    private SchedulingS3Connector schedulingS3Connector;
+
     @Override
     protected void doConfigure(final Node moduleConfig) throws RepositoryException {
-        synchronized (configurationLock) {
-            s3Bucket = getConfigValue(SYSTEM_PROPERTY_AWS_BUCKET_NAME, "s3Bucket", moduleConfig);
-            s3Region = getConfigValue(SYSTEM_PROPERTY_AWS_REGION, "s3Region", moduleConfig);
 
-            if (moduleConfig.hasProperty("s3Endpoint")) {
-                s3Endpoint = getConfigValue(SYSTEM_PROPERTY_AWS_S3_ENDPOINT, "s3Endpoint", moduleConfig);
-            } else {
-                s3Endpoint = System.getProperty(SYSTEM_PROPERTY_AWS_S3_ENDPOINT, "");
-            }
+        log.info("Updating S3 Connector configuration.");
+
+        // Unlike other public methods of this class, this one can be called several times,
+        // and, in theory, from different threads therefore write access to the fields needs
+        // synchronising.
+        synchronized (configurationLock) {
+            readInConfiguration(moduleConfig);
+
+            validateConfiguration();
+
+            unregisterServiceIfRegistered();
+
+            registerService();
         }
     }
 
     @Override
     protected void doInitialize(final Session session) throws RepositoryException {
-        s3Connector = new S3ConnectorImpl(
-            getAmazonS3(),
-            s3Bucket,
-            new S3ObjectKeyGenerator(this::newRandomString)
-        );
-
-        HippoServiceRegistry.registerService(s3Connector, S3Connector.class);
-    }
-
-    private String newRandomString() {
-        return UUID.randomUUID().toString();
+        // no-op - all work is done in doConfigure
     }
 
     @Override
     protected void doShutdown() {
-        HippoServiceRegistry.unregisterService(s3Connector, S3Connector.class);
+        unregisterServiceIfRegistered();
+        blockUntilTasksCompleteOrTimeout();
     }
 
-    private AmazonS3 getAmazonS3() {
+    private void readInConfiguration(final Node moduleConfig) throws RepositoryException {
+        s3Bucket = getValue(AWS_BUCKET, moduleConfig);
+        s3Region = getValue(AWS_REGION, moduleConfig);
+        s3Endpoint = getValue(AWS_S3_ENDPOINT, moduleConfig);
+
+        downloadsMaxConcurrentCount = getValue(DOWNLOAD_MAX_CONC_COUNT, moduleConfig);
+        downloadsShutdownTimeoutInSecs = getValue(DOWNLOAD_SHUTDOWN_TIMEOUT_IN_SECS, moduleConfig);
+
+        uploadsMaxConcurrentCount = getValue(UPLOAD_MAX_CONC_COUNT, moduleConfig);
+        uploadsShutdownTimeoutInSecs = getValue(UPLOAD_SHUTDOWN_TIMEOUT_IN_SECS, moduleConfig);
+    }
+
+    private void validateConfiguration() {
+
+        try {
+            Validate.notBlank(s3Bucket, "Required argument is missing: " + AWS_BUCKET.getJcrModulePropertyKey());
+            Validate.notBlank(s3Region, "Required argument is missing: " + AWS_REGION.getJcrModulePropertyKey());
+            // s3Endpoint is optional
+
+            Validate.inclusiveBetween(1L, (long)Integer.MAX_VALUE, downloadsMaxConcurrentCount,
+                "Required argument is missing or out of range: " + DOWNLOAD_MAX_CONC_COUNT.getJcrModulePropertyKey());
+            Validate.inclusiveBetween(1L, (long)Integer.MAX_VALUE, downloadsShutdownTimeoutInSecs,
+                "Required argument is missing or out of range: " + DOWNLOAD_SHUTDOWN_TIMEOUT_IN_SECS.getJcrModulePropertyKey());
+            Validate.inclusiveBetween(1L, (long)Integer.MAX_VALUE, uploadsMaxConcurrentCount,
+                "Required argument is missing or out of range: " + DOWNLOAD_MAX_CONC_COUNT.getJcrModulePropertyKey());
+            Validate.inclusiveBetween(1L, (long)Integer.MAX_VALUE, uploadsShutdownTimeoutInSecs,
+                "Required argument is missing or out of range: " + DOWNLOAD_SHUTDOWN_TIMEOUT_IN_SECS.getJcrModulePropertyKey());
+        } catch (Exception validationException) {
+            throw new IllegalArgumentException("Failed to configure " + getClass().getSimpleName(), validationException);
+        }
+    }
+
+    private void registerService() {
+
+        final S3Connector s3Connector = new S3SdkConnector(
+            getAmazonS3Client(),
+            s3Bucket,
+            new S3ObjectKeyGenerator(this::newRandomString)
+        );
+
+        downloadExecutorService = Executors.newWorkStealingPool(downloadsMaxConcurrentCount);
+        uploadExecutorService = Executors.newWorkStealingPool(uploadsMaxConcurrentCount);
+
+        schedulingS3Connector = new BlockingPooledS3Connector(s3Connector, downloadExecutorService, uploadExecutorService);
+
+        HippoServiceRegistry.registerService(schedulingS3Connector, SchedulingS3Connector.class);
+    }
+
+    private void unregisterServiceIfRegistered() {
+
+        if (HippoServiceRegistry.getService(SchedulingS3Connector.class) != null) {
+
+            HippoServiceRegistry.unregisterService(schedulingS3Connector, SchedulingS3Connector.class);
+
+            // null checks protect against failed doInitialize/doConfigure
+            Optional.ofNullable(downloadExecutorService).ifPresent(ExecutorService::shutdown);
+            Optional.ofNullable(uploadExecutorService).ifPresent(ExecutorService::shutdown);
+        }
+    }
+
+    /**
+     * <p>
+     * Blocks the application shutdown until all files finish downloading and uploading or the timeout
+     * occurs, whichever comes first.
+     * </p><p>
+     * Most files are small enough that it's likely they'll finish downloading within given timeout.
+     * There is no way around eventually forcefully terminating overrunning transfers, but it's expected
+     * that such cases would be few and far between.
+     * </p>
+     */
+    private void blockUntilTasksCompleteOrTimeout() {
+
+        waitUntilDoneOrTimeout("download", downloadExecutorService, downloadsShutdownTimeoutInSecs);
+        waitUntilDoneOrTimeout("upload", uploadExecutorService, uploadsShutdownTimeoutInSecs);
+    }
+
+    private static void waitUntilDoneOrTimeout(final String s3Operation,
+                                               final ExecutorService executorService,
+                                               final long shutdownTimeoutInSecs
+    ) {
+        if (executorService != null) {
+            try {
+                if (!executorService.isTerminated()) {
+                    log.info("At least one S3 {} is still in progress; waiting for it to finish.", s3Operation);
+                }
+                if (!executorService.awaitTermination(shutdownTimeoutInSecs, TimeUnit.SECONDS)) {
+                    log.warn(
+                        "At least one in-progress S3 {} has been forcefully terminated due to application shutdown.",
+                        s3Operation
+                    );
+                }
+            } catch (final InterruptedException ie) {
+                throw new RuntimeException("Interrupted when shutting down S3 " + s3Operation + "executor service.",
+                    ie);
+            }
+        }
+    }
+
+    private AmazonS3 getAmazonS3Client() {
         AWSCredentialsProvider provider = new SystemPropertiesCredentialsProvider();
         AmazonS3ClientBuilder s3Builder = AmazonS3ClientBuilder.standard()
             .withCredentials(provider)
@@ -79,12 +189,16 @@ public class S3ConnectorServiceRegistrationModule extends AbstractReconfigurable
         return s3Builder.build();
     }
 
-    private String getConfigValue(final String systemProperty, final String moduleProperty, Node moduleConfig) throws RepositoryException {
-        String value = System.getProperty(systemProperty, "");
+    private <T> T getValue(final S3ConnectorServiceRegistrationModuleParams<T> configProperty, final Node moduleConfig) throws RepositoryException {
+        String value = System.getProperty(configProperty.getSystemPropertyKey(), "");
         if (value.isEmpty()) {
-            value = moduleConfig.getProperty(moduleProperty).getString();
+            value = moduleConfig.getProperty(configProperty.getJcrModulePropertyKey()).getString();
         }
 
-        return value;
+        return configProperty.fromString(value);
+    }
+
+    private String newRandomString() {
+        return UUID.randomUUID().toString();
     }
 }

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/modules/S3ConnectorServiceRegistrationModuleParams.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/modules/S3ConnectorServiceRegistrationModuleParams.java
@@ -1,0 +1,74 @@
+package uk.nhs.digital.externalstorage.modules;
+
+import java.util.function.Function;
+
+public class S3ConnectorServiceRegistrationModuleParams<T> {
+
+    // AWS PARAMS
+
+    static final S3ConnectorServiceRegistrationModuleParams<String> AWS_BUCKET = init(
+        "externalstorage.aws.bucket", "s3Bucket", stringValue -> stringValue, ""
+    );
+    static final S3ConnectorServiceRegistrationModuleParams<String> AWS_REGION = init(
+        "externalstorage.aws.region","s3Region", stringValue -> stringValue, ""
+    );
+    static final S3ConnectorServiceRegistrationModuleParams<String> AWS_S3_ENDPOINT = init(
+        "externalstorage.aws.s3.endpoint", "s3Endpoint", stringValue -> stringValue, ""
+    );
+
+    // DOWNLOAD PARAMS
+
+    static final S3ConnectorServiceRegistrationModuleParams<Integer> DOWNLOAD_MAX_CONC_COUNT = init(
+        "externalstorage.download.maxConcurrent", "maxConcurrentDownloadsCount", Integer::valueOf, 0
+    );
+    static final S3ConnectorServiceRegistrationModuleParams<Long> DOWNLOAD_SHUTDOWN_TIMEOUT_IN_SECS = init(
+        "externalstorage.download.shutdown.timeoutInSecs", "downloadShutdownTimeoutInSecs", Long::valueOf, 0L
+    );
+
+    // UPLOAD PARAMS
+
+    static final S3ConnectorServiceRegistrationModuleParams<Integer> UPLOAD_MAX_CONC_COUNT = init(
+        "externalstorage.upload.maxConcurrent", "maxConcurrentUploadsCount", Integer::valueOf, 0
+    );
+    static final S3ConnectorServiceRegistrationModuleParams<Long> UPLOAD_SHUTDOWN_TIMEOUT_IN_SECS = init(
+        "externalstorage.upload.shutdown.timeoutInSecs", "uploadShutdownTimeoutInSecs", Long::valueOf, 0L
+    );
+
+    private final String systemPropertyKey;
+    private final String jcrModulePropertyKey;
+    private final Function<String, T> fromStringConverter;
+    private final T defaultValue;
+
+    private S3ConnectorServiceRegistrationModuleParams(final String systemPropertyKey,
+                                                       final String jcrModulePropertyKey,
+                                                       final Function<String, T> fromStringConverter,
+                                                       final T defaultValue
+    ) {
+        this.systemPropertyKey = systemPropertyKey;
+        this.jcrModulePropertyKey = jcrModulePropertyKey;
+        this.fromStringConverter = fromStringConverter;
+        this.defaultValue = defaultValue;
+    }
+
+    public String getSystemPropertyKey() {
+        return systemPropertyKey;
+    }
+
+    public String getJcrModulePropertyKey() {
+        return jcrModulePropertyKey;
+    }
+
+    public T fromString(final String stringValue) {
+        return stringValue == null ? defaultValue : fromStringConverter.apply(stringValue);
+    }
+
+    private static <T> S3ConnectorServiceRegistrationModuleParams<T> init(final String systemPropertyKey,
+                                                                          final String jcrModulePropertyKey,
+                                                                          final Function<String, T> fromStringConverter,
+                                                                          final T defaultValue
+    ) {
+        return new S3ConnectorServiceRegistrationModuleParams<>(
+            systemPropertyKey, jcrModulePropertyKey, fromStringConverter, defaultValue
+        );
+    }
+}

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/resource/ImageDisplayPlugin.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/resource/ImageDisplayPlugin.java
@@ -11,6 +11,7 @@ import org.apache.wicket.request.resource.ResourceStreamResource;
 import org.apache.wicket.util.lang.Bytes;
 import org.apache.wicket.util.resource.AbstractResourceStream;
 import org.apache.wicket.util.resource.ResourceStreamNotFoundException;
+import org.apache.wicket.util.time.Duration;
 import org.hippoecm.frontend.model.IModelReference;
 import org.hippoecm.frontend.plugin.IPluginContext;
 import org.hippoecm.frontend.plugin.config.IPluginConfig;
@@ -22,8 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import uk.nhs.digital.externalstorage.ExternalStorageConstants;
-import uk.nhs.digital.externalstorage.s3.S3Connector;
 import uk.nhs.digital.externalstorage.s3.S3File;
+import uk.nhs.digital.externalstorage.s3.SchedulingS3Connector;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -35,9 +36,9 @@ public class ImageDisplayPlugin extends RenderPlugin<Node> {
 
     private static final Logger log = LoggerFactory.getLogger(ImageDisplayPlugin.class);
 
-    public static final String MIME_TYPE_HIPPO_BLANK = "application/vnd.hippo.blank";
+    private static final String MIME_TYPE_HIPPO_BLANK = "application/vnd.hippo.blank";
 
-    ByteSizeFormatter formatter = new ByteSizeFormatter();
+    private ByteSizeFormatter formatter = new ByteSizeFormatter();
 
     public ImageDisplayPlugin(IPluginContext context, IPluginConfig config) {
         super(context, config);
@@ -107,10 +108,23 @@ public class ImageDisplayPlugin extends RenderPlugin<Node> {
     }
 
     private ResourceLink createFileLink(S3NodeMetadata metadata) throws RepositoryException {
-        final S3Connector s3ConnectorService = HippoServiceRegistry.getService(S3Connector.class);
-        S3FileResourceStream s3FileResourceStream = new S3FileResourceStream(metadata, s3ConnectorService);
-        ResourceStreamResource resourceStreamResource = new ResourceStreamResource(s3FileResourceStream);
+        S3FileResourceStream s3FileResourceStream = new S3FileResourceStream(metadata);
+        ResourceStreamResource resourceStreamResource = new ResourceStreamResource(s3FileResourceStream) {
 
+            @Override
+            public void respond(final Attributes attributes) {
+
+                final SchedulingS3Connector s3ConnectorService = HippoServiceRegistry.getService(SchedulingS3Connector.class);
+                s3ConnectorService.scheduleDownload(
+                    metadata.getReference(),
+                    s3File -> {
+                        s3FileResourceStream.setS3File(s3File);
+                        super.respond(attributes);
+                    }
+                );
+            }
+        };
+        resourceStreamResource.setCacheDuration(Duration.NONE);
         resourceStreamResource.setFileName(metadata.getFileName());
         resourceStreamResource.setContentDisposition(ContentDisposition.ATTACHMENT);
 
@@ -129,12 +143,14 @@ public class ImageDisplayPlugin extends RenderPlugin<Node> {
     private static class S3FileResourceStream extends AbstractResourceStream {
 
         private final S3NodeMetadata metadata;
-        private final S3Connector s3ConnectorService;
         private S3File s3File;
 
-        public S3FileResourceStream(S3NodeMetadata metadata, S3Connector s3ConnectorService) {
+        public S3FileResourceStream(S3NodeMetadata metadata) {
             this.metadata = metadata;
-            this.s3ConnectorService = s3ConnectorService;
+        }
+
+        public void setS3File(final S3File s3File) {
+            this.s3File = s3File;
         }
 
         @Override
@@ -150,7 +166,7 @@ public class ImageDisplayPlugin extends RenderPlugin<Node> {
         @Override
         public InputStream getInputStream() throws ResourceStreamNotFoundException {
             // TODO: Error handling (throw a ResourceStreamNotFoundException)
-            s3File = s3ConnectorService.getFile(metadata.getReference());
+
             return s3File.getContent();
         }
 

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/s3/BlockingPooledS3Connector.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/s3/BlockingPooledS3Connector.java
@@ -1,0 +1,144 @@
+package uk.nhs.digital.externalstorage.s3;
+
+import java.io.InputStream;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * <p>
+ * Processes Amazon S3 file upload and download requests, making sure that only a pre-configured
+ * number of them can be actively processed at the same time. Uses separate pools of threads for
+ * upload and download, blocking requests (and the calling threads) until pooled threads become available
+ * to serve them.
+ * </p><p>
+ * This class is a proxy for {@linkplain S3SdkConnector}. Note that only upload and download requests are
+ * handled as scheduled tasks as they are relatively  long running and consume more resources. All other
+ * requests are considered 'cheap' and short running and typically requiring an immediate response, therefore calls to
+ * methods serving these are passed on to the {@linkplain S3SdkConnector} immediately and without scheduling.
+ * </p><p>
+ * Since a non-blocking IO is <em>not</em> being used here, the traditional model of
+ * one-HTTP-serving-thread-per-user-request applies. This means that this mechanism <em>does not</em> help reducing the
+ * number of HTTP request serving threads being created (managed by application container, such as Tomcat) and waiting
+ * dormant until S3-serving-thread (managed by the application) becomes available. What it <em>does</em> help with is
+ * reducing the CPU load and memory usage coming from active processing of upload and download streams, which is the
+ * most resource hungry phase of serving the upload and download requests. For example, upload process reads the
+ * incoming file into memory in 5MB chunks, sending each chunk to S3 before reading another. It's easy to see that, if
+ * there was no limit of on the number of actively served requests the risk of using up all available memory is high in
+ * cases where many large file upload requests are initiated in a short space of time.
+ * </p>
+ */
+public class BlockingPooledS3Connector implements SchedulingS3Connector {
+
+    private final S3Connector s3Connector;
+    private final ExecutorService downloadExecutorService;
+    private final ExecutorService uploadExecutorService;
+
+    public BlockingPooledS3Connector(final S3Connector s3Connector,
+                                     final ExecutorService downloadExecutorService,
+                                     final ExecutorService uploadExecutorService
+    ) {
+        this.s3Connector = s3Connector;
+        this.downloadExecutorService = downloadExecutorService;
+        this.uploadExecutorService = uploadExecutorService;
+    }
+
+    /**
+     * Instantly triggers permissions on the given S3 file to be set to 'public' by delegating the call directly to
+     * {@linkplain S3SdkConnector#publishResource} method.
+     */
+    @Override
+    public boolean publishResource(final String objectPath) {
+        return s3Connector.publishResource(objectPath);
+    }
+
+    /**
+     * Instantly triggers permissions on the given S3 file to be set to 'restricted' by delegating the call directly to
+     * {@linkplain S3SdkConnector#unpublishResource} method.
+     */
+    @Override
+    public boolean unpublishResource(final String objectPath) {
+        return s3Connector.unpublishResource(objectPath);
+    }
+
+    /**
+     * <p>
+     * Schedules an upload to S3 as a task to be executed as soon as one of the pooled threads becomes available.
+     * Blocks the calling thread until the upload is complete.
+     * </p><p>
+     * </p>
+     *
+     * @param inputStreamSupplier Provider of the input stream of the file being uploaded. Wrapping the stream in
+     *                            a supplier allows to access the stream as late as possible, that is when the task
+     *                            is actually being executed rather than at the point of it being scheduled.
+     *                            If the method of obtaining the stream declares a checked exception, a conveninence
+     *                            method {@linkplain SchedulingS3Connector#wrapCheckedException} can be used to avoid
+     *                            having to deal with try-catch boilerplate code.
+     * @param fileName            Name of the uploaded file.
+     * @param mimeType            Type of the uploaded file.
+     */
+    @Override
+    public S3ObjectMetadata scheduleUpload(final Supplier<InputStream> inputStreamSupplier,
+                                           final String fileName,
+                                           final String mimeType
+    ) {
+        return schedule(uploadExecutorService, () -> {
+            final S3ObjectMetadata uploadedS3Object = s3Connector.uploadFile(
+                inputStreamSupplier.get(), fileName, mimeType
+            );
+
+            return uploadedS3Object;
+        });
+    }
+
+    /**
+     * <p>
+     * Schedules a download from S3 as a task to be executed as soon as one of the pooled threads becomes available,
+     * leaving the processing of the download input stream to the callback given as an argument. Blocks the calling
+     * thread until the callback finishes processing the download.
+     * <p/><p>
+     * The callback receives a reference to {@linkplain S3File} which exposes download input stream via
+     * {@linkplain S3File#getContent()}.
+     * <p/><p>
+     * <strong>Important</strong>:
+     * <ul>
+     * <li>Make sure that the processing of that stream takes place within the callback, to ensure that it's being
+     * processed by the pooled thread; failing to do it this way (say, by returning the stream to outside of the
+     * callback and processing it there) defeats the limitation of only a pre-defined number of requests being
+     * actively processed concurrently, thus risking starving the whole application of resources.</li>
+     * <li>Close the input stream as soon as you're done with it, preferably within the callback.</li>
+     * </ul>
+     * </p>
+     *
+     * @param s3Reference      Path to the file in S3.
+     * @param downloadConsumer Callback to execute once the download actually gets initiated
+     *                         and the download input stream becomes available.
+     */
+    @Override
+    public void scheduleDownload(final String s3Reference, final Consumer<S3File> downloadConsumer) {
+
+        schedule(downloadExecutorService, () -> {
+            final S3File s3File = s3Connector.downloadFile(s3Reference);
+            downloadConsumer.accept(s3File);
+        });
+    }
+
+    private void schedule(final ExecutorService executorService, final Runnable scheduledTask) {
+        try {
+            executorService.submit(scheduledTask).get();
+        } catch (final Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private <V> V schedule(final ExecutorService executorService,
+                           final Callable<V> scheduledTask
+    ) {
+        try {
+            return executorService.submit(scheduledTask).get();
+        } catch (final Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/s3/S3ObjectKeyGenerator.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/s3/S3ObjectKeyGenerator.java
@@ -2,15 +2,16 @@ package uk.nhs.digital.externalstorage.s3;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.function.Supplier;
 import javax.xml.bind.DatatypeConverter;
 
 public class S3ObjectKeyGenerator {
 
     private final MessageDigest messageDigest;
 
-    private final RandomSeedProvider randomSeedProvider;
+    private final Supplier<String> randomSeedProvider;
 
-    public S3ObjectKeyGenerator(final RandomSeedProvider randomSeedProvider) {
+    public S3ObjectKeyGenerator(final Supplier<String> randomSeedProvider) {
         this.randomSeedProvider = randomSeedProvider;
         messageDigest = getMd5MessageDigest();
     }
@@ -18,7 +19,7 @@ public class S3ObjectKeyGenerator {
 
     public String generateObjectKey(String fileName) {
 
-        final String fileNameSalt = randomSeedProvider.getRandomSeed();
+        final String fileNameSalt = randomSeedProvider.get();
 
         messageDigest.update((fileName + fileNameSalt).getBytes());
 
@@ -33,11 +34,7 @@ public class S3ObjectKeyGenerator {
         try {
             return MessageDigest.getInstance("MD5");
         } catch (NoSuchAlgorithmException ex) {
-            throw new RuntimeException("Error initialising MD5 MessageDigest in " + S3ConnectorImpl.class.getName(), ex);
+            throw new RuntimeException("Error initialising MD5 MessageDigest in " + S3SdkConnector.class.getName(), ex);
         }
-    }
-
-    public interface RandomSeedProvider {
-        String getRandomSeed();
     }
 }

--- a/cms/src/test/java/uk/nhs/digital/externalstorage/s3/BlockingPooledS3ConnectorTest.java
+++ b/cms/src/test/java/uk/nhs/digital/externalstorage/s3/BlockingPooledS3ConnectorTest.java
@@ -1,0 +1,135 @@
+package uk.nhs.digital.externalstorage.s3;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+
+import java.io.InputStream;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class BlockingPooledS3ConnectorTest {
+
+    @Mock private S3SdkConnector s3SdkConnector;
+    @Mock private ExecutorService uploadExecutorService;
+    @Mock private ExecutorService downloadExecutorService;
+    @Mock private Future future;
+
+    @Captor private ArgumentCaptor<Callable<S3ObjectMetadata>> scheduledUploadTaskArgumentCaptor;
+    @Captor private ArgumentCaptor<Runnable> scheduledDownloadTaskArgumentCaptor;
+
+
+    private BlockingPooledS3Connector s3proxy;
+    private String expectedObjectPath;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+
+        expectedObjectPath = newRandomString();
+
+        s3proxy = new BlockingPooledS3Connector(
+            s3SdkConnector,
+            downloadExecutorService,
+            uploadExecutorService
+        );
+    }
+
+    @Test
+    public void delegatesPublishedResourceDirectlyToStandardConnector() throws Exception {
+
+        // given
+        final boolean expectedActionResult = randomBoolean();
+        given(s3SdkConnector.publishResource(expectedObjectPath)).willReturn(expectedActionResult);
+
+        // when
+        final boolean actualActionResult = s3proxy.publishResource(expectedObjectPath);
+
+        // then
+        then(s3SdkConnector).should().publishResource(expectedObjectPath);
+        assertThat("Reported result is as received from the delegate.", actualActionResult, is(expectedActionResult));
+    }
+
+    @Test
+    public void delegatesUnPublishedResourceDirectlyToStandardConnector() throws Exception {
+
+        // given
+        final boolean expectedActionResult = randomBoolean();
+        given(s3SdkConnector.unpublishResource(expectedObjectPath)).willReturn(expectedActionResult);
+
+        // when
+        final boolean actualActionResult = s3proxy.unpublishResource(expectedObjectPath);
+
+        // then
+        then(s3SdkConnector).should().unpublishResource(expectedObjectPath);
+        assertThat("Reported result is as received from the delegate.", actualActionResult, is(expectedActionResult));
+    }
+
+    @Test
+    public void schedulesUploadFileRequest() throws Exception {
+
+        // given
+        given(uploadExecutorService.submit(scheduledUploadTaskArgumentCaptor.capture())).willReturn(future);
+
+        final S3ObjectMetadata expectedS3ObjectMetadata = mock(S3ObjectMetadata.class);
+        given(future.get()).willReturn(expectedS3ObjectMetadata);
+
+        final InputStream expectedUploadInputStream = mock(InputStream.class);
+        final String expectedFileName = newRandomString();
+        final String expectedMimeType = newRandomString();
+
+        // when
+        final S3ObjectMetadata actualS3ObjectMetadata = s3proxy.scheduleUpload(
+            () -> expectedUploadInputStream,
+            expectedFileName,
+            expectedMimeType
+        );
+
+        // then
+        then(future).should().get(); // ensures execution was delegated to provided ExecutorService
+        scheduledUploadTaskArgumentCaptor.getValue().call(); // ensures that the scheduled Runnable actually gets called
+
+        then(s3SdkConnector).should().uploadFile(expectedUploadInputStream, expectedFileName, expectedMimeType);
+        assertThat("Returns uploaded object metadata produced by the connector.",
+            actualS3ObjectMetadata, is(expectedS3ObjectMetadata)
+        );
+    }
+
+    @Test
+    public void schedulesDownloadFileRequest() throws Exception {
+
+        // given
+        given(downloadExecutorService.submit(scheduledDownloadTaskArgumentCaptor.capture())).willReturn(future);
+        final AtomicBoolean isTaskExecuted = new AtomicBoolean(false);
+
+        // when
+        s3proxy.scheduleDownload(expectedObjectPath, s3File -> isTaskExecuted.set(true));
+
+        // then
+        then(future).should().get(); // ensures execution was delegated to provided ExecutorService
+        scheduledDownloadTaskArgumentCaptor.getValue().run(); // ensures that the scheduled Runnable actually gets called
+
+        then(s3SdkConnector).should().downloadFile(expectedObjectPath);
+        assertThat("Download consumer task has been executed.", isTaskExecuted.get(), is(true));
+    }
+
+    private static String newRandomString() {
+        return UUID.randomUUID().toString();
+    }
+
+    private static boolean randomBoolean() {
+        return Math.round(Math.random() * 10) % 2 == 0;
+    }
+}

--- a/cms/src/test/java/uk/nhs/digital/externalstorage/s3/S3ObjectKeyGeneratorTest.java
+++ b/cms/src/test/java/uk/nhs/digital/externalstorage/s3/S3ObjectKeyGeneratorTest.java
@@ -18,7 +18,7 @@ public class S3ObjectKeyGeneratorTest {
         // given
         final String fileName = newRandomString();
 
-        final S3ObjectKeyGenerator s3ObjectKeyGenerator = new S3ObjectKeyGenerator(() -> newRandomString());
+        final S3ObjectKeyGenerator s3ObjectKeyGenerator = new S3ObjectKeyGenerator(this::newRandomString);
 
         // when
         final String actualObjectKey = s3ObjectKeyGenerator.generateObjectKey(fileName);
@@ -33,7 +33,7 @@ public class S3ObjectKeyGeneratorTest {
         // given
         final String fileName = newRandomString();
 
-        final S3ObjectKeyGenerator s3ObjectKeyGenerator = new S3ObjectKeyGenerator(() -> newRandomString());
+        final S3ObjectKeyGenerator s3ObjectKeyGenerator = new S3ObjectKeyGenerator(this::newRandomString);
 
         // when
         final String actualObjectKey = s3ObjectKeyGenerator.generateObjectKey(fileName);
@@ -66,8 +66,8 @@ public class S3ObjectKeyGeneratorTest {
         // given
         final String fileName = newRandomString();
 
-        final S3ObjectKeyGenerator s3ObjectKeyGeneratorA = new S3ObjectKeyGenerator(() -> newRandomString());
-        final S3ObjectKeyGenerator s3ObjectKeyGeneratorB = new S3ObjectKeyGenerator(() -> newRandomString());
+        final S3ObjectKeyGenerator s3ObjectKeyGeneratorA = new S3ObjectKeyGenerator(this::newRandomString);
+        final S3ObjectKeyGenerator s3ObjectKeyGeneratorB = new S3ObjectKeyGenerator(this::newRandomString);
 
         // when
         final String actualObjectKeyA = s3ObjectKeyGeneratorA.generateObjectKey(fileName);

--- a/cms/src/test/java/uk/nhs/digital/externalstorage/s3/S3SdkConnectorTest.java
+++ b/cms/src/test/java/uk/nhs/digital/externalstorage/s3/S3SdkConnectorTest.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 
-public class S3ConnectorImplTest {
+public class S3SdkConnectorTest {
 
     private static Random random = new Random();
     private static final int BUFFER_SIZE = 5 * 1024 * 1024;
@@ -37,7 +37,7 @@ public class S3ConnectorImplTest {
     private String objectKey;
     private String fileName;
 
-    private S3ConnectorImpl s3Connector;
+    private S3SdkConnector s3Connector;
 
     @Before
     public void setUp() throws Exception {
@@ -47,21 +47,7 @@ public class S3ConnectorImplTest {
         fileName = newRandomString();
         objectKey = newRandomString() + "/" + fileName;
 
-        s3Connector = new S3ConnectorImpl(s3, bucketName, s3ObjectKeyGenerator);
-    }
-
-    @Test
-    public void preservesS3BucketName() throws Exception {
-
-        // given
-        // setUp
-
-        // when
-        final String actualBucketName = s3Connector.getBucketName();
-
-        // then
-        assertThat("S3 bucket name is as provided to the constructor.", actualBucketName, is(bucketName));
-
+        s3Connector = new S3SdkConnector(s3, bucketName, s3ObjectKeyGenerator);
     }
 
     @Test
@@ -248,7 +234,7 @@ public class S3ConnectorImplTest {
         given(s3.getObject(bucketName, objectKey)).willReturn(s3ResponseObject);
 
         // when
-        final S3File actualS3File = s3Connector.getFile(objectKey);
+        final S3File actualS3File = s3Connector.downloadFile(objectKey);
 
         // then
         assertThat("Returned content stream is the one returned by S3.", actualS3File.getContent(),

--- a/repository-data/application/src/main/resources/hcm-config/configuration/modules/s3ConnectorRegistrationModule.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/modules/s3ConnectorRegistrationModule.yaml
@@ -3,9 +3,14 @@ definitions:
   config:
     /hippo:configuration/hippo:modules/s3ConnectorRegistrationModule:
       /hippo:moduleconfig:
+        downloadShutdownTimeoutInSecs: 30
         jcr:primaryType: hipposys:moduleconfig
+        maxConcurrentDownloadsCount: 50
+        maxConcurrentUploadsCount: 10
         s3Bucket: files.digital.nhs.uk
+        s3Endpoint: ''
         s3Region: eu-west-2
+        uploadShutdownTimeoutInSecs: 30
       hipposys:className: uk.nhs.digital.externalstorage.modules.S3ConnectorServiceRegistrationModule
       hipposys:cmsonly: true
       jcr:primaryType: hipposys:module

--- a/s3connector/src/main/java/uk/nhs/digital/externalstorage/s3/S3Connector.java
+++ b/s3connector/src/main/java/uk/nhs/digital/externalstorage/s3/S3Connector.java
@@ -1,13 +1,8 @@
 package uk.nhs.digital.externalstorage.s3;
 
-import org.onehippo.cms7.services.SingletonService;
-
 import java.io.InputStream;
 
-@SingletonService
 public interface S3Connector {
-
-    String getBucketName();
 
     boolean publishResource(String objectPath);
 
@@ -30,5 +25,5 @@ public interface S3Connector {
      * @param objectPath Path, uniquely idendifying the file in S3.
      * @return Proxy to S3 file.
      */
-    S3File getFile(String objectPath);
+    S3File downloadFile(String objectPath);
 }

--- a/s3connector/src/main/java/uk/nhs/digital/externalstorage/s3/SchedulingS3Connector.java
+++ b/s3connector/src/main/java/uk/nhs/digital/externalstorage/s3/SchedulingS3Connector.java
@@ -1,0 +1,47 @@
+package uk.nhs.digital.externalstorage.s3;
+
+import org.onehippo.cms7.services.SingletonService;
+
+import java.io.InputStream;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * See the implementing {@linkplain uk.nhs.digital.externalstorage.s3.BlockingPooledS3Connector} class for details.
+ */
+@SingletonService
+public interface SchedulingS3Connector {
+
+    boolean publishResource(String objectPath);
+
+    boolean unpublishResource(String objectPath);
+
+    void scheduleDownload(String s3Reference, Consumer<S3File> downloadConsumer);
+
+    S3ObjectMetadata scheduleUpload(Supplier<InputStream> inputStreamSupplier,
+                                    String fileName,
+                                    String mimeType);
+
+    /**
+     * Takes a supplier throwing checked exception and wraps it in a try-catch clause, rethrowing the original
+     * exception wrapped in {@linkplain RuntimeException}, thus preventing obscuring the calling code with a boilerplate
+     * try-catch-rethrow code at the point of calling.
+     *
+     * @param checkedExceptionThrowingSupplier The supplier to wrap.
+     * @param <T>                              Type of the value returned by the supplier.
+     * @return Original supplier wrapped in a rethrowing code.
+     */
+    static <T> Supplier<T> wrapCheckedException(CheckedExceptionThrowingSupplier<T> checkedExceptionThrowingSupplier) {
+        return () -> {
+            try {
+                return checkedExceptionThrowingSupplier.get();
+            } catch (final Exception ex) {
+                throw new RuntimeException(ex);
+            }
+        };
+    }
+
+    interface CheckedExceptionThrowingSupplier<T> {
+        T get() throws Exception;
+    }
+}

--- a/site/src/main/java/uk/nhs/digital/common/valve/S3ConnectorValve.java
+++ b/site/src/main/java/uk/nhs/digital/common/valve/S3ConnectorValve.java
@@ -4,115 +4,56 @@ import org.apache.commons.io.IOUtils;
 import org.hippoecm.hst.container.valves.AbstractOrderableValve;
 import org.hippoecm.hst.core.container.ContainerException;
 import org.hippoecm.hst.core.container.ValveContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import uk.nhs.digital.externalstorage.s3.S3Connector;
-import uk.nhs.digital.externalstorage.s3.S3File;
+import uk.nhs.digital.externalstorage.s3.SchedulingS3Connector;
 
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
 import javax.servlet.http.HttpServletResponse;
 
 public class S3ConnectorValve extends AbstractOrderableValve {
 
-    private static final Logger log = LoggerFactory.getLogger(uk.nhs.digital.common.valve.S3ConnectorValve.class);
+    private final SchedulingS3Connector s3connector;
 
-    private static final int DOWNLOAD_SHUTDOWN_TIMEOUT = 30;
-
-    private final ExecutorService executorService;
-    private final S3Connector s3Connector;
-
-    public S3ConnectorValve(final ExecutorService executorService,
-                            final S3Connector s3Connector
-    ) {
-        this.executorService = executorService;
-        this.s3Connector = s3Connector;
+    public S3ConnectorValve(final SchedulingS3Connector s3connector) {
+        this.s3connector = s3connector;
     }
 
     public void invoke(final ValveContext context) throws ContainerException {
 
-        try {
-            schedule(() -> download(context));
-        } catch (ContainerException ex) {
-            log.error("Download failure.", ex);
-            throw ex;
-        }
-    }
+        final String s3Reference = context.getServletRequest().getParameter("s3Reference");
 
-    private void schedule(final Runnable downloadTask) throws ContainerException {
+        s3connector.scheduleDownload(s3Reference, s3File -> {
 
-        try {
-            executorService.submit(downloadTask).get();
+            OutputStream responseOutputStream = null;
+            InputStream s3InputStream = null;
+            String fileName = null;
 
-        } catch (final Exception ex) {
-            throw new ContainerException("Failed to download from S3.", ex);
-        }
-    }
+            try {
+                final HttpServletResponse response = context.getServletResponse();
 
-    private void download(final ValveContext context) {
+                if (context.getRequestContext().isCmsRequest()) {
 
-        InputStream s3InputStream = null;
-        OutputStream responseOutputStream = null;
+                    fileName = context.getServletRequest().getParameter("fileName");
 
-        String s3Reference = null;
-        String fileName = null;
+                    response.setContentType("application/octet-stream");
+                    response.setHeader("Content-Disposition", "attachment; filename=" + fileName);
+                    response.setHeader("Content-Length", String.valueOf(s3File.getLength()));
+                    response.setStatus(HttpServletResponse.SC_ACCEPTED);
 
-        try {
-            final HttpServletResponse response = context.getServletResponse();
+                    s3InputStream = s3File.getContent();
 
-            if (context.getRequestContext().isCmsRequest()) {
+                    responseOutputStream = response.getOutputStream();
+                    IOUtils.copyLarge(s3InputStream, responseOutputStream);
+                } else {
+                    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+                }
+            } catch (final Exception ex) {
+                throw new RuntimeException("Failed to download content from S3: " + fileName + ": " + s3Reference, ex);
 
-                s3Reference = context.getServletRequest().getParameter("s3Reference");
-                fileName = context.getServletRequest().getParameter("fileName");
-
-                final S3File s3File = s3Connector.getFile(s3Reference);
-
-                response.setContentType("application/octet-stream");
-                response.setHeader("Content-Disposition", "attachment; filename=" + fileName);
-                response.setHeader("Content-Length", String.valueOf(s3File.getLength()));
-                response.setStatus(HttpServletResponse.SC_ACCEPTED);
-
-                s3InputStream = s3File.getContent();
-
-                responseOutputStream = response.getOutputStream();
-                IOUtils.copyLarge(s3InputStream, responseOutputStream);
-            } else {
-                response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+            } finally {
+                IOUtils.closeQuietly(responseOutputStream);
+                IOUtils.closeQuietly(s3InputStream);
             }
-        } catch (final Exception ex) {
-            throw new RuntimeException("Failed to download content from S3: " + fileName + ": " + s3Reference, ex);
-
-        } finally {
-            IOUtils.closeQuietly(responseOutputStream);
-            IOUtils.closeQuietly(s3InputStream);
-        }
-    }
-
-    @Override
-    public void destroy() {
-        try {
-            executorService.shutdown();
-
-            if (!executorService.isTerminated()) {
-                log.info("At least one S3 download is still in progress; waiting for it to finish.");
-            }
-
-            // We're blocking the application shutdown until all files finish downloading or the timeout occur,
-            // whichever comes first.
-            //
-            // Most files are small enough that it's likely they'll finish downloading within 30 seconds.
-            // Terminating a longer running download is not a problem, the user will simply re-download the content
-            // after logging back in but at least we try to gracefully handle most common cases.
-            //
-            final boolean abortedDownloadsInProgress = !executorService.awaitTermination(DOWNLOAD_SHUTDOWN_TIMEOUT, TimeUnit.SECONDS);
-            if (abortedDownloadsInProgress) {
-                log.warn("At least one in-progress S3 download has been forcefully terminated due to application shutdown.");
-            }
-
-        } catch (final InterruptedException ie) {
-            throw new RuntimeException("Interrupted when shutting down S3 download executor service.", ie);
-        }
+        });
     }
 }

--- a/site/src/main/resources/META-INF/hst-assembly/overrides/s3ConnectorPipeline.xml
+++ b/site/src/main/resources/META-INF/hst-assembly/overrides/s3ConnectorPipeline.xml
@@ -6,20 +6,12 @@
 
     <import resource="classpath:/org/hippoecm/hst/site/container/SpringComponentManager-pipelines.xml"/>
 
-    <bean name="MAX_CONCURRENT_PREVIEW_DOWNLOADS" class="java.lang.Integer">
-        <constructor-arg value="2"/>
-    </bean>
-
     <bean id="s3ConnectorValve" class="uk.nhs.digital.common.valve.S3ConnectorValve"
           init-method="initialize" destroy-method="destroy">
-        <constructor-arg name="executorService">
-            <bean class="java.util.concurrent.Executors" factory-method="newWorkStealingPool">
-                <constructor-arg type="int" ref="MAX_CONCURRENT_PREVIEW_DOWNLOADS"/>
-            </bean>
-        </constructor-arg>
-        <constructor-arg name="s3Connector">
+
+        <constructor-arg type="uk.nhs.digital.externalstorage.s3.SchedulingS3Connector">
             <bean class="org.onehippo.cms7.services.HippoServiceRegistry" factory-method="getService">
-                <constructor-arg type="java.lang.Class" value="uk.nhs.digital.externalstorage.s3.S3Connector"/>
+                <constructor-arg type="java.lang.Class" value="uk.nhs.digital.externalstorage.s3.SchedulingS3Connector"/>
             </bean>
         </constructor-arg>
         <property name="valveName" value="S3ConnectorValve"/>


### PR DESCRIPTION
It is now possible to configure limit of how many concurrent uploads and
downloads to and from S3 can be served concurrently.

Both can be configured via a Console/JCR properties, where the number of
uploads is being controlled separately from tghe number of downloads.
Changes to configuration in JCR are picked up immediately as they are
committed.

The same values can also be set via JVM system properties/command line;
these take precedence over values configured in JCR which may come handy
in development/testing scenarios.

See S3ConnectorServiceRegistrationModuleParams for applicable settings'
keys.