### PR TITLE
[RPS-456] Update Geographic Coverage as par DW-178

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/GeographicCoverage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/GeographicCoverage.java
@@ -2,11 +2,9 @@ package uk.nhs.digital.ps.test.acceptance.models;
 
 public enum GeographicCoverage {
     ENGLAND("England"),
-    GREAT_BRITAIN("Great Britain"),
-    INTERNATIONAL("International"),
     NORTHERN_IRELAND("Northern Ireland"),
+    REPUBLIC_OF_IRELAND("Republic of Ireland"),
     SCOTLAND("Scotland"),
-    UK("UK"),
     WALES("Wales");
 
     private final String displayValue;

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ContentPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ContentPage.java
@@ -73,12 +73,7 @@ public class ContentPage extends AbstractCmsPage {
 
         GeographicCoverage geographicCoverage = publication.getGeographicCoverage();
         if (geographicCoverage != null) {
-            getGeographicCoverageSection().addGeographicCoverageField();
-            new Select(helper.findElement(
-                By.xpath(XpathSelectors.EDITOR_BODY + "//span[text()='Geographic Coverage']/../following-sibling::div//select[@class='dropdown-plugin']")
-            )).selectByVisibleText(
-                geographicCoverage.getDisplayValue()
-            );
+            getGeographicCoverageSection().selectCheckbox(publication.getGeographicCoverage().getDisplayValue());
         }
 
         InformationType informationType = publication.getInformationType();

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/widgets/GeographicCoverageCmsWidget.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/widgets/GeographicCoverageCmsWidget.java
@@ -3,9 +3,6 @@ package uk.nhs.digital.ps.test.acceptance.pages.widgets;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.support.ui.Select;
-import uk.nhs.digital.ps.test.acceptance.models.GeographicCoverage;
 import uk.nhs.digital.ps.test.acceptance.pages.PageHelper;
 import uk.nhs.digital.ps.test.acceptance.pages.XpathSelectors;
 
@@ -19,9 +16,9 @@ public class GeographicCoverageCmsWidget {
         + "//span[text()='Geographic Coverage']/ancestor::div[contains(@class, 'hippo-editor-field')]";
 
     /**
-     * Targets drop-down's {@code <select>} element.
+     * Targets drop-down's {@code <span class="multiselect-checkboxes">} element.
      */
-    private static final String DROPDOWN_XPATH = ROOT_ELEMENT_XPATH + "//select[contains(@class, 'dropdown-plugin')]";
+    private static final String CHECKBOXES_XPATH = ROOT_ELEMENT_XPATH + "//span[contains(@class, 'multiselect-checkboxes')]";
 
     private final PageHelper helper;
     private final WebDriver webDriver;
@@ -31,29 +28,24 @@ public class GeographicCoverageCmsWidget {
         this.webDriver = webDriver;
     }
 
-    public void addGeographicCoverageField() {
-        // get element
-        WebElement addButton = helper.findElement(By.xpath(ROOT_ELEMENT_XPATH + "//a[contains(@class, 'add-link')]"));
+    public void selectCheckbox(String value) {
+        WebElement checkbox = findCheckbox(value);
 
-        // scroll to element, to prevent errors like "Other element would receive the click"
-        new Actions(webDriver)
-            .moveToElement(addButton)
-            .moveByOffset(0, 200)
-            .perform();
-
-        // click
-        addButton.click();
-
-        // wait after click for the dropdown to appear
-        helper.findElement(By.xpath(DROPDOWN_XPATH));
+        if (!checkbox.isSelected()) {
+            checkbox.click();
+        }
     }
 
-    public void populateGeographicCoverageField(final GeographicCoverage geographicCoverage) {
-        findDropDown().selectByVisibleText(geographicCoverage.getDisplayValue());
+    public void deselectCheckbox(String value) {
+        WebElement checkbox = findCheckbox(value);
+
+        if (checkbox.isSelected()) {
+            checkbox.click();
+        }
     }
 
-    private Select findDropDown() {
-        return new Select(helper.findElement(By.xpath(DROPDOWN_XPATH)));
+    private WebElement findCheckbox(String value) {
+        return helper.findElement(By.xpath(CHECKBOXES_XPATH + "//input[@value = '" + value + "']"));
     }
 
     private WebElement findRootElement() {

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/cms/ps/CmsSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/cms/ps/CmsSteps.java
@@ -232,12 +232,6 @@ public class CmsSteps extends AbstractSpringSteps {
         contentPage.getGranularitySection().addGranularityField();
     }
 
-    // Scenario: Blank Geographic Coverage field rejection =====================================================================
-    @When("^I add an empty Geographic Coverage field$")
-    public void whenIAddAnEmptyGeographicCoverageField() throws Throwable {
-        contentPage.getGeographicCoverageSection().addGeographicCoverageField();
-    }
-
     // Scenario: Blank related link rejection =========================================================================
     @When("^I add an empty related link field$")
     public void whenIAddAnEmptyRelatedLinkField() throws Throwable {

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
@@ -155,6 +155,17 @@ public class TestContentUrls {
 
         add("Data and information",
             "/data-and-information");
+
+        // Geographic coverage publications
+        add("Geographic Coverage - Great Britain",
+            "/data-and-information/publications/acceptance-tests/geographiccoverage-test/great-britain");
+        add("Geographic Coverage - United Kingdom",
+            "/data-and-information/publications/acceptance-tests/geographiccoverage-test/united-kingdom");
+        add("Geographic Coverage - British Isles",
+            "/data-and-information/publications/acceptance-tests/geographiccoverage-test/british-isles");
+        add("Geographic Coverage - Other combination",
+            "/data-and-information/publications/acceptance-tests/geographiccoverage-test/other-combination");
+
     }
 
     private String getAttachmentUrl(String siteUrl, String attachmentTag) {

--- a/acceptance-tests/src/test/resources/features/cms/createAndPublish.feature
+++ b/acceptance-tests/src/test/resources/features/cms/createAndPublish.feature
@@ -30,6 +30,7 @@ Feature: As am author I need to create a new publication
             | Data set            |
             | Publication         |
             | Legacy Publication  |
+            | Publication Page    |
 
     Scenario: Restricted document types in new publication system folders
         Given I am on the content page
@@ -41,6 +42,7 @@ Feature: As am author I need to create a new publication
             | Data set            |
             | Publication         |
             | Legacy Publication  |
+            | Publication Page    |
 
     Scenario: Restricted document types in ci hub folder
         Given I am logged in as admin on the content page

--- a/acceptance-tests/src/test/resources/features/cms/datasetValidation.feature
+++ b/acceptance-tests/src/test/resources/features/cms/datasetValidation.feature
@@ -70,14 +70,6 @@ Feature: Dataset edit screen - validation
 
 
     @DiscardAfter
-    Scenario: Blank Geographic Coverage field rejection
-        Given I have a publication opened for editing
-        When I add an empty Geographic Coverage field
-        And I save the publication
-        Then the save is rejected with error message containing "Geographic Coverage has a 'Choose One' placeholder without a value."
-
-
-    @DiscardAfter
     Scenario: Blank Resource Links field rejection
         Given I have a dataset opened for editing
         When I add an empty resource link field

--- a/acceptance-tests/src/test/resources/features/cms/publicationValidation.feature
+++ b/acceptance-tests/src/test/resources/features/cms/publicationValidation.feature
@@ -70,14 +70,6 @@ Feature: Publication edit screen - validation
 
 
     @DiscardAfter
-    Scenario: Blank Geographic Coverage field rejection
-        Given I have a publication opened for editing
-        When I add an empty Geographic Coverage field
-        And I save the publication
-        Then the save is rejected with error message containing "Geographic Coverage has a 'Choose One' placeholder without a value."
-
-
-    @DiscardAfter
     Scenario: Blank Related Links field rejection
         Given I have a publication opened for editing
         When I add an empty related link field

--- a/acceptance-tests/src/test/resources/features/cms/userGroups.feature
+++ b/acceptance-tests/src/test/resources/features/cms/userGroups.feature
@@ -6,19 +6,23 @@ Feature: As a user I want the CMS content to be restricted so I'm not able to do
         Then I should see the "Administration" folder
         And I should see the "Corporate Website/About" folder
         When I am logged in as ci-editor on the content page
-        Then I should not see the "Administration" folder
+        Then The "Administration" folder should have the menu options including:
+            | No actions available |
         And I should not see the "Corporate Website/About" folder
         When I am logged in as ci-author on the content page
-        Then I should not see the "Administration" folder
+        Then The "Administration" folder should have the menu options including:
+            | No actions available |
         And I should not see the "Corporate Website/About" folder
 
     Scenario: National Indicator Library authors and editors can only see the NIL folder
         When I am logged in as ni-editor on the content page
-        Then I should not see the "Administration" folder
+        Then The "Administration" folder should have the menu options including:
+            | No actions available |
         And I should not see the "Corporate Website/About" folder
         And I should see the "Corporate Website/National Indicator Library" folder
         When I am logged in as ni-author on the content page
-        Then I should not see the "Administration" folder
+        Then The "Administration" folder should have the menu options including:
+            | No actions available |
         And I should not see the "Corporate Website/About" folder
         And I should see the "Corporate Website/National Indicator Library" folder
 

--- a/acceptance-tests/src/test/resources/features/site/datasets.feature
+++ b/acceptance-tests/src/test/resources/features/site/datasets.feature
@@ -62,7 +62,7 @@ Feature: As a consumer I need to be able to navigate to publication data sets
         And I should also see:
             | Dataset Summary               | Sed viverra, odio nec eleifend sodales, ligula lectus varius ...  |
             | Dataset Granularity           | NHS Health Boards                                                 |
-            | Dataset Geographic Coverage   | Great Britain                                                     |
+            | Dataset Geographic Coverage   | Northern Ireland                                                  |
 
     Scenario: Click back to publication from data set
         Given I navigate to "publication with datasets Dataset" data set page

--- a/acceptance-tests/src/test/resources/features/site/facets.feature
+++ b/acceptance-tests/src/test/resources/features/site/facets.feature
@@ -20,9 +20,9 @@ Feature: Faceted search
             | Audit (1)                   |
             | National statistics (1)     |
         And I should see the list with title "GEOGRAPHICAL COVERAGE" containing:
-            | England (1)       |
-            | International (1) |
-            | Scotland (1)      |
+            | England (1)          |
+            | Northern Ireland (1) |
+            | Scotland (1)         |
         And I should see the list with title "GEOGRAPHICAL GRANULARITY" containing:
             | Cancer networks (2)  |
             | Ambulance Trusts (1) |

--- a/acceptance-tests/src/test/resources/features/site/publication.feature
+++ b/acceptance-tests/src/test/resources/features/site/publication.feature
@@ -113,3 +113,22 @@ Feature: Ensure publication page displays required fields.
         Then I should also see:
             | Publication Information Types | Experimental statistics       |
         And I should not see element with title "National statistics"
+
+    Scenario: Sectioned body
+        Given I have a sectioned publication
+        When I navigate to the "sectioned publication" page
+        Then I can see the sectioned publication body
+
+    Scenario: Geographic Coverage displays appropriate label based on selections
+        Given I navigate to the "Geographic Coverage - Great Britain" page
+        Then I should also see:
+            | Publication Geographic Coverage | Great Britain                                  |
+        When I navigate to the "Geographic Coverage - United Kingdom" page
+        Then I should also see:
+            | Publication Geographic Coverage | United Kingdom                                 |
+        When I navigate to the "Geographic Coverage - British Isles" page
+        Then I should also see:
+            | Publication Geographic Coverage | British Isles                                  |
+        When I navigate to the "Geographic Coverage - Other combination" page
+        Then I should also see:
+            | Publication Geographic Coverage | England, Northern Ireland, Republic of Ireland |

--- a/repository-data/application/src/main/resources/hcm-config/configuration/domains/cms-user-read.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/domains/cms-user-read.yaml
@@ -2,6 +2,15 @@
 definitions:
   config:
     /hippo:configuration/hippo:domains/cms-user-read:
+      /administration-node:
+        /node-by-uuid:
+          hipposys:equals: true
+          hipposys:facet: jcr:path
+          hipposys:filter: false
+          hipposys:type: Reference
+          hipposys:value: /content/documents/administration
+          jcr:primaryType: hipposys:facetrule
+        jcr:primaryType: hipposys:domainrule
       /assets-node:
         /node-by-uuid:
           hipposys:equals: true

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/indicator.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/nationalindicatorlibrary/indicator.yaml
@@ -93,15 +93,17 @@ definitions:
           /GeographicCoverage:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-              selectable.options: England,Great Britain,International,Northern Ireland,Scotland,UK,Wales
+              source: /content/documents/administration/value-lists/geographic-coverage
             caption: Geographic Coverage
-            field: geographic_coverage
-            hint: ''
+            field: GeographicCoverage
             jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.css:
-            - geographic-coverage
-            wicket.id: ${cluster.id}.left.item
+            multiselect.type: checkboxes
+            palette.alloworder: false
+            palette.maxrows: '10'
+            plugin.class: org.onehippo.forge.selection.frontend.plugin.DynamicMultiSelectPlugin
+            selectlist.maxrows: '10'
+            valuelist.provider: service.valuelist.default
+            wicket.id: ${cluster.id}.right.item
           /assuranceDate:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
@@ -133,6 +135,14 @@ definitions:
         jcr:primaryType: editor:templateset
       /hipposysedit:nodetype:
         /hipposysedit:nodetype:
+          /GeographicCoverage:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: true
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:GeographicCoverage
+            hipposysedit:primary: false
+            hipposysedit:type: String
+            jcr:primaryType: hipposysedit:field
           /assuranceDate:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
@@ -164,14 +174,6 @@ definitions:
             hipposysedit:path: nationalindicatorlibrary:details
             hipposysedit:primary: false
             hipposysedit:type: nationalindicatorlibrary:details
-            jcr:primaryType: hipposysedit:field
-          /geographic_coverage:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:GeographicCoverage
-            hipposysedit:primary: false
-            hipposysedit:type: StaticDropdown
             jcr:primaryType: hipposysedit:field
           /publishedBy:
             hipposysedit:mandatory: false
@@ -292,6 +294,7 @@ definitions:
           nationalindicatorlibrary:publishedBy: ''
           nationalindicatorlibrary:reportingLevel: ''
           nationalindicatorlibrary:title: ''
+          publicationsystem:GeographicCoverage: []
         jcr:primaryType: hipposysedit:prototypeset
       jcr:mixinTypes:
       - editor:editable

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/dataset.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/dataset.yaml
@@ -122,11 +122,16 @@ definitions:
           /GeographicCoverage:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-              selectable.options: England,Great Britain,International,Northern Ireland,Scotland,UK,Wales
+              source: /content/documents/administration/value-lists/geographic-coverage
             caption: Geographic Coverage
             field: GeographicCoverage
             jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            multiselect.type: checkboxes
+            palette.alloworder: false
+            palette.maxrows: '10'
+            plugin.class: org.onehippo.forge.selection.frontend.plugin.DynamicMultiSelectPlugin
+            selectlist.maxrows: '10'
+            valuelist.provider: service.valuelist.default
             wicket.id: ${cluster.id}.right.item
           /Granularity:
             /cluster.options:
@@ -187,9 +192,7 @@ definitions:
             hipposysedit:ordered: false
             hipposysedit:path: publicationsystem:GeographicCoverage
             hipposysedit:primary: false
-            hipposysedit:type: StaticDropdown
-            hipposysedit:validators:
-            - publicationsystem-blank-geographic-coverage
+            hipposysedit:type: String
             jcr:primaryType: hipposysedit:field
           /Granularity:
             hipposysedit:mandatory: false
@@ -282,6 +285,7 @@ definitions:
           jcr:primaryType: publicationsystem:dataset
           publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
           publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+          publicationsystem:GeographicCoverage: []
           publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
           publicationsystem:NominalDate: 0001-01-01T12:00:00Z
           publicationsystem:Summary: ''

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/legacypublication.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/legacypublication.yaml
@@ -127,38 +127,16 @@ definitions:
           /GeographicCoverage:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-              selectable.options: England,Great Britain,International,Northern Ireland,Scotland,UK,Wales
+              source: /content/documents/administration/value-lists/geographic-coverage
             caption: Geographic Coverage
-            field: geographic_coverage
-            hint: ''
+            field: GeographicCoverage
             jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.css:
-            - geographic-coverage
-            wicket.id: ${cluster.id}.right.item
-          /Granularity:
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-              selectable.options: Ambulance Trusts,Cancer networks,Care Trusts,Census
-                Area Statistics Wards,Clinical Commissioning Area Teams,Clinical Commissioning
-                Groups,Clinical Commissioning Regions,Community health services,Councils
-                with Adult Social Services Responsibilities (CASSRs),Country,County,Crime
-                & disorder reduction partnership,Dental practices,Deprivation,Education
-                Authority,Government Office Regions,GP practices,Health Education
-                England Region,Hospital and Community Health Services,Hospital Trusts,Independent
-                Sector Health Care Providers,Local Authorities,London Authorities,Mental
-                Health Trusts,Middle Layer Super Output Areas,NHS Health Boards,NHS
-                Trusts,ONS Area Classification,Parliamentary constituency,Pharmacies
-                and clinics,Primary Care Organisations,Primary Care Trusts,Provider,Provider
-                clusters,Regional health body,Regions,Strategic Health Authorities,Sustainability
-                and Transformation Partnerships,Wards
-            caption: Granularity
-            field: granularity
-            hint: ''
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.css:
-            - granularity
+            multiselect.type: checkboxes
+            palette.alloworder: false
+            palette.maxrows: '10'
+            plugin.class: org.onehippo.forge.selection.frontend.plugin.DynamicMultiSelectPlugin
+            selectlist.maxrows: '10'
+            valuelist.provider: service.valuelist.default
             wicket.id: ${cluster.id}.right.item
           /KeyFacts:
             /cluster.options:
@@ -212,6 +190,30 @@ definitions:
             wicket.css:
             - administrative-sources
             wicket.id: ${cluster.id}.left.item
+          /Granularity:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+              selectable.options: Ambulance Trusts,Cancer networks,Care Trusts,Census
+                Area Statistics Wards,Clinical Commissioning Area Teams,Clinical Commissioning
+                Groups,Clinical Commissioning Regions,Community health services,Councils
+                with Adult Social Services Responsibilities (CASSRs),Country,County,Crime
+                & disorder reduction partnership,Dental practices,Deprivation,Education
+                Authority,Government Office Regions,GP practices,Health Education
+                England Region,Hospital and Community Health Services,Hospital Trusts,Independent
+                Sector Health Care Providers,Local Authorities,London Authorities,Mental
+                Health Trusts,Middle Layer Super Output Areas,NHS Health Boards,NHS
+                Trusts,ONS Area Classification,Parliamentary constituency,Pharmacies
+                and clinics,Primary Care Organisations,Primary Care Trusts,Provider,Provider
+                clusters,Regional health body,Regions,Strategic Health Authorities,Sustainability
+                and Transformation Partnerships,Wards
+            caption: Granularity
+            field: granularity
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.css:
+            - granularity
+            wicket.id: ${cluster.id}.right.item
           /gossid:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
@@ -233,6 +235,14 @@ definitions:
         jcr:primaryType: editor:templateset
       /hipposysedit:nodetype:
         /hipposysedit:nodetype:
+          /GeographicCoverage:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: true
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:GeographicCoverage
+            hipposysedit:primary: false
+            hipposysedit:type: String
+            jcr:primaryType: hipposysedit:field
           /ResourceLinks:
             hipposysedit:mandatory: false
             hipposysedit:multiple: true
@@ -274,16 +284,6 @@ definitions:
             hipposysedit:path: publicationsystem:CoverageStart
             hipposysedit:primary: false
             hipposysedit:type: CalendarDate
-            jcr:primaryType: hipposysedit:field
-          /geographic_coverage:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: true
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:GeographicCoverage
-            hipposysedit:primary: false
-            hipposysedit:type: StaticDropdown
-            hipposysedit:validators:
-            - publicationsystem-blank-geographic-coverage
             jcr:primaryType: hipposysedit:field
           /gossid:
             hipposysedit:mandatory: false
@@ -417,6 +417,7 @@ definitions:
           publicationsystem:AdministrativeSources: ''
           publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
           publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+          publicationsystem:GeographicCoverage: []
           publicationsystem:NominalDate: 0001-01-01T12:00:00Z
           publicationsystem:PubliclyAccessible: false
           publicationsystem:Title: ''

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publication.yaml
@@ -128,14 +128,16 @@ definitions:
           /GeographicCoverage:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-              selectable.options: England,Great Britain,International,Northern Ireland,Scotland,UK,Wales
+              source: /content/documents/administration/value-lists/geographic-coverage
             caption: Geographic Coverage
-            field: geographic_coverage
-            hint: ''
+            field: GeographicCoverage
             jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.css:
-            - geographic-coverage
+            multiselect.type: checkboxes
+            palette.alloworder: false
+            palette.maxrows: '10'
+            plugin.class: org.onehippo.forge.selection.frontend.plugin.DynamicMultiSelectPlugin
+            selectlist.maxrows: '10'
+            valuelist.provider: service.valuelist.default
             wicket.id: ${cluster.id}.right.item
           /Granularity:
             /cluster.options:
@@ -225,6 +227,14 @@ definitions:
         jcr:primaryType: editor:templateset
       /hipposysedit:nodetype:
         /hipposysedit:nodetype:
+          /GeographicCoverage:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: true
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:GeographicCoverage
+            hipposysedit:primary: false
+            hipposysedit:type: String
+            jcr:primaryType: hipposysedit:field
           /ResourceLinks:
             hipposysedit:mandatory: false
             hipposysedit:multiple: true
@@ -266,16 +276,6 @@ definitions:
             hipposysedit:path: publicationsystem:CoverageStart
             hipposysedit:primary: false
             hipposysedit:type: CalendarDate
-            jcr:primaryType: hipposysedit:field
-          /geographic_coverage:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: true
-            hipposysedit:ordered: false
-            hipposysedit:path: publicationsystem:GeographicCoverage
-            hipposysedit:primary: false
-            hipposysedit:type: StaticDropdown
-            hipposysedit:validators:
-            - publicationsystem-blank-geographic-coverage
             jcr:primaryType: hipposysedit:field
           /granularity:
             hipposysedit:mandatory: false
@@ -398,6 +398,7 @@ definitions:
           publicationsystem:AdministrativeSources: ''
           publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
           publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+          publicationsystem:GeographicCoverage: []
           publicationsystem:KeyFacts: ''
           publicationsystem:NominalDate: 0001-01-01T12:00:00Z
           publicationsystem:PubliclyAccessible: false

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/value-lists.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/value-lists.yaml
@@ -1,0 +1,46 @@
+---
+/content/documents/administration/value-lists:
+  /geographic-coverage:
+    /geographic-coverage:
+      /selection:listitem[1]:
+        jcr:primaryType: selection:listitem
+        selection:key: England
+        selection:label: England
+      /selection:listitem[2]:
+        jcr:primaryType: selection:listitem
+        selection:key: Scotland
+        selection:label: Scotland
+      /selection:listitem[3]:
+        jcr:primaryType: selection:listitem
+        selection:key: Wales
+        selection:label: Wales
+      /selection:listitem[4]:
+        jcr:primaryType: selection:listitem
+        selection:key: Northern Ireland
+        selection:label: Northern Ireland
+      /selection:listitem[5]:
+        jcr:primaryType: selection:listitem
+        selection:key: Republic of Ireland
+        selection:label: Republic of Ireland
+      hippo:availability:
+      - live
+      - preview
+      hippotranslation:id: 28b37ec2-8848-4df4-b1f0-40d4bae74cb4
+      hippotranslation:locale: inherited - from query
+      jcr:mixinTypes:
+      - hippotranslation:translated
+      - mix:referenceable
+      jcr:primaryType: selection:valuelist
+    hippo:name: Geographic coverage
+    jcr:mixinTypes:
+    - hippo:named
+    - mix:referenceable
+    jcr:primaryType: hippo:handle
+  hippo:name: Value lists
+  hippostd:foldertype:
+  - new-document
+  - new-folder
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:versionable
+  jcr:primaryType: hippostd:folder

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/facets-test.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/facets-test.yaml
@@ -22,7 +22,7 @@
         publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
         publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
         publicationsystem:GeographicCoverage:
-        - International
+        - Northern Ireland
         publicationsystem:Granularity:
         - Country
         - County
@@ -56,7 +56,7 @@
         publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
         publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
         publicationsystem:GeographicCoverage:
-        - International
+        - Northern Ireland
         publicationsystem:Granularity:
         - Country
         - County
@@ -90,7 +90,7 @@
         publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
         publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
         publicationsystem:GeographicCoverage:
-        - International
+        - Northern Ireland
         publicationsystem:Granularity:
         - Country
         - County

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/geographic-coverage-test.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/geographic-coverage-test.yaml
@@ -1,0 +1,374 @@
+---
+/content/documents/corporate-website/publication-system/acceptance-tests/geographiccoverage-test:
+  /british-isles:
+    /british-isles[1]:
+      common:searchable: true
+      hippo:availability: []
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-29T12:24:30.725Z
+      hippostdpubwf:lastModificationDate: 2018-01-29T12:48:50.731Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 6ca4d793-489b-4b57-b646-d444ba76eb0b
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 2018-01-27T00:00:00Z
+      publicationsystem:CoverageStart: 2018-01-27T00:00:00Z
+      publicationsystem:GeographicCoverage:
+      - England
+      - Scotland
+      - Wales
+      - Northern Ireland
+      - Republic of Ireland
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2018-01-29T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: British Isles test Document
+      publicationsystem:Title: British Isles test Document
+    /british-isles[2]:
+      common:searchable: true
+      hippo:availability:
+      - preview
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-29T12:24:30.725Z
+      hippostdpubwf:lastModificationDate: 2018-01-29T12:26:27.027Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 6ca4d793-489b-4b57-b646-d444ba76eb0b
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      - mix:versionable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 2018-01-27T00:00:00Z
+      publicationsystem:CoverageStart: 2018-01-27T00:00:00Z
+      publicationsystem:GeographicCoverage:
+      - England
+      - Scotland
+      - Wales
+      - Northern Ireland
+      - Republic of Ireland
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2018-01-29T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: British Isles test Document
+      publicationsystem:Title: British Isles test Document
+    /british-isles[3]:
+      common:searchable: true
+      hippo:availability:
+      - live
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-29T12:24:30.725Z
+      hippostdpubwf:lastModificationDate: 2018-01-29T12:26:27.027Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2018-01-29T12:26:31.087Z
+      hippotranslation:id: 6ca4d793-489b-4b57-b646-d444ba76eb0b
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 2018-01-27T00:00:00Z
+      publicationsystem:CoverageStart: 2018-01-27T00:00:00Z
+      publicationsystem:GeographicCoverage:
+      - England
+      - Scotland
+      - Wales
+      - Northern Ireland
+      - Republic of Ireland
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2018-01-29T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: British Isles test Document
+      publicationsystem:Title: British Isles test Document
+    hippo:name: British Isles test Document
+    jcr:mixinTypes:
+    - hippo:named
+    - mix:referenceable
+    jcr:primaryType: hippo:handle
+  /great-britain:
+    /great-britain[1]:
+      common:searchable: true
+      hippo:availability: []
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-29T12:24:30.725Z
+      hippostdpubwf:lastModificationDate: 2018-01-29T12:48:50.731Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 6ca4d793-489b-4b57-b646-d444ba76eb0b
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 2018-01-27T00:00:00Z
+      publicationsystem:CoverageStart: 2018-01-27T00:00:00Z
+      publicationsystem:GeographicCoverage:
+      - England
+      - Scotland
+      - Wales
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2018-01-29T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: Great Britain test Document
+      publicationsystem:Title: Great Britain test Document
+    /great-britain[2]:
+      common:searchable: true
+      hippo:availability:
+      - preview
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-29T12:24:30.725Z
+      hippostdpubwf:lastModificationDate: 2018-01-29T12:26:27.027Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 6ca4d793-489b-4b57-b646-d444ba76eb0b
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      - mix:versionable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 2018-01-27T00:00:00Z
+      publicationsystem:CoverageStart: 2018-01-27T00:00:00Z
+      publicationsystem:GeographicCoverage:
+      - England
+      - Scotland
+      - Wales
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2018-01-29T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: Great Britain test Document
+      publicationsystem:Title: Great Britain test Document
+    /great-britain[3]:
+      common:searchable: true
+      hippo:availability:
+      - live
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-29T12:24:30.725Z
+      hippostdpubwf:lastModificationDate: 2018-01-29T12:26:27.027Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2018-01-29T12:26:31.087Z
+      hippotranslation:id: 6ca4d793-489b-4b57-b646-d444ba76eb0b
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 2018-01-27T00:00:00Z
+      publicationsystem:CoverageStart: 2018-01-27T00:00:00Z
+      publicationsystem:GeographicCoverage:
+      - England
+      - Scotland
+      - Wales
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2018-01-29T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: Great Britain test Document
+      publicationsystem:Title: Great Britain test Document
+    hippo:name: Great Britain test Document
+    jcr:mixinTypes:
+    - hippo:named
+    - mix:referenceable
+    jcr:primaryType: hippo:handle
+  /other-combination:
+    /other-combination[1]:
+      common:searchable: true
+      hippo:availability: []
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-29T12:24:30.725Z
+      hippostdpubwf:lastModificationDate: 2018-01-29T12:48:50.731Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 6ca4d793-489b-4b57-b646-d444ba76eb0b
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 2018-01-27T00:00:00Z
+      publicationsystem:CoverageStart: 2018-01-27T00:00:00Z
+      publicationsystem:GeographicCoverage:
+      - England
+      - Northern Ireland
+      - Republic of Ireland
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2018-01-29T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: Other combination test Document
+      publicationsystem:Title: Other combination test Document
+    /other-combination[2]:
+      common:searchable: true
+      hippo:availability:
+      - preview
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-29T12:24:30.725Z
+      hippostdpubwf:lastModificationDate: 2018-01-29T12:26:27.027Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 6ca4d793-489b-4b57-b646-d444ba76eb0b
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      - mix:versionable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 2018-01-27T00:00:00Z
+      publicationsystem:CoverageStart: 2018-01-27T00:00:00Z
+      publicationsystem:GeographicCoverage:
+      - England
+      - Northern Ireland
+      - Republic of Ireland
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2018-01-29T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: Other combination test Document
+      publicationsystem:Title: Other combination test Document
+    /other-combination[3]:
+      common:searchable: true
+      hippo:availability:
+      - live
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-29T12:24:30.725Z
+      hippostdpubwf:lastModificationDate: 2018-01-29T12:26:27.027Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2018-01-29T12:26:31.087Z
+      hippotranslation:id: 6ca4d793-489b-4b57-b646-d444ba76eb0b
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 2018-01-27T00:00:00Z
+      publicationsystem:CoverageStart: 2018-01-27T00:00:00Z
+      publicationsystem:GeographicCoverage:
+      - England
+      - Northern Ireland
+      - Republic of Ireland
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2018-01-29T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: Other combination test Document
+      publicationsystem:Title: Other combination test Document
+    hippo:name: Other combination test Document
+    jcr:mixinTypes:
+    - hippo:named
+    - mix:referenceable
+    jcr:primaryType: hippo:handle
+  /united-kingdom:
+    /united-kingdom[1]:
+      common:searchable: true
+      hippo:availability: []
+      hippostd:state: draft
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-29T12:24:30.725Z
+      hippostdpubwf:lastModificationDate: 2018-01-29T12:48:50.731Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 6ca4d793-489b-4b57-b646-d444ba76eb0b
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 2018-01-27T00:00:00Z
+      publicationsystem:CoverageStart: 2018-01-27T00:00:00Z
+      publicationsystem:GeographicCoverage:
+      - England
+      - Scotland
+      - Wales
+      - Northern Ireland
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2018-01-29T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: United Kingdom test Document
+      publicationsystem:Title: United Kingdom test Document
+    /united-kingdom[2]:
+      common:searchable: true
+      hippo:availability:
+      - preview
+      hippostd:state: unpublished
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-29T12:24:30.725Z
+      hippostdpubwf:lastModificationDate: 2018-01-29T12:26:27.027Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippotranslation:id: 6ca4d793-489b-4b57-b646-d444ba76eb0b
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      - mix:versionable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 2018-01-27T00:00:00Z
+      publicationsystem:CoverageStart: 2018-01-27T00:00:00Z
+      publicationsystem:GeographicCoverage:
+      - England
+      - Scotland
+      - Wales
+      - Northern Ireland
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2018-01-29T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: United Kingdom test Document
+      publicationsystem:Title: United Kingdom test Document
+    /united-kingdom[3]:
+      common:searchable: true
+      hippo:availability:
+      - live
+      hippostd:state: published
+      hippostdpubwf:createdBy: admin
+      hippostdpubwf:creationDate: 2018-01-29T12:24:30.725Z
+      hippostdpubwf:lastModificationDate: 2018-01-29T12:26:27.027Z
+      hippostdpubwf:lastModifiedBy: admin
+      hippostdpubwf:publicationDate: 2018-01-29T12:26:31.087Z
+      hippotranslation:id: 6ca4d793-489b-4b57-b646-d444ba76eb0b
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippotaxonomy:classifiable
+      - mix:referenceable
+      jcr:primaryType: publicationsystem:publication
+      publicationsystem:AdministrativeSources: ''
+      publicationsystem:CoverageEnd: 2018-01-27T00:00:00Z
+      publicationsystem:CoverageStart: 2018-01-27T00:00:00Z
+      publicationsystem:GeographicCoverage:
+      - England
+      - Scotland
+      - Wales
+      - Northern Ireland
+      publicationsystem:KeyFacts: ''
+      publicationsystem:NominalDate: 2018-01-29T00:00:00Z
+      publicationsystem:PubliclyAccessible: true
+      publicationsystem:Summary: United Kingdom test Document
+      publicationsystem:Title: United Kingdom test Document
+    hippo:name: United Kingdom test Document
+    jcr:mixinTypes:
+    - hippo:named
+    - mix:referenceable
+    jcr:primaryType: hippo:handle
+  hippo:name: Geographic Coverage
+  hippostd:foldertype:
+  - new-statistical-publications-and-clinical-indicators-document
+  - new-statistical-publications-and-clinical-indicators-folder
+  hippotranslation:id: eaf4fc44-8d7c-4bdf-afae-550d6a45adac
+  hippotranslation:locale: en
+  jcr:mixinTypes:
+  - hippo:named
+  - hippotranslation:translated
+  - mix:versionable
+  jcr:primaryType: hippostd:folder

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/series-publication-with-datasets-dataset.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/series-publication-with-datasets-dataset.yaml
@@ -20,7 +20,7 @@
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage:
-    - Great Britain
+    - Northern Ireland
     publicationsystem:Granularity:
     - NHS Health Boards
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
@@ -66,7 +66,7 @@
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage:
-    - Great Britain
+    - Northern Ireland
     publicationsystem:Granularity:
     - NHS Health Boards
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
@@ -114,7 +114,7 @@
     publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
     publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
     publicationsystem:GeographicCoverage:
-    - Great Britain
+    - Northern Ireland
     publicationsystem:Granularity:
     - NHS Health Boards
     publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z

--- a/site/src/main/java/uk/nhs/digital/common/enums/Region.java
+++ b/site/src/main/java/uk/nhs/digital/common/enums/Region.java
@@ -1,0 +1,48 @@
+package uk.nhs.digital.common.enums;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public enum Region {
+
+    GREAT_BRITAIN("Great Britain", "England", "Scotland", "Wales"),
+    UNITED_KINGDOM("United Kingdom", "England", "Scotland", "Wales", "Northern Ireland"),
+    BRITISH_ISLES("British Isles", "England", "Scotland", "Wales", "Northern Ireland", "Republic of Ireland");
+
+    private final String regionName;
+    private final Set<String> geographicCoverageValues;
+
+    Region(String regionName, String... geographicCoverageValues) {
+        this.regionName = regionName;
+        this.geographicCoverageValues = new HashSet<>(Arrays.asList(geographicCoverageValues));
+    }
+
+    /**
+     * Converts selected geographic coverage values:
+     * If England, Wales, Scotland are checked and no others - Great Britain
+     * If England, Wales, Scotland and Northern Ireland are checked and no others - United Kingdom
+     * If England, Wales, Scotland and Northern Ireland, and Republic of Ireland are ticked - British Isles
+     * If any other combination is checked, serve up a list of the checked values
+     */
+    public static String[] convertGeographicCoverageValues(final String[] cmsValues) {
+
+        for (Region region: Region.values()) {
+            if (region.matches(cmsValues)) {
+                return new String[] {region.getDisplayName()};
+            }
+        }
+        return cmsValues;
+    }
+
+    private boolean matches(String[] cmsValues) {
+        if (cmsValues == null) {
+            return false;
+        }
+        return geographicCoverageValues.equals(new HashSet<>(Arrays.asList(cmsValues)));
+    }
+
+    private String getDisplayName() {
+        return regionName;
+    }
+}

--- a/site/src/main/java/uk/nhs/digital/nil/beans/Indicator.java
+++ b/site/src/main/java/uk/nhs/digital/nil/beans/Indicator.java
@@ -5,6 +5,7 @@ import org.apache.cxf.common.util.CollectionUtils;
 import org.hippoecm.hst.content.beans.Node;
 import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
 import uk.nhs.digital.ps.beans.Attachment;
+import uk.nhs.digital.ps.beans.BaseDocument;
 import uk.nhs.digital.ps.beans.HippoBeanHelper;
 
 import java.util.Calendar;
@@ -52,7 +53,7 @@ public class Indicator extends BaseDocument {
 
     @HippoEssentialsGenerated(internalName = PropertyKeys.GEOGRAPHIC_COVERAGE)
     public String[] getGeographicCoverage() {
-        return getProperty(PropertyKeys.GEOGRAPHIC_COVERAGE);
+        return geographicCoverageValuesToRegionValue(getProperty(PropertyKeys.GEOGRAPHIC_COVERAGE));
     }
 
     @HippoEssentialsGenerated(internalName = PropertyKeys.TAXONOMY)

--- a/site/src/main/java/uk/nhs/digital/ps/beans/BaseDocument.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/BaseDocument.java
@@ -3,6 +3,7 @@ package uk.nhs.digital.ps.beans;
 import org.hippoecm.hst.content.beans.Node;
 import org.hippoecm.hst.content.beans.standard.HippoBean;
 import org.hippoecm.hst.content.beans.standard.HippoDocument;
+import uk.nhs.digital.common.enums.Region;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -62,5 +63,12 @@ public abstract class BaseDocument extends HippoDocument {
         return nominalPublicationDate.isAfter(cutOffPoint)
             ? RestrictableDate.restrictedDateFrom(nominalPublicationDate)
             : RestrictableDate.fullDateFrom(nominalPublicationDate);
+    }
+
+    /**
+    * Convert selected values to appropriate geographic region
+    */
+    protected String[] geographicCoverageValuesToRegionValue(final String[] cmsValues) {
+        return Region.convertGeographicCoverageValues(cmsValues);
     }
 }

--- a/site/src/main/java/uk/nhs/digital/ps/beans/Dataset.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/Dataset.java
@@ -52,7 +52,7 @@ public class Dataset extends BaseDocument {
 
     @HippoEssentialsGenerated(internalName = PropertyKeys.GEOGRAPHIC_COVERAGE)
     public String[] getGeographicCoverage() {
-        return getPropertyIfPermitted(PropertyKeys.GEOGRAPHIC_COVERAGE);
+        return geographicCoverageValuesToRegionValue(getPropertyIfPermitted(PropertyKeys.GEOGRAPHIC_COVERAGE));
     }
 
     @HippoEssentialsGenerated(internalName = PropertyKeys.TAXONOMY)

--- a/site/src/main/java/uk/nhs/digital/ps/beans/PublicationBase.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/PublicationBase.java
@@ -147,7 +147,7 @@ public abstract class PublicationBase extends BaseDocument {
 
     @HippoEssentialsGenerated(internalName = PropertyKeys.GEOGRAPHIC_COVERAGE)
     public String[] getGeographicCoverage() {
-        return getPropertyIfPermitted(PropertyKeys.GEOGRAPHIC_COVERAGE);
+        return geographicCoverageValuesToRegionValue(getPropertyIfPermitted(PropertyKeys.GEOGRAPHIC_COVERAGE));
     }
 
     @HippoEssentialsGenerated(internalName = PropertyKeys.GRANULARITY)


### PR DESCRIPTION
Replaced Geographic Coverage picker with five check boxes, as follows:
England,Wales,Scotland,Northern Ireland,Republic of Ireland

Also serve up the following to the front-end
* If England,Wales,Scotland are checked and no others - Great Britain
* If England,Wales,Scotland and Northern Ireland are checked and no
others - United Kingdom
* If England,Wales,Scotland,Northern Ireland and Republic of Ireland
are checked - British Isles
* If any other combination is checked, serve up list of checked values

Note: Check boxes are optional (i.e. all can be unchecked). Script to update existing values is not required since no values for Great Britain,UK or International exist in RPS content, and CW have not migrated yet and will map to new values. This change exposes the Administration folder as readonly for author/editor role since the value list lookup document resides in the "Administration/value lists" folder, and their roles must be able to see this document for it to render correctly.