### PR TITLE
RPS-450 cap S3 concurrent uploads

### DIFF
--- a/site/src/main/java/uk/nhs/digital/common/ServiceProvider.java
+++ b/site/src/main/java/uk/nhs/digital/common/ServiceProvider.java
@@ -1,0 +1,14 @@
+package uk.nhs.digital.common;
+
+import org.onehippo.cms7.services.HippoServiceRegistry;
+
+/**
+ * Delegates calls to {@linkplain HippoServiceRegistry} making it easier to
+ * test classes that interact with the static methods of the registry class.
+ */
+public class ServiceProvider {
+
+    public  <T> T getService(final Class<T> serviceClass) {
+        return HippoServiceRegistry.getService(serviceClass);
+    }
+}

--- a/site/src/main/resources/META-INF/hst-assembly/overrides/s3ConnectorPipeline.xml
+++ b/site/src/main/resources/META-INF/hst-assembly/overrides/s3ConnectorPipeline.xml
@@ -6,13 +6,11 @@
 
     <import resource="classpath:/org/hippoecm/hst/site/container/SpringComponentManager-pipelines.xml"/>
 
-    <bean id="s3ConnectorValve" class="uk.nhs.digital.common.valve.S3ConnectorValve"
+    <bean id="s3ConnectorValve" class="uk.nhs.digital.externalstorage.s3.valves.S3ConnectorValve"
           init-method="initialize" destroy-method="destroy">
 
-        <constructor-arg type="uk.nhs.digital.externalstorage.s3.SchedulingS3Connector">
-            <bean class="org.onehippo.cms7.services.HippoServiceRegistry" factory-method="getService">
-                <constructor-arg type="java.lang.Class" value="uk.nhs.digital.externalstorage.s3.SchedulingS3Connector"/>
-            </bean>
+        <constructor-arg type="uk.nhs.digital.common.ServiceProvider">
+            <bean class="uk.nhs.digital.common.ServiceProvider"/>
         </constructor-arg>
         <property name="valveName" value="S3ConnectorValve"/>
     </bean>

--- a/site/src/test/java/uk/nhs/digital/externalstorage/s3/valves/S3ConnectorValveTest.java
+++ b/site/src/test/java/uk/nhs/digital/externalstorage/s3/valves/S3ConnectorValveTest.java
@@ -1,4 +1,4 @@
-package uk.nhs.digital.common.valve;
+package uk.nhs.digital.externalstorage.s3.valves;
 
 import org.hippoecm.hst.core.container.ValveContext;
 import org.hippoecm.hst.core.request.HstRequestContext;
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import uk.nhs.digital.common.ServiceProvider;
 import uk.nhs.digital.externalstorage.s3.SchedulingS3Connector;
 import uk.nhs.digital.externalstorage.s3.S3File;
 
@@ -37,6 +38,7 @@ import static uk.nhs.digital.test.util.RandomHelper.newRandomString;
 
 public class S3ConnectorValveTest {
 
+    @Mock private ServiceProvider serviceProvider;
     @Mock private SchedulingS3Connector s3Connector;
     @Mock private HttpServletRequest request;
     @Mock private HttpServletResponse response;
@@ -83,7 +85,9 @@ public class S3ConnectorValveTest {
         given(s3File.getContent()).willReturn(s3InputStream);
         given(s3File.getLength()).willReturn(expectedFileLength);
 
-        s3ConnectorValve = new S3ConnectorValve(s3Connector);
+        given(serviceProvider.getService(SchedulingS3Connector.class)).willReturn(s3Connector);
+
+        s3ConnectorValve = new S3ConnectorValve(serviceProvider);
     }
 
     @Test


### PR DESCRIPTION
Configuration of SchedulingS3Connector service can be changed via
Console on the fly, without restarting the server. This stops the thread
pools from accepting new tasks, un-registers the previous instance of
the service, initialises new thread pools and registers new instance
of the service.

S3ConnectorValve used to only retrieve an instance of this service once,
upon system start and would not use the latest instance of the service,
which would lead to the stopped thread pools reject download requests,
breaking the Channel Manager Preview in the process.

This fix eliminates this problem by making the valve retrieve the latest
instance of the service for each download request rather than get it
once and store as a field for the lifetime of the valve object.