### PR TITLE
[RPS-461] Publish only finalised publication resources

### DIFF
--- a/acceptance-tests/.gitignore
+++ b/acceptance-tests/.gitignore
@@ -1,0 +1,1 @@
+src/test/resources/attachments/attachment.*MB.zip

--- a/ci-cd/Makefile
+++ b/ci-cd/Makefile
@@ -150,7 +150,7 @@ ondemand.deploy: vendor/rd
 #        make ondemand.schedule-deploy ENV=uat RD_CONF=my-rd.conf RELEASE_DATE=2018-02-28 RELEASE_TIME_UTC=02:00:00
 ondemand.schedule-deploy: vendor/rd
 	source $(RD_CONF) && vendor/rd run \
-		--at $(RELEASE_DATE)T$(RELEASE_TIME_UTC)Z\
+		--at "$(RELEASE_DATE)T$(RELEASE_TIME_UTC)Z"\
 		--project nhs \
 		--job "jobs/$(OD_ENV)/Deploy" \
 		-- \

--- a/cms/src/main/java/uk/nhs/digital/JcrQueryHelper.java
+++ b/cms/src/main/java/uk/nhs/digital/JcrQueryHelper.java
@@ -1,0 +1,39 @@
+package uk.nhs.digital;
+
+import static java.text.MessageFormat.format;
+
+import org.apache.jackrabbit.util.Text;
+import org.hippoecm.repository.HippoStdNodeType;
+
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryResult;
+
+public class JcrQueryHelper {
+
+    private static QueryResult executeSql2Query(Session session, String sql2QueryTemplate, String... queryArgs) throws RepositoryException {
+        String query = format(sql2QueryTemplate, queryArgs);
+
+        return session
+            .getWorkspace()
+            .getQueryManager()
+            .createQuery(query, Query.JCR_SQL2)
+            .execute();
+    }
+
+    public static QueryResult findDescendantVariants(Node node, String decendantPrimaryType, String decendantVariant) throws RepositoryException {
+        String queryTemplate = "SELECT * FROM [{0}] WHERE ISDESCENDANTNODE ([''{1}'']) AND [{2}] = ''{3}''";
+
+        return executeSql2Query(node.getSession(), queryTemplate,
+            decendantPrimaryType, Text.escapePath(node.getPath()), HippoStdNodeType.HIPPOSTD_STATE, Text.escape(decendantVariant));
+    }
+
+    public static QueryResult findDescendantNodes(Node node, String decendantPrimaryType) throws RepositoryException {
+        String queryTemplate = "SELECT * FROM [{0}] WHERE ISDESCENDANTNODE ([''{1}''])";
+
+        return executeSql2Query(node.getSession(), queryTemplate,
+            decendantPrimaryType, Text.escapePath(node.getPath()));
+    }
+}

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFilePublish/ExternalFilePublishTask.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFilePublish/ExternalFilePublishTask.java
@@ -1,11 +1,119 @@
 package uk.nhs.digital.externalstorage.workflow.externalFilePublish;
 
+import static org.hippoecm.repository.HippoStdNodeType.PUBLISHED;
+import static uk.nhs.digital.ps.PublicationSystemConstants.INDEX_FILE_NAME;
+
+import org.hippoecm.repository.api.WorkflowException;
+import org.onehippo.repository.documentworkflow.DocumentHandle;
+import org.onehippo.repository.documentworkflow.DocumentVariant;
+import uk.nhs.digital.externalstorage.ExternalStorageConstants;
 import uk.nhs.digital.externalstorage.s3.SchedulingS3Connector;
 import uk.nhs.digital.externalstorage.workflow.AbstractExternalFileTask;
