### PR TITLE
[RPS-487] NPE in SearchTabsComponent

### DIFF
--- a/site/src/main/java/uk/nhs/digital/common/components/SearchComponent.java
+++ b/site/src/main/java/uk/nhs/digital/common/components/SearchComponent.java
@@ -72,16 +72,18 @@ public class SearchComponent extends CommonComponent {
 
         if (facetNavigationBean != null) {
             HippoResultSetBean resultSet = facetNavigationBean.getResultSet();
-            Pageable<HippoBean> pageable = getPageableFactory()
-                .createPageable(
-                    resultSet.getDocumentIterator(HippoBean.class),
-                    facetNavigationBean.getCount().intValue(),
-                    paramInfo.getPageSize(),
-                    getCurrentPage(request)
-                );
+            if (resultSet != null) {
+                Pageable<HippoBean> pageable = getPageableFactory()
+                    .createPageable(
+                        resultSet.getDocumentIterator(HippoBean.class),
+                        facetNavigationBean.getCount().intValue(),
+                        paramInfo.getPageSize(),
+                        getCurrentPage(request)
+                    );
 
-            request.setAttribute("pageable", pageable);
-            request.setAttribute("pageNumbers", getPageNumbers(pageable));
+                request.setAttribute("pageable", pageable);
+                request.setAttribute("pageNumbers", getPageNumbers(pageable));
+            }
         }
 
         request.setAttribute("query", getQueryParameter(request));


### PR DESCRIPTION
It appears that when the 'timeframe' facet is specified last
in the search URL and its value is the only one in the query that makes
it not match any documents, the resultSet returned from the
facetNavigationBean is null rather than empty. The null value was the
source of the offending exception seen in the logs.

There is now a null-check in place to prevent the exception from being
thrown.