+import uk.nhs.digital.ps.PublicationSystemConstants;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
 
 public class ExternalFilePublishTask extends AbstractExternalFileTask {
 
-    protected void setTargetStatus(final SchedulingS3Connector s3Connector, final String resource) {
-        s3Connector.publishResource(resource);
+    private static final String DOCUMENTS_ROOT_FOLDER = "/content/documents";
+
+    protected void setResourcePermission(final SchedulingS3Connector s3Connector, final NodeIterator resourceNodes) throws RepositoryException, WorkflowException {
+        Node variantNode = getVariant().getNode(getWorkflowContext().getInternalWorkflowSession());
+
+        if (isPublication(variantNode)) {
+            // if publishing publication we need to check "PUBLICLY ACCESSIBLE" flag, and also update all datasets
+            setResourcePermissionOnPublication(s3Connector, resourceNodes);
+        } else if (isDataset(variantNode)) {
+            // when publishing dataset, we need to check parent LIVE publication state
+            publishResources(s3Connector, resourceNodes, isParentPublicationFinalised(variantNode));
+        } else {
+            // no additional logic for other document types. Published == public attachments
+            publishResources(s3Connector, resourceNodes, true);
+        }
+    }
+
+    private void publishResources(SchedulingS3Connector s3Connector, NodeIterator resourceNodes, boolean shouldBePublic) throws RepositoryException {
+        for (Node node; resourceNodes.hasNext(); ) {
+            node = resourceNodes.nextNode();
+            if (node.hasProperty(ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_REFERENCE)) {
+                String externalResource = node
+                    .getProperty(ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_REFERENCE)
+                    .getString();
+
+                if (shouldBePublic) {
+                    s3Connector.publishResource(externalResource);
+                } else {
+                    s3Connector.unpublishResource(externalResource);
+                }
+            }
+        }
+    }
+
+    private void setResourcePermissionOnPublication(SchedulingS3Connector s3Connector, NodeIterator resourceNodes) throws RepositoryException {
+        Node variantNode = getVariant().getNode(getWorkflowContext().getInternalWorkflowSession());
+
+        publishResources(s3Connector, resourceNodes, isPublicationFinalised(variantNode));
+
+        // now find all datasets and publish resources
+        // only if publication name is "content"
+        if (INDEX_FILE_NAME.equals(variantNode.getName())) {
+            NodeIterator nodes = findPublicationDatasetsVariant(variantNode, PUBLISHED);
+
+            while (nodes.hasNext()) {
+                publishResources(s3Connector, findResourceNodes(nodes.nextNode()), isPublicationFinalised(variantNode));
+            }
+        }
+    }
+
+    private boolean isParentPublicationFinalised(Node datasetVariant) throws RepositoryException, WorkflowException {
+        DocumentVariant parentPublication = findPublicationInFolder(datasetVariant.getParent().getParent());
+
+        if (parentPublication == null) {
+            // no parent publication found
+            return false;
+        }
+
+        return parentPublication.getNode(getWorkflowContext().getInternalWorkflowSession())
+            .getProperty(PublicationSystemConstants.PROPERTY_PUBLICLY_ACCESSIBLE)
+            .getBoolean();
+    }
+
+    private DocumentVariant findPublicationInFolder(Node folder) throws RepositoryException, WorkflowException {
+        if (DOCUMENTS_ROOT_FOLDER.equals(folder.getPath())) {
+            return null;
+        }
+
+        NodeIterator nodes = folder.getNodes();
+        while (nodes.hasNext()) {
+            Node node = nodes.nextNode();
+            if (isContentHandle(node)) {
+                DocumentHandle documentHandle = new DocumentHandle(node);
+                documentHandle.initialize();
+
+                return documentHandle.getDocuments().get(variantState);
+            }
+        }
+
+        return findPublicationInFolder(folder.getParent());
+    }
+
+    private boolean isContentHandle(Node node) throws RepositoryException {
+        return node.isNodeType("hippo:handle")
+            && INDEX_FILE_NAME.equals(node.getName());
+    }
+
+    private boolean isPublicationFinalised(Node publicationVariant) throws RepositoryException {
+        return publicationVariant.getProperty(PublicationSystemConstants.PROPERTY_PUBLICLY_ACCESSIBLE).getBoolean();
+    }
+
+    private boolean isDataset(Node variantNode) throws RepositoryException {
+        return  variantNode.isNodeType(PublicationSystemConstants.NODE_TYPE_DATASET);
+    }
+
+    private boolean isPublication(Node variantNode) throws RepositoryException {
+        return variantNode.isNodeType(PublicationSystemConstants.NODE_TYPE_PUBLICATION)
+            || variantNode.isNodeType(PublicationSystemConstants.NODE_TYPE_LEGACY_PUBLICATION);
     }
 }

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFileUnpublish/ExternalFileUnpublishTask.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFileUnpublish/ExternalFileUnpublishTask.java
@@ -1,11 +1,63 @@
 package uk.nhs.digital.externalstorage.workflow.externalFileUnpublish;
 
+import static org.hippoecm.repository.HippoStdNodeType.PUBLISHED;
+import static uk.nhs.digital.ps.PublicationSystemConstants.INDEX_FILE_NAME;
+
+import uk.nhs.digital.externalstorage.ExternalStorageConstants;
 import uk.nhs.digital.externalstorage.s3.SchedulingS3Connector;
 import uk.nhs.digital.externalstorage.workflow.AbstractExternalFileTask;
+import uk.nhs.digital.ps.PublicationSystemConstants;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
 
 public class ExternalFileUnpublishTask extends AbstractExternalFileTask {
 
-    protected void setTargetStatus(final SchedulingS3Connector s3Connector, final String resource) {
-        s3Connector.unpublishResource(resource);
+    protected void setResourcePermission(final SchedulingS3Connector s3Connector, final NodeIterator resourceNodes) throws RepositoryException {
+        Node variantNode = getVariant().getNode(getWorkflowContext().getInternalWorkflowSession());
+
+        if (isPublication(variantNode)) {
+            // if un-publishing publication we need to also un-publish its dataset resources.
+            unpublishPublicationResources(s3Connector, resourceNodes);
+        } else {
+            // no additional logic for other document types. Un-published == private attachments
+            unpublishResources(s3Connector, resourceNodes);
+        }
+    }
+
+    private void unpublishPublicationResources(final SchedulingS3Connector s3Connector, NodeIterator resourceNodes) throws RepositoryException {
+        Node variantNode = getVariant().getNode(getWorkflowContext().getInternalWorkflowSession());
+
+        unpublishResources(s3Connector, resourceNodes);
+
+        // now find all datasets and publish resources
+        // only if publication name is "content"
+        if (INDEX_FILE_NAME.equals(variantNode.getName())) {
+            NodeIterator nodes = findPublicationDatasetsVariant(variantNode, PUBLISHED);
+
+            while (nodes.hasNext()) {
+                unpublishResources(s3Connector, findResourceNodes(nodes.nextNode()));
+            }
+        }
+    }
+
+    private void unpublishResources(final SchedulingS3Connector s3Connector, NodeIterator resourceNodes) throws RepositoryException {
+        for (Node node; resourceNodes.hasNext(); ) {
+            node = resourceNodes.nextNode();
+            if (node.hasProperty(ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_REFERENCE)) {
+                String externalResource = node
+                    .getProperty(ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_REFERENCE)
+                    .getString();
+
+                s3Connector.unpublishResource(externalResource);
+            }
+        }
+    }
+
+
+    private boolean isPublication(Node variantNode) throws RepositoryException {
+        return variantNode.isNodeType(PublicationSystemConstants.NODE_TYPE_PUBLICATION)
+            || variantNode.isNodeType(PublicationSystemConstants.NODE_TYPE_LEGACY_PUBLICATION);
     }
 }

--- a/cms/src/main/java/uk/nhs/digital/ps/PublicationSystemConstants.java
+++ b/cms/src/main/java/uk/nhs/digital/ps/PublicationSystemConstants.java
@@ -1,0 +1,12 @@
+package uk.nhs.digital.ps;
+
+public interface PublicationSystemConstants {
+
+    String NODE_TYPE_PUBLICATION = "publicationsystem:publication";
+    String NODE_TYPE_LEGACY_PUBLICATION = "publicationsystem:legacypublication";
+    String NODE_TYPE_DATASET = "publicationsystem:dataset";
+
+    String PROPERTY_PUBLICLY_ACCESSIBLE = "publicationsystem:PubliclyAccessible";
+
+    String INDEX_FILE_NAME = "content";
+}

--- a/cms/src/test/java/uk/nhs/digital/externalstorage/workflow/externalFilePublish/ExternalFilePublishTaskTest.java
+++ b/cms/src/test/java/uk/nhs/digital/externalstorage/workflow/externalFilePublish/ExternalFilePublishTaskTest.java
@@ -1,12 +1,20 @@
 package uk.nhs.digital.externalstorage.workflow.externalFilePublish;
 
+import static org.hippoecm.repository.HippoStdNodeType.HIPPOSTD_STATE;
+import static org.hippoecm.repository.HippoStdNodeType.NT_FOLDER;
+import static org.hippoecm.repository.HippoStdNodeType.PUBLISHED;
 import static org.hippoecm.repository.HippoStdNodeType.UNPUBLISHED;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import org.apache.sling.testing.mock.jcr.MockJcr;
+import org.apache.sling.testing.mock.jcr.MockQueryResult;
+import org.apache.sling.testing.mock.jcr.MockQueryResultHandler;
 import org.hippoecm.repository.api.WorkflowContext;
 import org.hippoecm.repository.api.WorkflowException;
 import org.junit.Before;
@@ -15,10 +23,14 @@ import org.mockito.Mock;
 import org.onehippo.repository.documentworkflow.DocumentHandle;
 import uk.nhs.digital.externalstorage.ExternalStorageConstants;
 import uk.nhs.digital.externalstorage.s3.SchedulingS3Connector;
+import uk.nhs.digital.ps.PublicationSystemConstants;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.PropertyIterator;
 import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
@@ -30,18 +42,22 @@ public class ExternalFilePublishTaskTest {
 
     private ExternalFilePublishTask externalFilePublishTask;
     private Session session;
-
     private Node rootNode;
+    private Node testFolder;
+    private final String testExternalReference = "ab/1c2d3e/one.pdf";
 
     @Before
     public void setUp() throws RepositoryException {
         initMocks(this);
         given(s3Connector.publishResource(any(String.class)))
             .willReturn(true);
+        given(s3Connector.unpublishResource(any(String.class)))
+            .willReturn(true);
 
         Repository repository = MockJcr.newRepository();
         session = repository.login();
         rootNode = session.getRootNode();
+        testFolder = rootNode.addNode("lorem-ipsum", NT_FOLDER);
         externalFilePublishTask = new ExternalFilePublishTask();
 
         given(workflowContext.getInternalWorkflowSession()).willReturn(session);
@@ -49,14 +65,163 @@ public class ExternalFilePublishTaskTest {
     }
 
     @Test
-    public void shouldCallS3() throws WorkflowException, RepositoryException {
-        Node docNode = rootNode.addNode("test-document");
-        addVariantNode(docNode, UNPUBLISHED);
-        MockJcr.setQueryResult(session, getQueryResults());
+    public void shouldPublishAnyDocumentResource() throws WorkflowException, RepositoryException {
+        Node document = getDocumentHandleWithVariant(getRandomDocumentType(), UNPUBLISHED);
+        MockJcr.addQueryResultHandler(session, searchResourcesHandle(getVariantPath(document), testExternalReference));
 
-        executeTask(docNode, externalFilePublishTask);
+        executeTask(document, externalFilePublishTask);
 
-        then(s3Connector).should().publishResource("the/one");
+        then(s3Connector).should().publishResource(testExternalReference);
+        then(s3Connector).should(never()).unpublishResource(anyString());
+    }
+
+    @Test
+    public void shouldPublishFinalisedStandalonePublicationResources() throws WorkflowException, RepositoryException {
+        Node document = getDocumentHandleWithVariant(getFinalisedPublication(), UNPUBLISHED);
+        MockJcr.addQueryResultHandler(session, searchResourcesHandle(getVariantPath(document), testExternalReference));
+
+        executeTask(document, externalFilePublishTask);
+
+        then(s3Connector).should().publishResource(testExternalReference);
+        then(s3Connector).should(never()).unpublishResource(anyString());
+    }
+
+    @Test
+    public void shouldUnpublishUpcomingStandalonePublicationResources() throws WorkflowException, RepositoryException {
+        Node document = getDocumentHandleWithVariant(getUpcomingPublication(), UNPUBLISHED);
+        MockJcr.addQueryResultHandler(session, searchResourcesHandle(getVariantPath(document), testExternalReference));
+
+        executeTask(document, externalFilePublishTask);
+
+        then(s3Connector).should(never()).publishResource(anyString());
+        then(s3Connector).should().unpublishResource(testExternalReference);
+    }
+
+    @Test
+    public void shouldUnpublishDatasetResourcesPartOfUpcomingPublication() throws WorkflowException, RepositoryException {
+        Node publication = getDocumentHandleWithVariant(getUpcomingPublication(), UNPUBLISHED);
+        Node dataset = getDocumentHandleWithVariant(getDataset(), UNPUBLISHED);
+        String publicationResource = "ab/cdef12/lorem.pdf";
+        MockJcr.addQueryResultHandler(session, searchResourcesHandle(getVariantPath(dataset), testExternalReference));
+        MockJcr.addQueryResultHandler(session, searchResourcesHandle(getVariantPath(publication), publicationResource));
+
+        executeTask(dataset, externalFilePublishTask);
+
+        then(s3Connector).should(never()).publishResource(anyString());
+        then(s3Connector).should().unpublishResource(testExternalReference);
+        then(s3Connector).should(never()).unpublishResource(publicationResource);
+    }
+
+    @Test
+    public void shouldPublishDatasetResourcesPartOfFinalisedPublication() throws WorkflowException, RepositoryException {
+        Node publication = getDocumentHandleWithVariant(getFinalisedPublication(), UNPUBLISHED);
+        Node dataset = getDocumentHandleWithVariant(getDataset(), UNPUBLISHED);
+        String publicationResource = "ab/cdef12/lorem.pdf";
+
+        MockJcr.addQueryResultHandler(session, searchResourcesHandle(getVariantPath(dataset), testExternalReference));
+        MockJcr.addQueryResultHandler(session, searchResourcesHandle(getVariantPath(publication), publicationResource));
+
+        // when
+        executeTask(dataset, externalFilePublishTask);
+
+        then(s3Connector).should().publishResource(testExternalReference);
+        then(s3Connector).should(never()).publishResource(publicationResource);
+        then(s3Connector).should(never()).unpublishResource(anyString());
+    }
+
+    @Test
+    public void shouldPublishFinalisedPublicationAndItsDatasetsResources() throws WorkflowException, RepositoryException {
+        // add Dataset to JCR
+        Node dataset = getDocumentHandleWithVariant(getDataset(), PUBLISHED);
+        Node publication = getDocumentHandleWithVariant(getFinalisedPublication(), UNPUBLISHED);
+        String publicationResource = "ab/cdef12/lorem.pdf";
+
+        MockJcr.addQueryResultHandler(session, searchResourcesHandle(getVariantPath(dataset), testExternalReference));
+        MockJcr.addQueryResultHandler(session, searchResourcesHandle(getVariantPath(publication), publicationResource));
+        MockJcr.addQueryResultHandler(session, searchDatasetsHandle(dataset.getNode(dataset.getName())));
+
+        // when publishing finalised publication
+        executeTask(publication, externalFilePublishTask);
+
+        // should be executed once for publication and once for dataset
+        then(s3Connector).should(times(1)).publishResource(testExternalReference);
+        then(s3Connector).should(times(1)).publishResource(publicationResource);
+        then(s3Connector).should(never()).unpublishResource(anyString());
+    }
+
+    @Test
+    public void shouldUnpublishUpcomingPublicationAndItsDatasetsResources() throws WorkflowException, RepositoryException {
+        // add Dataset to JCR
+        Node dataset = getDocumentHandleWithVariant(getDataset(), PUBLISHED);
+        Node publication = getDocumentHandleWithVariant(getUpcomingPublication(), UNPUBLISHED);
+        String publicationResource = "ab/cdef12/lorem.pdf";
+
+        MockJcr.addQueryResultHandler(session, searchResourcesHandle(getVariantPath(dataset), testExternalReference));
+        MockJcr.addQueryResultHandler(session, searchResourcesHandle(getVariantPath(publication), publicationResource));
+        MockJcr.addQueryResultHandler(session, searchDatasetsHandle(dataset.getNode(dataset.getName())));
+
+        // when publishing upcoming publication
+        executeTask(publication, externalFilePublishTask);
+
+        // should be executed once for publication and once for dataset
+        then(s3Connector).should(times(1)).unpublishResource(testExternalReference);
+        then(s3Connector).should(times(1)).unpublishResource(publicationResource);
+        then(s3Connector).should(never()).publishResource(anyString());
+    }
+
+    private String getVariantPath(Node node) throws RepositoryException {
+        return node.getNode(node.getName()).getPath();
+    }
+
+    private MockQueryResultHandler searchDatasetsHandle(Node dataset) {
+        return mockQuery -> {
+            if (mockQuery.getStatement().matches("SELECT \\* FROM \\[publicationsystem:dataset].*\\[hippostd:state]\\s?=\\s?'published'")) {
+                return new MockQueryResult(Arrays.asList(dataset));
+            }
+            return null;
+        };
+    }
+
+    private MockQueryResultHandler searchResourcesHandle(final String nodePath, final String externalReference) {
+        return mockQuery -> {
+            String jcrSafeNodePath = org.apache.jackrabbit.util.Text.escapePath(nodePath);
+
+            System.out.println(mockQuery.getStatement());
+            System.out.println("SELECT \\* FROM \\[externalstorage:resource].*ISDESCENDANTNODE \\(\\['" + jcrSafeNodePath + "']\\).*");
+
+            if (mockQuery.getStatement().matches("SELECT \\* FROM \\[externalstorage:resource].*ISDESCENDANTNODE \\(\\['" + jcrSafeNodePath + "']\\).*")) {
+                return new MockQueryResult(getQueryResultsWithSingleExternalResource(externalReference));
+            }
+            return null;
+        };
+    }
+
+    private Node getFinalisedPublication() throws RepositoryException {
+        Node publicationVariant = rootNode.addNode("content", PublicationSystemConstants.NODE_TYPE_PUBLICATION);
+
+        publicationVariant.setProperty(PublicationSystemConstants.PROPERTY_PUBLICLY_ACCESSIBLE, true);
+
+        return publicationVariant;
+    }
+
+    private Node getUpcomingPublication() throws RepositoryException {
+        Node publicationVariant = rootNode.addNode("content", PublicationSystemConstants.NODE_TYPE_PUBLICATION);
+
+        publicationVariant.setProperty(PublicationSystemConstants.PROPERTY_PUBLICLY_ACCESSIBLE, false);
+
+        return publicationVariant;
+    }
+
+    private Node getRandomDocumentType() throws RepositoryException {
+        Node randomTypeVariant = rootNode.addNode("test-document", "lorem:ipsum");
+
+        return randomTypeVariant;
+    }
+
+    private Node getDataset() throws RepositoryException {
+        Node datasetVariant = rootNode.addNode("test-document", PublicationSystemConstants.NODE_TYPE_DATASET);
+
+        return datasetVariant;
     }
 
     private void executeTask(Node document, ExternalFilePublishTask task) throws WorkflowException {
@@ -69,23 +234,37 @@ public class ExternalFilePublishTaskTest {
         task.execute();
     }
 
-    private Node addVariantNode(Node documentNode, String state) throws RepositoryException {
-        String name = documentNode.getName();
-        Node document = documentNode.addNode(name);
-        document.setProperty("hippostd:state", state);
+    private Node getDocumentHandleWithVariant(Node documentVariant, String state) throws RepositoryException {
+        String name = documentVariant.getName();
+        Node handle = testFolder.addNode(name, "hippo:handle");
 
-        return document;
+        // create new variant
+        Node variant = handle.addNode(name, documentVariant.getPrimaryNodeType().getName());
+        variant.setProperty(HIPPOSTD_STATE, state);
+
+        // copy properties to variant
+        PropertyIterator properties = documentVariant.getProperties();
+        for (Property prop; properties.hasNext();) {
+            prop = properties.nextProperty();
+            variant.setProperty(prop.getName(), prop.getValue());
+        }
+
+        return handle;
     }
 
-    private List<Node> getQueryResults() throws RepositoryException {
+    private List<Node> getQueryResultsWithSingleExternalResource(String reference) {
+        System.out.println(reference);
         List<Node> nodes = new ArrayList<>();
+        Node resources;
 
-        Node node = rootNode
-            .addNode("resources")
-            .addNode("one");
-        node.setProperty(ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_REFERENCE, "the/one");
-
-        nodes.add(node);
+        try {
+            resources = rootNode.addNode("resources");
+            Node one = resources.addNode("one");
+            one.setProperty(ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_REFERENCE, reference);
+            nodes.add(one);
+        } catch (RepositoryException repositoryEx) {
+            throw new RuntimeException(repositoryEx);
+        }
 
         return nodes;
     }

--- a/cms/src/test/java/uk/nhs/digital/externalstorage/workflow/externalFileUnpublish/ExternalFileUnpublishTaskTest.java
+++ b/cms/src/test/java/uk/nhs/digital/externalstorage/workflow/externalFileUnpublish/ExternalFileUnpublishTaskTest.java
@@ -1,12 +1,19 @@
 package uk.nhs.digital.externalstorage.workflow.externalFileUnpublish;
 
+import static org.hippoecm.repository.HippoStdNodeType.HIPPOSTD_STATE;
+import static org.hippoecm.repository.HippoStdNodeType.NT_FOLDER;
 import static org.hippoecm.repository.HippoStdNodeType.PUBLISHED;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import org.apache.sling.testing.mock.jcr.MockJcr;
+import org.apache.sling.testing.mock.jcr.MockQueryResult;
+import org.apache.sling.testing.mock.jcr.MockQueryResultHandler;
 import org.hippoecm.repository.api.WorkflowContext;
 import org.hippoecm.repository.api.WorkflowException;
 import org.junit.Before;
@@ -15,10 +22,14 @@ import org.mockito.Mock;
 import org.onehippo.repository.documentworkflow.DocumentHandle;
 import uk.nhs.digital.externalstorage.ExternalStorageConstants;
 import uk.nhs.digital.externalstorage.s3.SchedulingS3Connector;
+import uk.nhs.digital.ps.PublicationSystemConstants;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.PropertyIterator;
 import javax.jcr.Repository;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
@@ -30,8 +41,9 @@ public class ExternalFileUnpublishTaskTest {
 
     private ExternalFileUnpublishTask externalFileUnpublishTask;
     private Session session;
-
     private Node rootNode;
+    private Node testFolder;
+    private final String testExternalReference = "ab/1c2d3e/one.pdf";
 
     @Before
     public void setUp() throws RepositoryException {
@@ -42,22 +54,67 @@ public class ExternalFileUnpublishTaskTest {
         Repository repository = MockJcr.newRepository();
         session = repository.login();
         rootNode = session.getRootNode();
+        testFolder = rootNode.addNode("lorem-ipsum", NT_FOLDER);
         externalFileUnpublishTask = new ExternalFileUnpublishTask();
-        externalFileUnpublishTask.setS3Connector(s3Connector);
 
         given(workflowContext.getInternalWorkflowSession()).willReturn(session);
         externalFileUnpublishTask.setWorkflowContext(workflowContext);
     }
 
     @Test
-    public void shouldCallS3() throws WorkflowException, RepositoryException {
-        Node docNode = rootNode.addNode("test-document");
-        addVariantNode(docNode, PUBLISHED);
-        MockJcr.setQueryResult(session, getQueryResults());
+    public void shouldUnpublishAnyDocumentResources() throws WorkflowException, RepositoryException {
+        Node document = getDocumentHandleWithVariant(getRandomDocumentType(), PUBLISHED);
+        MockJcr.addQueryResultHandler(session, searchResourcesHandle(getVariantPath(document), testExternalReference));
 
-        executeTask(docNode, externalFileUnpublishTask);
+        executeTask(document, externalFileUnpublishTask);
 
-        then(s3Connector).should().unpublishResource("the/one");
+        then(s3Connector).should().unpublishResource(testExternalReference);
+        then(s3Connector).should(never()).publishResource(anyString());
+    }
+
+    @Test
+    public void shouldUnpublishPublicationAndItsDatasetsResources() throws WorkflowException, RepositoryException {
+        // add Dataset to JCR
+        Node dataset = getDocumentHandleWithVariant(getDataset(), PUBLISHED);
+        Node publication = getDocumentHandleWithVariant(getPublication(), PUBLISHED);
+        String publicationResource = "ab/cdef12/publication-resource.pdf";
+
+        MockJcr.addQueryResultHandler(session, searchResourcesHandle(getVariantPath(dataset), testExternalReference));
+        MockJcr.addQueryResultHandler(session, searchResourcesHandle(getVariantPath(publication), publicationResource));
+
+        MockJcr.addQueryResultHandler(session, searchDatasetsHandle(dataset.getNode(dataset.getName())));
+
+        // when unpublishing upcoming publication
+        executeTask(publication, externalFileUnpublishTask);
+
+        // should be executed once for publication resource and once for dataset resource
+        then(s3Connector).should(times(1)).unpublishResource(testExternalReference);
+        then(s3Connector).should(times(1)).unpublishResource(publicationResource);
+        then(s3Connector).should(never()).publishResource(anyString());
+    }
+
+    private String getVariantPath(Node node) throws RepositoryException {
+        return node.getNode(node.getName()).getPath();
+    }
+
+    private MockQueryResultHandler searchResourcesHandle(final String nodePath, final String externalReference) {
+        return mockQuery -> {
+            String jcrSafeNodePath = org.apache.jackrabbit.util.Text.escapePath(nodePath);
+
+            if (mockQuery.getStatement().matches("SELECT \\* FROM \\[externalstorage:resource].*ISDESCENDANTNODE \\(\\['" + jcrSafeNodePath + "']\\).*")) {
+                return new MockQueryResult(getQueryResultsWithSingleExternalResource(externalReference));
+            }
+            return null;
+        };
+    }
+
+    private MockQueryResultHandler searchDatasetsHandle(Node dataset) {
+        return mockQuery -> {
+            if (mockQuery.getStatement().matches("SELECT \\* FROM \\[publicationsystem:dataset].*\\[hippostd:state]\\s*=\\s*'published'")) {
+                return new MockQueryResult(Arrays.asList(dataset));
+            }
+            return null;
+        };
     }
 
     private void executeTask(Node document, ExternalFileUnpublishTask task) throws WorkflowException {
@@ -78,15 +135,48 @@ public class ExternalFileUnpublishTaskTest {
         return document;
     }
 
-    private List<Node> getQueryResults() throws RepositoryException {
+    private Node getPublication() throws RepositoryException {
+        return rootNode.addNode("content", PublicationSystemConstants.NODE_TYPE_PUBLICATION);
+    }
+
+    private Node getRandomDocumentType() throws RepositoryException {
+        return rootNode.addNode("test-document", "lorem:ipsum");
+    }
+
+    private Node getDataset() throws RepositoryException {
+        return rootNode.addNode("test-document", PublicationSystemConstants.NODE_TYPE_DATASET);
+    }
+
+    private Node getDocumentHandleWithVariant(Node documentVariant, String state) throws RepositoryException {
+        String name = documentVariant.getName();
+        Node handle = testFolder.addNode(name, "hippo:handle");
+
+        // create new variant
+        Node variant = handle.addNode(name, documentVariant.getPrimaryNodeType().getName());
+        variant.setProperty(HIPPOSTD_STATE, state);
+
+        // copy properties to variant
+        PropertyIterator properties = documentVariant.getProperties();
+        for (Property prop; properties.hasNext();) {
+            prop = properties.nextProperty();
+            variant.setProperty(prop.getName(), prop.getValue());
+        }
+
+        return handle;
+    }
+
+    private List<Node> getQueryResultsWithSingleExternalResource(String reference) {
         List<Node> nodes = new ArrayList<>();
+        Node resources;
 
-        Node node = rootNode
-            .addNode("resources")
-            .addNode("one");
-        node.setProperty(ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_REFERENCE, "the/one");
-
-        nodes.add(node);
+        try {
+            resources = rootNode.addNode("resources");
+            Node one = resources.addNode("one");
+            one.setProperty(ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_REFERENCE, reference);
+            nodes.add(one);
+        } catch (RepositoryException repositoryEx) {
+            throw new RuntimeException(repositoryEx);
+        }
 
         return nodes;
     }

--- a/docs/what-if/deploy-to-test.md
+++ b/docs/what-if/deploy-to-test.md
@@ -1,6 +1,6 @@
 # What If I want to deploy to Test?
 
-## How to Deploy specific branch to Test Environment 
+## How to Deploy specific branch to Test Environment
 
 1. Get Rundek access first
 
@@ -18,13 +18,12 @@
 		export RD_AUTH_PROMPT=false
 		export RD_COLOR=0
 
-
-6. Checkout the branch you want to deploy 
+6. Checkout the branch you want to deploy
 
 		cd ci-cd
 
 		make clean build ondemand.upload ondemand.deploy ENV=tst RD_CONF=~/nhsd.rundec.env
 
-7. Now see the status here: 
+7. Now see the status here:
 
 		https://deploys.onehippo.com/project/nhs/activity


### PR DESCRIPTION
This change adds checks for publish and un-publish workflow tasks to
ensure that when:
* Publishing a data set document, we will only make its attachments
  public if its parent publication is "finalised".
* Publishing publication document, we will make its attachments public
  if it is "finalised". We will also find all data set documents
  belonging to that publication and make its attachments public.
* Publishing publication document we will make its attachments private
  if it is "upcoming". We will also find all data set documents
  belonging to that publication and make its attachments private.
* Un-publishing publication document, we will make its attachments
  private. We will also find all data set documents belonging to that
  publication and meke its attachments private.