### PR TITLE
[RPS-435] Extend code style checks to test code

### DIFF
--- a/.git-local/config
+++ b/.git-local/config
@@ -17,3 +17,6 @@
 
 	# delete branches that are gone from origin
 	delete-gone = "!f() { d=${1-origin/master}; git branch --merged \"$d\" -vv | grep ': gone]' | awk '{ print $1; }' | xargs git branch -d; }; f"
+
+[pull]
+    rebase = true

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/config/AcceptanceTestConfiguration.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/config/AcceptanceTestConfiguration.java
@@ -28,7 +28,7 @@ import java.nio.file.Paths;
 @Configuration
 public class AcceptanceTestConfiguration {
 
-    private final static Logger log = getLogger(AcceptanceTestConfiguration.class);
+    private static final Logger log = getLogger(AcceptanceTestConfiguration.class);
 
     @Bean
     public LoginPage loginPage(final WebDriverProvider webDriverProvider, PageHelper helper) {

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/config/AcceptanceTestProperties.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/config/AcceptanceTestProperties.java
@@ -42,10 +42,10 @@ public class AcceptanceTestProperties {
 
     @Override
     public String toString() {
-        return "AcceptanceTestProperties{" +
-            "headlessMode=" + headlessMode +
-            ", downloadDir=" + downloadDir +
-            ", tempDir=" + tempDir +
-            '}';
+        return "AcceptanceTestProperties{"
+            + "headlessMode=" + headlessMode
+            + ", downloadDir=" + downloadDir
+            + ", tempDir=" + tempDir
+            + '}';
     }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/data/ExpectedTestDataProvider.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/data/ExpectedTestDataProvider.java
@@ -108,12 +108,14 @@ public class ExpectedTestDataProvider {
                 .withPubliclyAccessible(true),
             newPublication()
                 .withTitle("publication with datasets")
-                .withSummary("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis convallis non massa vel " +
-                    "dictum. In vel ex sapien. Donec sit amet leo lobortis, tempor ex ut, luctus eros. In in eleifend" +
-                    " orci, nec suscipit nisi. Maecenas sed velit condimentum, lobortis tortor id, ultricies metus. " +
-                    "Integer odio ante, congue pulvinar ultrices nec, mollis vitae dolor. Curabitur euismod erat " +
-                    "elit, quis facilisis neque eleifend id. Maecenas convallis vel mi nec bibendum. Donec ut erat " +
-                    "dictum, molestie dolor non, aliquet nibh.")
+                .withSummary("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis"
+                    + " convallis non massa vel dictum. In vel ex sapien. Donec sit amet leo"
+                    + " lobortis, tempor ex ut, luctus eros. In in eleifend orci, nec suscipit nisi."
+                    + " Maecenas sed velit condimentum, lobortis tortor id, ultricies metus."
+                    + " Integer odio ante, congue pulvinar ultrices nec, mollis vitae dolor."
+                    + " Curabitur euismod erat elit, quis facilisis neque eleifend id."
+                    + " Maecenas convallis vel mi nec bibendum. Donec ut erat dictum, molestie dolor"
+                    + " non, aliquet nibh.")
                 .withNominalDate(asInstant("2020-10-11T00:00:00Z"))
                 .inState(PUBLISHED)
                 .withPubliclyAccessible(true)
@@ -151,30 +153,27 @@ public class ExpectedTestDataProvider {
                 "Image with link and caption",
                 "https://google.com/"),
             new TextSection("Second text section with body below",
-                "Far far away, behind the word mountains, far from the countries Vokalia and Consonantia, " +
-                    "there live the blind texts. Separated they live in Bookmarksgrove right at the coast of " +
-                    "the Semantics, a large language ocean. A small river named Duden flows by their place and" +
-                    " supplies it with the necessary regelialia. It is a paradisematic country, in which roasted" +
-                    " parts of sentences fly into your mouth. Even the all-powerful Pointing has no control about" +
-                    " the blind texts it is an almost unorthographic life One day however a small line of blind" +
-                    " text by the name of Lorem Ipsum decided to"),
+                "Far far away, behind the word mountains, far from the countries Vokalia and Consonantia, "
+                    + "there live the blind texts. Separated they live in Bookmarksgrove right at the coast of "
+                    + "the Semantics, a large language ocean. A small river named Duden flows by their place and"
+                    + " supplies it with the necessary regelialia. It is a paradisematic country, in which roasted"
+                    + " parts of sentences fly into your mouth. Even the all-powerful Pointing has no control about"
+                    + " the blind texts it is an almost unorthographic life One day however a small line of blind"
+                    + " text by the name of Lorem Ipsum decided to"),
             new TextSection(null,
-                "Body without heading. Convallis, nascetur. Pede tristique nam interdum augue euismod nibh " +
-                    "hendrerit. Ut. Condimentum libero facilisi sed. Inceptos natoque feugiat venenatis mattis " +
-                    "turpis leo platea est mollis quam pretium lacus hymenaeos metus ac. Convallis tristique. " +
-                    "Suscipit accumsan tempor ante natoque fermentum nisl, iaculis natoque molestie magna mattis" +
-                    " porttitor ligula Consequat mattis facilisis amet montes consequat vel dis class quisque netus" +
-                    " montes. Placerat nam bibendum libero consectetuer. Mattis aliquam. Consequat."),
+                "Body without heading. Convallis, nascetur. Pede tristique nam interdum augue euismod nibh "
+                    + "hendrerit. Ut. Condimentum libero facilisi sed. Inceptos natoque feugiat venenatis mattis "
+                    + "turpis leo platea est mollis quam pretium lacus hymenaeos metus ac. Convallis tristique. "
+                    + "Suscipit accumsan tempor ante natoque fermentum nisl, iaculis natoque molestie magna mattis"
+                    + " porttitor ligula Consequat mattis facilisis amet montes consequat vel dis class quisque netus"
+                    + " montes. Placerat nam bibendum libero consectetuer. Mattis aliquam. Consequat."),
             new ImageSection("sectioned publication snowman",
                 "Snowman",
                 null,
                 null),
-            new RelatedLinkSection("BBC Homepage",
-            "https://www.bbc.co.uk/"),
-            new RelatedLinkSection("Sky website",
-                "http://www.sky.com/")
+            new RelatedLinkSection("BBC Homepage", "https://www.bbc.co.uk/"),
+            new RelatedLinkSection("Sky website", "http://www.sky.com/")
         );
-
 
         return newPublication()
             .withTitle("Sectioned publication")

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/AttachmentBuilder.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/AttachmentBuilder.java
@@ -1,5 +1,7 @@
 package uk.nhs.digital.ps.test.acceptance.models;
 
+import static java.text.MessageFormat.format;
+
 import org.apache.commons.io.FilenameUtils;
 import uk.nhs.digital.ps.test.acceptance.util.FileHelper;
 
@@ -13,6 +15,17 @@ public class AttachmentBuilder {
     private FileType fileType;
     private byte[] content;
     private Path path;
+
+    private AttachmentBuilder() {
+        // no-op; made private to promote the use of factory methods
+    }
+
+    private AttachmentBuilder(final AttachmentBuilder original) {
+        name = original.getName();
+        fileType = original.getFileType();
+        content = original.getContent();
+        path = original.getPath();
+    }
 
     public static AttachmentBuilder newAttachment() {
         return new AttachmentBuilder();
@@ -36,6 +49,7 @@ public class AttachmentBuilder {
 
         return cloneAndAmend(builder -> builder.content = content);
     }
+    //</editor-fold>
 
     public AttachmentBuilder withFile(final Path path) {
 
@@ -54,7 +68,6 @@ public class AttachmentBuilder {
     public Path getPath() {
         return path;
     }
-    //</editor-fold>
 
     public Attachment build() {
         return new Attachment(this);
@@ -64,6 +77,7 @@ public class AttachmentBuilder {
     String getName() {
         return name;
     }
+    //</editor-fold>
 
     FileType getFileType() {
         return fileType;
@@ -71,18 +85,6 @@ public class AttachmentBuilder {
 
     byte[] getContent() {
         return content;
-    }
-    //</editor-fold>
-
-    private AttachmentBuilder() {
-        // no-op; made private to promote the use of factory methods
-    }
-
-    private AttachmentBuilder(final AttachmentBuilder original) {
-        name = original.getName();
-        fileType = original.getFileType();
-        content = original.getContent();
-        path = original.getPath();
     }
 
     private AttachmentBuilder cloneAndAmend(final PropertySetter propertySetter) {
@@ -93,17 +95,17 @@ public class AttachmentBuilder {
 
     private void vetSettingProperty(final String propertyName) {
         if (path != null) {
-            throw new IllegalStateException(MessageFormat.format(
-                "Setting of {0} is not permitted as this attachment is already backed by an actual file and " +
-                    "changing its {0} would leave it in inconsistent state. To set arbitrary {0} use use a builder " +
-                    "without the path set.", propertyName)
-            );
+            throw new IllegalStateException(format(
+                "Setting of {0} is not permitted as this attachment is already backed by an actual"
+                    + " file and changing its {0} would leave it in inconsistent state."
+                    + " To set arbitrary {0} use a builder without the path set.",
+                propertyName
+            ));
         }
     }
 
     @FunctionalInterface
     interface PropertySetter {
-
         void setProperties(AttachmentBuilder builder);
     }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/PublicationBuilder.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/PublicationBuilder.java
@@ -63,6 +63,7 @@ public class PublicationBuilder {
     public PublicationBuilder withAttachments(final List<AttachmentBuilder> attachmentBuilders) {
         return cloneAndAmend(builder -> builder.attachmentBuilders = attachmentBuilders);
     }
+
     public PublicationBuilder withAttachments(final AttachmentBuilder... attachmentBuilders) {
         return cloneAndAmend(builder -> builder.attachmentBuilders = asList(attachmentBuilders));
     }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/PublicationSeries.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/PublicationSeries.java
@@ -1,10 +1,10 @@
 package uk.nhs.digital.ps.test.acceptance.models;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static java.util.stream.Collectors.toList;
 import static uk.nhs.digital.ps.test.acceptance.models.PublicationState.PUBLISHED;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class PublicationSeries {
 

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/PublicationSeriesBuilder.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/PublicationSeriesBuilder.java
@@ -1,10 +1,10 @@
 package uk.nhs.digital.ps.test.acceptance.models;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @SuppressWarnings("WeakerAccess") // builder's methods are intentionally public
 public class PublicationSeriesBuilder {

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/Taxonomy.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/Taxonomy.java
@@ -16,6 +16,13 @@ public class Taxonomy {
         this.level3 = level3;
     }
 
+    /**
+     * @return New instance
+     */
+    public static Taxonomy createNew(final String level1, final String level2, final String level3) {
+        return new Taxonomy(level1, level2, level3);
+    }
+
     public String getLevel1() {
         return level1;
     }
@@ -28,29 +35,21 @@ public class Taxonomy {
         return level3;
     }
 
-    /**
-     * @return New instance
-     */
-    public static Taxonomy createNew(final String level1, final String level2, final String level3) {
-
-        return new Taxonomy(level1, level2, level3);
-
-    }
-
-    public String getTaxonomyContext(){
+    public String getTaxonomyContext() {
 
         String taxonomyContext = "";
 
-        if (!StringUtils.isBlank(level1)){
+        if (!StringUtils.isBlank(level1)) {
             taxonomyContext += level1;
         }
 
-        if (!StringUtils.isBlank(level2)){
+        if (!StringUtils.isBlank(level2)) {
             taxonomyContext += DELIMITER + level2;
         }
 
-        if (!StringUtils.isBlank(level3)){
-            taxonomyContext += DELIMITER + level3;}
+        if (!StringUtils.isBlank(level3)) {
+            taxonomyContext += DELIMITER + level3;
+        }
 
         return taxonomyContext;
     }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/section/RelatedLinkSection.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/section/RelatedLinkSection.java
@@ -3,8 +3,8 @@ package uk.nhs.digital.ps.test.acceptance.models.section;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
-import uk.nhs.digital.ps.test.acceptance.pages.widgets.SectionWidget;
 import uk.nhs.digital.ps.test.acceptance.pages.widgets.RelatedLinkSectionWidget;
+import uk.nhs.digital.ps.test.acceptance.pages.widgets.SectionWidget;
 
 public class RelatedLinkSection extends BodySection {
     private final String linkText;

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/AbstractCmsPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/AbstractCmsPage.java
@@ -4,7 +4,7 @@ import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverProvider;
 
 public class AbstractCmsPage extends AbstractPage {
 
-    static protected final String URL = "http://localhost:8080/cms";
+    protected static final String URL = "http://localhost:8080/cms";
 
     AbstractCmsPage(final WebDriverProvider webDriverProvider) {
         super(webDriverProvider);

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ContentPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ContentPage.java
@@ -199,7 +199,7 @@ public class ContentPage extends AbstractCmsPage {
         findSaveAndClose().click();
     }
 
-    public void publish(){
+    public void publish() {
         findPublicationMenu().click();
         findPublish().click();
 
@@ -222,11 +222,11 @@ public class ContentPage extends AbstractCmsPage {
         helper.findElement(By.xpath("//input[@type='submit' and @value='OK']")).click();
     }
 
-    public void cancelModalDialog(){
+    public void cancelModalDialog() {
         clickButtonOnModalDialog("Cancel");
     }
 
-    public void copyDocument(){
+    public void copyDocument() {
         findDocumentMenu().click();
         findCopy().click();
 
@@ -282,10 +282,9 @@ public class ContentPage extends AbstractCmsPage {
     }
 
     public WebElement getFolderMenuItem(String menuOption, String... folders) {
-        return helper.findOptionalChildElement(getFolderMenu(folders), By.cssSelector(
-            "span[title='" +
-                menuOption +
-                "']"));
+        return helper.findOptionalChildElement(getFolderMenu(folders),
+            By.cssSelector("span[title='" + menuOption + "']")
+        );
     }
 
     private WebElement getFolderMenu(String[] folders) {
@@ -391,7 +390,7 @@ public class ContentPage extends AbstractCmsPage {
         ) != null;
     }
 
-    public boolean isDocumentSaved(){
+    public boolean isDocumentSaved() {
         // When a document is saved, a yellow status bar appears informing user document is either offline
         // or a previous version is live
         return helper.assertElementPresent(By.className("hippo-toolbar-status"));
@@ -409,17 +408,20 @@ public class ContentPage extends AbstractCmsPage {
     }
 
     public void discardUnsavedChanges(String documentName) {
-        WebElement closeButton = helper.findElement(
-            By.xpath("//div[contains(@class, 'hippo-tabs-documents')]//a[contains(@class, 'hippo-tabs-documents-tab') and @title='" + documentName + "']/following-sibling::a[contains(@class, 'hippo-tabs-documents-close')]"));
+        WebElement closeButton = helper.findElement(By.xpath(
+            "//div[contains(@class, 'hippo-tabs-documents')]"
+                + "//a[contains(@class, 'hippo-tabs-documents-tab') and @title='" + documentName + "']"
+                + "/following-sibling::a[contains(@class, 'hippo-tabs-documents-close')]"
+        ));
         closeButton.click();
         clickButtonOnModalDialog("Discard");
     }
 
-    private void clickDocument(String name){
+    private void clickDocument(String name) {
         helper.findElement(By.xpath("//span[@class='hippo-document' and @title='" + name + "']")).click();
     }
 
-    private WebElement findPublicationMenu(){
+    private WebElement findPublicationMenu() {
         return helper.findElement(
             By.xpath(XpathSelectors.EDITOR_BODY + "//span[text()='Publication']"));
     }
@@ -434,12 +436,12 @@ public class ContentPage extends AbstractCmsPage {
             By.xpath(XpathSelectors.EDITOR_BODY + "//span[text()='Schedule publication...']"));
     }
 
-    private WebElement findDocumentMenu(){
+    private WebElement findDocumentMenu() {
         return helper.findElement(
             By.xpath(XpathSelectors.EDITOR_BODY + "//span[text()='Document']"));
     }
 
-    private WebElement findViewMenu(){
+    private WebElement findViewMenu() {
         return helper.findElement(
             By.xpath(XpathSelectors.EDITOR_BODY + "//span[text()='View']"));
     }
@@ -471,13 +473,14 @@ public class ContentPage extends AbstractCmsPage {
     private void clickButtonOnModalDialog(String buttonText) {
         try {
             clickButtonOnModalDialogOnce(buttonText);
-        } catch (TimeoutException e) {
+        } catch (TimeoutException exception) {
             clickButtonOnModalDialogOnce(buttonText);
         }
     }
+
     private void clickButtonOnModalDialogOnce(String buttonText) {
         helper.findElement(
-            By.xpath("//div[contains(@class, 'wicket-modal')]//input[@value='"+ buttonText +"']"))
+            By.xpath("//div[contains(@class, 'wicket-modal')]//input[@value='" + buttonText + "']"))
             .click();
 
         helper.waitForElementUntil(ExpectedConditions.invisibilityOfElementLocated(

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/LoginPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/LoginPage.java
@@ -54,7 +54,7 @@ public class LoginPage extends AbstractCmsPage {
         return helper.findChildElement(hippoLoginFeedbackPanel, By.tagName("span")).getText();
     }
 
-    public boolean isLoggedIn(){
+    public boolean isLoggedIn() {
         return findLogoutButton() != null;
     }
 

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/PageHelper.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/PageHelper.java
@@ -32,28 +32,28 @@ public class PageHelper {
         return firstOrNull(findElements(bySelector));
     }
 
-    public WebElement findChildElement(final WebElement parentElement, final By bySelector) {
-        return firstOrNull(findChildElements(parentElement, bySelector));
-    }
-
     public List<WebElement> findElements(By bySelector) {
         return findElements((by) -> getWebDriver().findElements(by), bySelector);
     }
 
-    public List<WebElement> findChildElements(final WebElement parentElement, final By bySelector) {
-        return findElements(parentElement::findElements, bySelector);
-    }
-
     private List<WebElement> findElements(final Function<By, List<WebElement>> findElements,
-                                          final By bySelector) {
+        final By bySelector) {
         try {
             return pollWithTimeout().until((WebDriver driver) -> {
                 List<WebElement> elements = findElements.apply(bySelector);
                 return isEmpty(elements) ? null : elements;
             });
-        } catch (TimeoutException e){
-            throw new RuntimeException("Failed to find element matching '" + bySelector + "'", e);
+        } catch (TimeoutException exception) {
+            throw new RuntimeException("Failed to find element matching '" + bySelector + "'", exception);
         }
+    }
+
+    public WebElement findChildElement(final WebElement parentElement, final By bySelector) {
+        return firstOrNull(findChildElements(parentElement, bySelector));
+    }
+
+    public List<WebElement> findChildElements(final WebElement parentElement, final By bySelector) {
+        return findElements(parentElement::findElements, bySelector);
     }
 
     public void waitUntilTrue(final Predicate predicate) {
@@ -61,7 +61,7 @@ public class PageHelper {
         pollWithTimeout().until(webDriver -> {
             try {
                 return predicate.executeWithPredicate();
-            } catch (final Exception e) {
+            } catch (final Exception exception) {
                 return false;
             }
         });
@@ -76,12 +76,12 @@ public class PageHelper {
                 try {
                     task.execute();
                     return true;
-                } catch (final Exception e) {
-                    lastException.set(e);
+                } catch (final Exception exception) {
+                    lastException.set(exception);
                     return false;
                 }
             });
-        } catch (final TimeoutException e) { // ignore TimeoutException
+        } catch (final TimeoutException exception) { // ignore TimeoutException
             throw new RuntimeException("Failed to execute task within timeout.", lastException.get());
         }
     }
@@ -89,8 +89,8 @@ public class PageHelper {
     public void waitUntilVisible(WebElement webElement) {
         try {
             pollWithTimeout().until((WebDriver innerDriver) -> webElement.isDisplayed());
-        } catch (TimeoutException e){
-            throw new RuntimeException("Timeout while waiting for element to become visible: '" + webElement + "'", e);
+        } catch (TimeoutException exception) {
+            throw new RuntimeException("Timeout while waiting for element to become visible: '" + webElement + "'", exception);
         }
     }
 

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/XpathSelectors.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/XpathSelectors.java
@@ -2,15 +2,25 @@ package uk.nhs.digital.ps.test.acceptance.pages;
 
 public class XpathSelectors  {
 
-    /** This is the dark gray left menu with links to: Dashboard, Channels, Content, ... */
-    public final static String TABBED_PANEL = "//div[contains(@class, 'tabbed-panel-layout-left')]";
+    /**
+     * This is the dark gray left menu with links to: Dashboard, Channels, Content, ...
+     */
+    public static final String TABBED_PANEL = "//div[contains(@class, 'tabbed-panel-layout-left')]";
 
-    /** This is the navigation pane with documents */
-    public final static String NAVIGATION_CENTRE = "//div[@class='navigator-center-body']";
+    /**
+     * This is the navigation pane with documents
+     */
+    public static final String NAVIGATION_CENTRE = "//div[@class='navigator-center-body']";
 
-    /** This is the navigation pane with folders */
-    public final static String NAVIGATION_LEFT = "//div[@class='navigator-left-body']";
+    /**
+     * This is the navigation pane with folders
+     */
+    public static final String NAVIGATION_LEFT = "//div[@class='navigator-left-body']";
 
-    public final static String EDITOR_BODY = "//div[contains(@class, 'browse-perspective-center-body')]//div[contains(@style, 'block')]//div[contains(@class, 'hippo-editor') and contains(@class, 'perspective')]";
-    public final static String TAXONOMY_PICKER = "//div[contains(@class, 'wicket-modal') and contains(@aria-labelledby, 'Taxonomy picker')]";
+    public static final String EDITOR_BODY =
+        "//div[contains(@class, 'browse-perspective-center-body')]"
+            + "//div[contains(@style, 'block')]"
+            + "//div[contains(@class, 'hippo-editor') and contains(@class, 'perspective')]";
+
+    public static final String TAXONOMY_PICKER = "//div[contains(@class, 'wicket-modal') and contains(@aria-labelledby, 'Taxonomy picker')]";
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/CommonPageElements.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/CommonPageElements.java
@@ -9,13 +9,15 @@ import java.util.Map;
 
 public class CommonPageElements implements PageElements {
 
-    private final static Map<String, By> pageElements = new HashMap<String, By>() {{
-        put("Search Box",
-            By.xpath("//input[@name='query']"));
-        put("Pagination page",
-            By.xpath("//li[contains(@class, " +
-            "'pagination__list__item pagination__list__item--current')]/span"));
-    }};
+    private static final Map<String, By> pageElements = new HashMap<String, By>() {
+        {
+            put("Search Box",
+                By.xpath("//input[@name='query']"));
+            put("Pagination page",
+                By.xpath(
+                    "//li[contains(@class, 'pagination__list__item pagination__list__item--current')]/span"));
+        }
+    };
 
     @Override
     public boolean contains(String elementName) {

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/HomePage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/HomePage.java
@@ -4,7 +4,7 @@ import org.openqa.selenium.By;
 import uk.nhs.digital.ps.test.acceptance.pages.PageHelper;
 import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverProvider;
 
-public class HomePage extends AbstractSitePage{
+public class HomePage extends AbstractSitePage {
 
     private PageHelper helper;
 
@@ -14,77 +14,55 @@ public class HomePage extends AbstractSitePage{
         this.helper = helper;
     }
 
-    public String getPageTitle(){
+    public String getPageTitle() {
         return getWebDriver().getTitle();
     }
 
     public String findPageElement(String elementName) {
-        if(elementName.toLowerCase().equals("top label")) {
+        if (elementName.toLowerCase().equals("top label")) {
             return getWebDriver().findElement(By.xpath("html/body/header/div/div/section/div/p")).getText();
-        }
-        else if(elementName.toLowerCase().equals("search")){
+        } else if (elementName.toLowerCase().equals("search")) {
             return getWebDriver().findElement(By.xpath("html/body/header/div/div/section/div/form/div[2]/button")).getText();
-        }
-        else if(elementName.toLowerCase().equals("data and information")){
+        } else if (elementName.toLowerCase().equals("data and information")) {
             return getWebDriver().findElement(By.xpath("html/body/main/div/div/div[1]/div[1]/h2")).getText();
-        }
-        else if(elementName.toLowerCase().equals("systems and services")){
+        } else if (elementName.toLowerCase().equals("systems and services")) {
             return getWebDriver().findElement(By.xpath("html/body/main/div/div/div[2]/div[1]/h2")).getText();
-        }
-        else if(elementName.toLowerCase().equals("find data and information")) {
+        } else if (elementName.toLowerCase().equals("find data and information")) {
             return getWebDriver().findElement(By.xpath("html/body/main/div/div/div[1]/div[2]/div/div[1]/div/div/div[1]/div/h3")).getText();
-        }
-        else if(elementName.toLowerCase().equals("indicator library")) {
+        } else if (elementName.toLowerCase().equals("indicator library")) {
             return getWebDriver().findElement(By.xpath("html/body/main/div/div/div[1]/div[2]/div/div[1]/div/div/div[2]/div/h3")).getText();
-        }
-        else if(elementName.toLowerCase().equals("data and information summary")) {
+        } else if (elementName.toLowerCase().equals("data and information summary")) {
             return getWebDriver().findElement(By.xpath("html/body/main/div/div/div[1]/div[2]/div/div[1]/div/div/div[1]/div/p")).getText();
-        }
-        else if(elementName.toLowerCase().equals("see all data and publications")) {
+        } else if (elementName.toLowerCase().equals("see all data and publications")) {
             return getWebDriver().findElement(By.xpath("html/body/main/div/div/div[1]/div[2]/div/div[1]/div/div/div[1]/div/a")).getText();
-        }
-        else if(elementName.toLowerCase().equals("view indicator library")) {
+        } else if (elementName.toLowerCase().equals("view indicator library")) {
             return getWebDriver().findElement(By.xpath("html/body/main/div/div/div[1]/div[2]/div/div[1]/div/div/div[2]/div/a")).getText();
-        }
-        else if(elementName.toLowerCase().equals("latest publications")) {
+        } else if (elementName.toLowerCase().equals("latest publications")) {
             return getWebDriver().findElement(By.xpath("html/body/main/div/div/div[1]/div[2]/div/div[2]/div/div[1]/div/h3")).getText();
-        }
-        else if(elementName.toLowerCase().equals("systems and services")) {
+        } else if (elementName.toLowerCase().equals("systems and services")) {
             return getWebDriver().findElement(By.xpath("html/body/main/div/div/div[3]/div[1]/h2")).getText();
-        }
-        else if(elementName.toLowerCase().equals("systems and services summary")) {
+        } else if (elementName.toLowerCase().equals("systems and services summary")) {
             return getWebDriver().findElement(By.xpath("html/body/main/div/div/div[2]/div[1]/p")).getText();
-        }
-        else if(elementName.toLowerCase().equals("most popular services")) {
+        } else if (elementName.toLowerCase().equals("most popular services")) {
             return getWebDriver().findElement(By.xpath("html/body/main/div/div/div[2]/div[2]/div/div/div[1]/div[1]/div/h3")).getText();
-        }
-        else if(elementName.toLowerCase().equals("view all services")) {
+        } else if (elementName.toLowerCase().equals("view all services")) {
             return getWebDriver().findElement(By.xpath("html/body/main/div/div/div[2]/div[2]/div/div/div[2]/div/a")).getText();
-        }
-        else if(elementName.toLowerCase().equals("latest news")) {
+        } else if (elementName.toLowerCase().equals("latest news")) {
             return getWebDriver().findElement(By.xpath("html/body/main/div/div/div[3]/div[2]/div/div[2]/div/div/h3")).getText();
-        }
-        else if(elementName.toLowerCase().equals("view all news")) {
+        } else if (elementName.toLowerCase().equals("view all news")) {
             return getWebDriver().findElement(By.xpath("html/body/main/div/div/div[3]/div[2]/div/div[2]/div/div/a")).getText();
-        }
-        else if(elementName.toLowerCase().equals("upcoming events")) {
+        } else if (elementName.toLowerCase().equals("upcoming events")) {
             return getWebDriver().findElement(By.xpath("html/body/main/div/div/div[3]/div[2]/div/div[3]/div/div/h3")).getText();
-        }
-        else if(elementName.toLowerCase().equals("view all events")) {
+        } else if (elementName.toLowerCase().equals("view all events")) {
             return getWebDriver().findElement(By.xpath("html/body/main/div/div/div[3]/div[2]/div/div[3]/div/div/a")).getText();
-        }
-        else if(elementName.toLowerCase().equals("how we look after your information")) {
+        } else if (elementName.toLowerCase().equals("how we look after your information")) {
             return getWebDriver().findElement(By.xpath("html/body/main/div/div/div[4]/div/div/div/div/div[1]/div/h3")).getText();
-        }
-        else if(elementName.toLowerCase().equals("find out how we look after your information")) {
+        } else if (elementName.toLowerCase().equals("find out how we look after your information")) {
             return getWebDriver().findElement(By.xpath("html/body/main/div/div/div[4]/div/div/div/div/div[2]/div[1]/div/a")).getText();
-        }
-        else if(elementName.toLowerCase().equals("about us")) {
+        } else if (elementName.toLowerCase().equals("about us")) {
             return getWebDriver().findElement(By.xpath("html/body/main/div/div/div[3]/div[1]/h2")).getText();
-        }
-        else{
+        } else {
             return "No element found! or please check whether expected sections are with uppercases";
         }
     }
-
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ServicePage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ServicePage.java
@@ -4,7 +4,7 @@ import org.openqa.selenium.By;
 import uk.nhs.digital.ps.test.acceptance.pages.PageHelper;
 import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverProvider;
 
-public class ServicePage extends AbstractSitePage{
+public class ServicePage extends AbstractSitePage {
 
     private PageHelper helper;
 
@@ -14,39 +14,27 @@ public class ServicePage extends AbstractSitePage{
         this.helper = helper;
     }
 
-    public String getPageTitle(){
+    public String getPageTitle() {
         return getWebDriver().findElement(By.xpath("html/body/article/div/div[1]/h1")).getText();
     }
 
     public String findPageElement(String elementName) {
-        if(elementName.toLowerCase().equals("summary")) {
+        if (elementName.toLowerCase().equals("summary")) {
             return getWebDriver().findElement(By.xpath(".//*[@id='section-summary']/p")).getText();
-        }
-        else if(elementName.toLowerCase().equals("top tasks")){
+        } else if (elementName.toLowerCase().equals("top tasks")) {
             return getWebDriver().findElement(By.xpath("html/body/article/div/div[2]/div[2]/section[2]/div/p[1]")).getText();
-        }
-        else if(elementName.toLowerCase().equals("introduction")){
+        } else if (elementName.toLowerCase().equals("introduction")) {
             return getWebDriver().findElement(By.xpath("html/body/article/div/div[2]/div[2]/div/p")).getText();
-        }
-        else if(elementName.toLowerCase().equals("body section 1")){
+        } else if (elementName.toLowerCase().equals("body section 1")) {
             return getWebDriver().findElement(By.xpath(".//*[@id='section-1']/h2")).getText();
-        }
-        else if(elementName.toLowerCase().equals("body section 2")){
+        } else if (elementName.toLowerCase().equals("body section 2")) {
             return getWebDriver().findElement(By.xpath(".//*[@id='section-2']/h2")).getText();
-        }
-        else if(elementName.toLowerCase().equals("further information")){
+        } else if (elementName.toLowerCase().equals("further information")) {
             return getWebDriver().findElement(By.xpath(".//*[@id='section-child-pages']/ol/li/article/h2/a")).getText();
-        }
-        else if(elementName.toLowerCase().equals("page contents")){
+        } else if (elementName.toLowerCase().equals("page contents")) {
             return getWebDriver().findElement(By.xpath("html/body/article/div/div[2]/div[1]/div/nav/ol/li[1]/a")).getText();
-        }
-
-        else{
+        } else {
             return "No element found!";
         }
     }
-
-
-
-
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ServicePageElements.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ServicePageElements.java
@@ -10,11 +10,13 @@ import java.util.Map;
 
 public class ServicePageElements implements PageElements {
 
-    private final static Map<String, By> pageElements = new HashMap<String, By>() {{
-        put("Summary",
-            By.cssSelector("#section-summary>p"));
+    private static final Map<String, By> pageElements = new HashMap<String, By>() {
+        {
+            put("Summary",
+                By.cssSelector("#section-summary>p"));
 
-    }};
+        }
+    };
 
     @Override
     public boolean contains(String elementName) {

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/nil/IndicatorPageElements.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/nil/IndicatorPageElements.java
@@ -11,12 +11,18 @@ import java.util.Map;
 
 public class IndicatorPageElements implements PageElements {
 
-    private final static Map<String, By> pageElements = new HashMap<String, By>() {{
-        put("Indicator Title",
-            By.xpath("//*[" + getDataUiPathXpath("title") + "]"));
-        put("Indicator Summary",
-            By.xpath("//p[" + getDataUiPathXpath("summary") + "]"));
-    }};
+    private static final Map<String, By> pageElements = new HashMap<String, By>() {
+        {
+            put("Indicator Title",
+                By.xpath("//*[" + getDataUiPathXpath("title") + "]"));
+            put("Indicator Summary",
+                By.xpath("//p[" + getDataUiPathXpath("summary") + "]"));
+        }
+    };
+
+    private static String getDataUiPathXpath(String fieldName) {
+        return "@data-uipath='ps.indicator." + fieldName + "'";
+    }
 
     @Override
     public boolean contains(String elementName) {
@@ -37,9 +43,5 @@ public class IndicatorPageElements implements PageElements {
         }
 
         return elements.get(nth);
-    }
-
-    private static String getDataUiPathXpath(String fieldName) {
-        return "@data-uipath='ps.indicator." + fieldName + "'";
     }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ps/ArchivePageElements.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ps/ArchivePageElements.java
@@ -11,12 +11,18 @@ import java.util.Map;
 
 public class ArchivePageElements implements PageElements {
 
-    private final static Map<String, By> pageElements = new HashMap<String, By>() {{
-        put("Archive Title",
-            By.xpath("//*[" + getDataUiPathXpath("title") + "]"));
-        put("Archive Summary",
-            By.xpath("//p[" + getDataUiPathXpath("summary") + "]"));
-    }};
+    private static final Map<String, By> pageElements = new HashMap<String, By>() {
+        {
+            put("Archive Title",
+                By.xpath("//*[" + getDataUiPathXpath("title") + "]"));
+            put("Archive Summary",
+                By.xpath("//p[" + getDataUiPathXpath("summary") + "]"));
+        }
+    };
+
+    private static String getDataUiPathXpath(String fieldName) {
+        return "@data-uipath='ps.archive." + fieldName + "'";
+    }
 
     @Override
     public boolean contains(String elementName) {
@@ -37,9 +43,5 @@ public class ArchivePageElements implements PageElements {
         }
 
         return elements.get(nth);
-    }
-
-    private static String getDataUiPathXpath(String fieldName) {
-        return "@data-uipath='ps.archive." + fieldName + "'";
     }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ps/DatasetPageElements.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ps/DatasetPageElements.java
@@ -11,24 +11,30 @@ import java.util.Map;
 
 public class DatasetPageElements implements PageElements {
 
-    private final static Map<String, By> pageElements = new HashMap<String, By>() {{
-        put("Dataset Title",
-            By.xpath("//*[" + getDataUiPathXpath("title") + "]"));
-        put("Dataset Summary",
-            By.xpath("//*[" + getDataUiPathXpath("summary") + "]"));
-        put("Dataset Granularity",
-            By.xpath("//*[" + getDataUiPathXpath("granularity") + "]"));
-        put("Dataset Geographic Coverage",
-            By.xpath("//*[" + getDataUiPathXpath("geographic-coverage") + "]"));
-        put("Dataset Date Range",
-            By.xpath("//*[" + getDataUiPathXpath("date-range") + "]"));
-        put("Dataset Resources",
-            By.xpath("//*[" + getDataUiPathXpath("resources") + "]"));
-        put("Dataset Nominal Date",
-            By.xpath("//*[" + getDataUiPathXpath("nominal-date") + "]"));
-        put("Dataset Next Publication Date",
-            By.xpath("//*[" + getDataUiPathXpath("next-publication-date") + "]"));
-    }};
+    private static final Map<String, By> pageElements = new HashMap<String, By>() {
+        {
+            put("Dataset Title",
+                By.xpath("//*[" + getDataUiPathXpath("title") + "]"));
+            put("Dataset Summary",
+                By.xpath("//*[" + getDataUiPathXpath("summary") + "]"));
+            put("Dataset Granularity",
+                By.xpath("//*[" + getDataUiPathXpath("granularity") + "]"));
+            put("Dataset Geographic Coverage",
+                By.xpath("//*[" + getDataUiPathXpath("geographic-coverage") + "]"));
+            put("Dataset Date Range",
+                By.xpath("//*[" + getDataUiPathXpath("date-range") + "]"));
+            put("Dataset Resources",
+                By.xpath("//*[" + getDataUiPathXpath("resources") + "]"));
+            put("Dataset Nominal Date",
+                By.xpath("//*[" + getDataUiPathXpath("nominal-date") + "]"));
+            put("Dataset Next Publication Date",
+                By.xpath("//*[" + getDataUiPathXpath("next-publication-date") + "]"));
+        }
+    };
+
+    private static String getDataUiPathXpath(String fieldName) {
+        return "@data-uipath='ps.dataset." + fieldName + "'";
+    }
 
     @Override
     public boolean contains(String elementName) {
@@ -49,10 +55,6 @@ public class DatasetPageElements implements PageElements {
         }
 
         return elements.get(nth);
-    }
-
-    private static String getDataUiPathXpath(String fieldName) {
-        return "@data-uipath='ps.dataset." + fieldName + "'";
     }
 
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ps/PublicationPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ps/PublicationPage.java
@@ -2,7 +2,18 @@ package uk.nhs.digital.ps.test.acceptance.pages.site.ps;
 
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
-import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.*;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.ADMINISTRATIVE_SOURCES;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.BODY;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.DATA_SETS;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.DATE_RANGE;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.GEOGRAPHIC_COVERAGE;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.GRANULARITY;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.INFORMATION_TYPES;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.KEY_FACTS;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.NOMINAL_PUBLICATION_DATE;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.RESOURCES;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.SUMMARY;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.UPCOMING_DISCLAIMER;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -12,9 +23,9 @@ import uk.nhs.digital.ps.test.acceptance.pages.site.AbstractSitePage;
 import uk.nhs.digital.ps.test.acceptance.pages.site.PageElements;
 import uk.nhs.digital.ps.test.acceptance.pages.widgets.AttachmentWidget;
 import uk.nhs.digital.ps.test.acceptance.pages.widgets.ImageSectionWidget;
+import uk.nhs.digital.ps.test.acceptance.pages.widgets.RelatedLinkSectionWidget;
 import uk.nhs.digital.ps.test.acceptance.pages.widgets.SectionWidget;
 import uk.nhs.digital.ps.test.acceptance.pages.widgets.TextSectionWidget;
-import uk.nhs.digital.ps.test.acceptance.pages.widgets.RelatedLinkSectionWidget;
 import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverProvider;
 
 import java.util.Collection;

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ps/PublicationPageElements.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ps/PublicationPageElements.java
@@ -1,6 +1,19 @@
 package uk.nhs.digital.ps.test.acceptance.pages.site.ps;
 
-import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.*;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.ADMINISTRATIVE_SOURCES;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.BODY;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.DATA_SETS;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.DATE_RANGE;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.GEOGRAPHIC_COVERAGE;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.GRANULARITY;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.INFORMATION_TYPES;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.KEY_FACTS;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.NOMINAL_PUBLICATION_DATE;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.PUBLICATION_TITLE;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.RELATED_LINKS;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.RESOURCES;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.SUMMARY;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.ps.PublicationPageElements.FieldKeys.UPCOMING_DISCLAIMER;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -13,36 +26,46 @@ import java.util.Map;
 
 public class PublicationPageElements implements PageElements {
 
-    private final static Map<String, By> pageElements = new HashMap<String, By>() {{
-        put(PUBLICATION_TITLE,
-            By.xpath("//*[" + getDataUiPathXpath("title") + "]"));
-        put(NOMINAL_PUBLICATION_DATE,
-            By.xpath("//*[" + getDataUiPathXpath("nominal-publication-date") + "]"));
-        put(UPCOMING_DISCLAIMER,
-            By.xpath("//*[" + getDataUiPathXpath("upcoming-disclaimer") + "]"));
-        put(SUMMARY,
-            By.xpath("//*[" + getDataUiPathXpath("summary") + "]"));
-        put(GEOGRAPHIC_COVERAGE,
-            By.xpath("//*[" + getDataUiPathXpath("geographic-coverage") + "]"));
-        put(GRANULARITY,
-            By.xpath("//*[" + getDataUiPathXpath("granularity") + "]"));
-        put(DATE_RANGE,
-            By.xpath("//*[" + getDataUiPathXpath("date-range") + "]"));
-        put(INFORMATION_TYPES,
-            By.xpath("//*[" + getDataUiPathXpath("information-types") + "]"));
-        put(KEY_FACTS,
-            By.xpath("//*[" + getDataUiPathXpath("key-facts") + "]"));
-        put(RESOURCES,
-            By.xpath("//*[" + getDataUiPathXpath("resources") + "]"));
-        put(DATA_SETS,
-            By.xpath("//*[" + getDataUiPathXpath("datasets") + "]"));
-        put(RELATED_LINKS,
-            By.xpath("//*[" + getDataUiPathXpath("related-links") + "]"));
-        put(ADMINISTRATIVE_SOURCES,
-            By.xpath("//*[" + getDataUiPathXpath("administrative-sources") + "]"));
-        put(BODY,
-            By.xpath("//*[" + getDataUiPathXpath("body") + "]"));
-    }};
+    private static final Map<String, By> pageElements = new HashMap<String, By>() {
+        {
+            put(PUBLICATION_TITLE,
+                By.xpath("//*[" + getDataUiPathXpath("title") + "]"));
+            put(NOMINAL_PUBLICATION_DATE,
+                By.xpath("//*[" + getDataUiPathXpath("nominal-publication-date") + "]"));
+            put(UPCOMING_DISCLAIMER,
+                By.xpath("//*[" + getDataUiPathXpath("upcoming-disclaimer") + "]"));
+            put(SUMMARY,
+                By.xpath("//*[" + getDataUiPathXpath("summary") + "]"));
+            put(GEOGRAPHIC_COVERAGE,
+                By.xpath("//*[" + getDataUiPathXpath("geographic-coverage") + "]"));
+            put(GRANULARITY,
+                By.xpath("//*[" + getDataUiPathXpath("granularity") + "]"));
+            put(DATE_RANGE,
+                By.xpath("//*[" + getDataUiPathXpath("date-range") + "]"));
+            put(INFORMATION_TYPES,
+                By.xpath("//*[" + getDataUiPathXpath("information-types") + "]"));
+            put(KEY_FACTS,
+                By.xpath("//*[" + getDataUiPathXpath("key-facts") + "]"));
+            put(RESOURCES,
+                By.xpath("//*[" + getDataUiPathXpath("resources") + "]"));
+            put(DATA_SETS,
+                By.xpath("//*[" + getDataUiPathXpath("datasets") + "]"));
+            put(RELATED_LINKS,
+                By.xpath("//*[" + getDataUiPathXpath("related-links") + "]"));
+            put(ADMINISTRATIVE_SOURCES,
+                By.xpath("//*[" + getDataUiPathXpath("administrative-sources") + "]"));
+            put(BODY,
+                By.xpath("//*[" + getDataUiPathXpath("body") + "]"));
+        }
+    };
+
+    public static By getFieldSelector(final String fieldSelectorKey) {
+        return pageElements.get(fieldSelectorKey);
+    }
+
+    private static String getDataUiPathXpath(String fieldName) {
+        return "@data-uipath='ps.publication." + fieldName + "'";
+    }
 
     @Override
     public boolean contains(String elementName) {
@@ -64,15 +87,8 @@ public class PublicationPageElements implements PageElements {
         return elements.get(nth);
     }
 
-    public static By getFieldSelector(final String fieldSelectorKey) {
-        return pageElements.get(fieldSelectorKey);
-    }
-
-    private static String getDataUiPathXpath(String fieldName) {
-        return "@data-uipath='ps.publication." + fieldName + "'";
-    }
-
     interface FieldKeys {
+
         String PUBLICATION_TITLE = "Publication Title";
         String NOMINAL_PUBLICATION_DATE = "Publication Date";
         String UPCOMING_DISCLAIMER = "Upcoming Disclaimer";

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ps/SeriesPageElements.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ps/SeriesPageElements.java
@@ -11,22 +11,28 @@ import java.util.Map;
 
 public class SeriesPageElements implements PageElements {
 
-    private final static Map<String, By> pageElements = new HashMap<String, By>() {{
-        put("Series Title",
-            By.xpath("//*[" + getDataUiPathXpath("title") + "]"));
-        put("Series Summary",
-            By.xpath("//p[" + getDataUiPathXpath("summary") + "]"));
-        put("Series Granularity",
-            By.xpath("//*[" + getDataUiPathXpath("granularity") + "]"));
-        put("Series Geographic Coverage",
-            By.xpath("//*[" + getDataUiPathXpath("geographic-coverage") + "]"));
-        put("Series Latest Publication",
-            By.xpath("//*[" + getDataUiPathXpath("publications-list.latest") + "]"));
-        put("Series Previous Publications",
-            By.xpath("//*[" + getDataUiPathXpath("publications-list.previous") + "]"));
-        put("Series Publications",
-            By.xpath("//*[" + getDataUiPathXpath("publications-list") + "]"));
-    }};
+    private static final Map<String, By> pageElements = new HashMap<String, By>() {
+        {
+            put("Series Title",
+                By.xpath("//*[" + getDataUiPathXpath("title") + "]"));
+            put("Series Summary",
+                By.xpath("//p[" + getDataUiPathXpath("summary") + "]"));
+            put("Series Granularity",
+                By.xpath("//*[" + getDataUiPathXpath("granularity") + "]"));
+            put("Series Geographic Coverage",
+                By.xpath("//*[" + getDataUiPathXpath("geographic-coverage") + "]"));
+            put("Series Latest Publication",
+                By.xpath("//*[" + getDataUiPathXpath("publications-list.latest") + "]"));
+            put("Series Previous Publications",
+                By.xpath("//*[" + getDataUiPathXpath("publications-list.previous") + "]"));
+            put("Series Publications",
+                By.xpath("//*[" + getDataUiPathXpath("publications-list") + "]"));
+        }
+    };
+
+    private static String getDataUiPathXpath(String fieldName) {
+        return "@data-uipath='ps.series." + fieldName + "'";
+    }
 
     @Override
     public boolean contains(String elementName) {
@@ -47,9 +53,5 @@ public class SeriesPageElements implements PageElements {
         }
 
         return elements.get(nth);
-    }
-
-    private static String getDataUiPathXpath(String fieldName) {
-        return "@data-uipath='ps.series." + fieldName + "'";
     }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/widgets/AttachmentsCmsWidget.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/widgets/AttachmentsCmsWidget.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 public class AttachmentsCmsWidget {
 
-    private final static Logger log = getLogger(AttachmentsCmsWidget.class);
+    private static final Logger log = getLogger(AttachmentsCmsWidget.class);
 
     private final PageHelper helper;
     private WebDriver webDriver;

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/widgets/GeographicCoverageCmsWidget.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/widgets/GeographicCoverageCmsWidget.java
@@ -12,13 +12,15 @@ import uk.nhs.digital.ps.test.acceptance.pages.XpathSelectors;
 public class GeographicCoverageCmsWidget {
 
     /**
-     * Targets 'parent' div that _contains_ an 'h3/span' child elements, where the <span> has text 'Geographic Coverage'
+     * Targets 'parent' div that _contains_ an 'h3/span' child elements, where the {@code <span>} has text 'Geographic Coverage'
      * this is so that further searches can be performed in context of the root element.
      */
     private static final String ROOT_ELEMENT_XPATH = XpathSelectors.EDITOR_BODY
         + "//span[text()='Geographic Coverage']/ancestor::div[contains(@class, 'hippo-editor-field')]";
 
-    /** Targets drop-down's {@code <select>} element. */
+    /**
+     * Targets drop-down's {@code <select>} element.
+     */
     private static final String DROPDOWN_XPATH = ROOT_ELEMENT_XPATH + "//select[contains(@class, 'dropdown-plugin')]";
 
     private final PageHelper helper;

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/widgets/GranularityCmsWidget.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/widgets/GranularityCmsWidget.java
@@ -12,13 +12,15 @@ import uk.nhs.digital.ps.test.acceptance.pages.XpathSelectors;
 public class GranularityCmsWidget {
 
     /**
-     * Targets 'parent' div that _contains_ an 'h3/span' child elements, where the <span> has text 'Granularity'
+     * Targets 'parent' div that _contains_ an 'h3/span' child elements, where the {@code <span>} has text 'Granularity'
      * this is so that further searches can be performed in context of the root element.
      */
     private static final String ROOT_ELEMENT_XPATH = XpathSelectors.EDITOR_BODY
         + "//span[text()='Granularity']/ancestor::div[contains(@class, 'hippo-editor-field')]";
 
-    /** Targets drop-down's {@code <select>} element. */
+    /**
+     * Targets drop-down's {@code <select>} element.
+     */
     private static final String DROPDOWN_XPATH = ROOT_ELEMENT_XPATH + "//select[contains(@class, 'dropdown-plugin')]";
 
     private final PageHelper helper;

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/widgets/InformationTypeCmsWidget.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/widgets/InformationTypeCmsWidget.java
@@ -12,13 +12,15 @@ import uk.nhs.digital.ps.test.acceptance.pages.XpathSelectors;
 public class InformationTypeCmsWidget {
 
     /**
-     * Targets 'parent' div that _contains_ an 'h3/span' child elements, where the <span> has text 'Information Type'
+     * Targets 'parent' div that _contains_ an 'h3/span' child elements, where the {@code <span>} has text 'Information Type'
      * this is so that further searches can be performed in context of the root element.
      */
     private static final String ROOT_ELEMENT_XPATH = XpathSelectors.EDITOR_BODY
         + "//span[text()='Information Type']/ancestor::div[contains(@class, 'hippo-editor-field')]";
 
-    /** Targets drop-down's {@code <select>} element. */
+    /**
+     * Targets drop-down's {@code <select>} element.
+     */
     private static final String DROPDOWN_XPATH = ROOT_ELEMENT_XPATH + "//select[contains(@class, 'dropdown-plugin')]";
 
     private final PageHelper helper;

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/TestDataSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/TestDataSteps.java
@@ -15,7 +15,7 @@ import uk.nhs.digital.ps.test.acceptance.pages.ContentPage;
 
 public class TestDataSteps extends AbstractSpringSteps {
 
-    private final static Logger log = getLogger(TestDataSteps.class);
+    private static final Logger log = getLogger(TestDataSteps.class);
 
     @Autowired
     private ContentPage contentPage;
@@ -109,8 +109,8 @@ public class TestDataSteps extends AbstractSpringSteps {
             contentPage.unpublishDocument();
             contentPage.deleteDocument();
 
-        } catch (Exception e) {
-            log.error("Failed to take publication offline.", e);
+        } catch (Exception exception) {
+            log.error("Failed to take publication offline.", exception);
         }
     }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/cms/LoginSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/cms/LoginSteps.java
@@ -57,13 +57,13 @@ public class LoginSteps extends AbstractSpringSteps {
     }
 
     @When("^I change my password to \"([^\"]*)\"$")
-    public void iChangeMyPasswordTo(String password) throws Throwable {
+    public void whenIChangeMyPasswordTo(String password) throws Throwable {
         dashboardPage.open();
         dashboardPage.changePasswordTo(password);
     }
 
     @Then("^I can see the password error messages$")
-    public void iCanSeeThePasswordErrorMessages() throws Throwable {
+    public void thenICanSeeThePasswordErrorMessages() throws Throwable {
         assertThat("Password error is displayed", dashboardPage.getPasswordErrorMessages(),
             hasItems(
                 equalTo("Password must be at least 12 characters long"),

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/HomeSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/HomeSteps.java
@@ -1,36 +1,31 @@
 package uk.nhs.digital.ps.test.acceptance.steps.site;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+
 import cucumber.api.DataTable;
 import cucumber.api.java.en.Then;
 import org.hamcrest.Matcher;
-import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.nhs.digital.ps.test.acceptance.pages.site.HomePage;
 import uk.nhs.digital.ps.test.acceptance.steps.AbstractSpringSteps;
 
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
-import static org.slf4j.LoggerFactory.getLogger;
-
 public class HomeSteps extends AbstractSpringSteps {
-
-    private final static Logger log = getLogger(HomeSteps.class);
 
     @Autowired
     private HomePage homePage;
 
-
     @Then("^I should see the home page title \"([^\"]+)\"$")
-    public void iShouldSeePageTitled(String pageTitle) throws Throwable {
+    public void thenIShouldSeePageTitled(String pageTitle) throws Throwable {
         assertThat("I should see page titled.", homePage.getPageTitle(), is(pageTitle));
     }
 
 
     @Then("^I should (?:also )?see following items in home page:?$")
-    public void iShouldAlsoSee(final DataTable pageSections) throws Throwable {
+    public void thenIShouldAlsoSee(final DataTable pageSections) throws Throwable {
         String elementName = null;
         for (List<String> elementsContent : pageSections.raw()) {
             elementName = elementsContent.get(0);

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/SearchSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/SearchSteps.java
@@ -3,16 +3,20 @@ package uk.nhs.digital.ps.test.acceptance.steps.site;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.capitalize;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.*;
-import static org.slf4j.LoggerFactory.getLogger;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import cucumber.api.DataTable;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
-import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.nhs.digital.ps.test.acceptance.data.TestDataRepo;
 import uk.nhs.digital.ps.test.acceptance.pages.site.common.SearchPage;
@@ -24,8 +28,6 @@ import java.util.List;
 
 public class SearchSteps extends AbstractSpringSteps {
 
-    private final static Logger log = getLogger(SearchSteps.class);
-
     @Autowired
     private SearchPage searchPage;
 
@@ -33,24 +35,24 @@ public class SearchSteps extends AbstractSpringSteps {
     private TestDataRepo testDataRepo;
 
     @When("^I search for \"(.*)\"$")
-    public void iSearchFor(String searchTerm) throws Throwable {
+    public void whenISearchFor(String searchTerm) throws Throwable {
         searchPage.searchForTerm(searchTerm);
     }
 
     @When("^I search for the publication$")
-    public void iSearchForThePublication() throws Throwable {
+    public void whenISearchForThePublication() throws Throwable {
         String title = testDataRepo.getCurrentPublication().getTitle();
-        iSearchFor(title);
+        whenISearchFor(title);
     }
 
     @When("^I search for a publication taxonomy term$")
-    public void iSearchForAPublicationTaxonomyTerm() throws Throwable {
+    public void whenISearchForAPublicationTaxonomyTerm() throws Throwable {
         String taxonomy = testDataRepo.getCurrentPublication().getTaxonomy().getLevel3();
-        iSearchFor(taxonomy);
+        whenISearchFor(taxonomy);
     }
 
     @Then("^I should see publication in search results$")
-    public void iShouldSeePublicationInSearchResults() throws Throwable {
+    public void thenIShouldSeePublicationInSearchResults() throws Throwable {
         String expectedTitle = testDataRepo.getCurrentPublication().getTitle();
 
         List<String> actualResults = searchPage.getSearchResultWidgets()
@@ -62,7 +64,7 @@ public class SearchSteps extends AbstractSpringSteps {
     }
 
     @Then("^I should not see publication in search results$")
-    public void iShouldNotSeePublicationInSearchResults() throws Throwable {
+    public void thenIShouldNotSeePublicationInSearchResults() throws Throwable {
         String expectedTitle = testDataRepo.getCurrentPublication().getTitle();
 
         List<String> actualResults = searchPage.getSearchResultWidgets()
@@ -74,44 +76,30 @@ public class SearchSteps extends AbstractSpringSteps {
     }
 
     @Then("^I should see (\\d+) search results?$")
-    public void iShouldSeeSearchResults(String count) throws Throwable {
+    public void thenIShouldSeeSearchResults(String count) throws Throwable {
         assertThat("Correct result count found", searchPage.getResultCount(), startsWith(count));
     }
 
     @Then("^I should see search results starting with:$")
-    public void iShouldSeeSearchResultsStartingWith(DataTable searchResults) throws Throwable {
+    public void thenIShouldSeeSearchResultsStartingWith(DataTable searchResults) throws Throwable {
         assertSearchResultsStartWith(searchResults.asList(String.class));
     }
 
-    private void assertSearchResultsStartWith(List<String> searchResults) {
-        List<String> actualResults = searchPage.getSearchResultWidgets()
-            .stream()
-            .map(SearchResultWidget::getTitle)
-            .collect(toList());
-
-        List<Matcher<? super String>> expectedResults = searchResults
-            .stream()
-            .map(Matchers::startsWith)
-            .collect(toList());
-
-        assertThat("Search results match", actualResults, contains(expectedResults));
-    }
-
     @Then("^I should see search results which also include:$")
-    public void iShouldSeeSearchResultsWhichAlsoInclude(DataTable expectedResults) throws Throwable {
+    public void thenIShouldSeeSearchResultsWhichAlsoInclude(DataTable expectedResults) throws Throwable {
 
         List<SearchResultWidget> actualResults = searchPage.getSearchResultWidgets();
 
         for (List<String> elementItem : expectedResults.raw()) {
             assertTrue("Search result includes item specified",
                 actualResults.stream()
-                    .anyMatch(result->result.getType().equals(elementItem.get(0))
-                    && result.getTitle().equals(elementItem.get(1))));
+                    .anyMatch(result -> result.getType().equals(elementItem.get(0))
+                        && result.getTitle().equals(elementItem.get(1))));
         }
     }
 
     @Then("^I should see search results which (have|doesnt have) the national statistics logo")
-    public void iShouldSeeSearchResultsWithTheNationalStatisticsLogo(String hasLogo) throws Throwable {
+    public void thenIShouldSeeSearchResultsWithTheNationalStatisticsLogo(String hasLogo) throws Throwable {
         List<SearchResultWidget> actualResults = searchPage.getSearchResultWidgets();
 
         actualResults.stream()
@@ -122,19 +110,19 @@ public class SearchSteps extends AbstractSpringSteps {
     }
 
     @Then("^I should see the search term \"(.+)\" on the results page$")
-    public void iShouldSeeTheSearchTermOnTheResultsPage(String term) throws Throwable {
+    public void thenIShouldSeeTheSearchTermOnTheResultsPage(String term) throws Throwable {
         assertThat("Result description ends with search term", searchPage.getResultDescription(), endsWith(term));
         assertEquals("Search query is maintained in search box", term, searchPage.getSearchFieldValue());
     }
 
     @Then("^I can see the search description matching \"([^\"]*)\"$")
-    public void iCanSeeTheSearchDescriptionMatching(String regex) throws Throwable {
+    public void thenICanSeeTheSearchDescriptionMatching(String regex) throws Throwable {
         String resultDescription = searchPage.getResultDescription();
         assertTrue("Result description [" + resultDescription + "] matches", resultDescription.matches(regex));
     }
 
     @Then("^I should see the weight search test results ordered by (relevance|date)$")
-    public void iShouldSeeTheWeightSearchTestResultsOrderedBy(String sort) throws Throwable {
+    public void thenIShouldSeeTheWeightSearchTestResultsOrderedBy(String sort) throws Throwable {
         // check the results are actually sorted correctly
         assertSearchResultsStartWith(getSortedWeightSearchResults(sort));
 
@@ -152,6 +140,20 @@ public class SearchSteps extends AbstractSpringSteps {
             default:
                 throw new RuntimeException("Unknown sort mode: " + sort);
         }
+    }
+
+    private void assertSearchResultsStartWith(List<String> searchResults) {
+        List<String> actualResults = searchPage.getSearchResultWidgets()
+            .stream()
+            .map(SearchResultWidget::getTitle)
+            .collect(toList());
+
+        List<Matcher<? super String>> expectedResults = searchResults
+            .stream()
+            .map(Matchers::startsWith)
+            .collect(toList());
+
+        assertThat("Search results match", actualResults, contains(expectedResults));
     }
 
     private static List<String> getWeightSearchResultsSortedByRelevance() {

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/ServiceSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/ServiceSteps.java
@@ -1,39 +1,32 @@
 package uk.nhs.digital.ps.test.acceptance.steps.site;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+
 import cucumber.api.DataTable;
 import cucumber.api.java.en.Then;
-import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
-import org.openqa.selenium.By;
-import org.openqa.selenium.WebElement;
-import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.nhs.digital.ps.test.acceptance.pages.site.ServicePage;
 import uk.nhs.digital.ps.test.acceptance.steps.AbstractSpringSteps;
 
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.assertThat;
-import static org.slf4j.LoggerFactory.getLogger;
-
 public class ServiceSteps extends AbstractSpringSteps {
-
-    private final static Logger log = getLogger(ServiceSteps.class);
 
     @Autowired
     private ServicePage servicePage;
 
 
     @Then("^I should see the service page title \"([^\"]+)\"$")
-    public void iShouldSeePageTitled(String pageTitle) throws Throwable {
+    public void thenIShouldSeePageTitled(String pageTitle) throws Throwable {
         assertThat("I should see page titled.", servicePage.getPageTitle(), is(pageTitle));
     }
 
 
     @Then("^I should (?:also )?see following items in service page:?$")
-    public void iShouldAlsoSee(final DataTable pageSections) throws Throwable {
+    public void thenIShouldAlsoSee(final DataTable pageSections) throws Throwable {
         String elementName = null;
         for (List<String> elementsContent : pageSections.raw()) {
             elementName = elementsContent.get(0);

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/SiteSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/SiteSteps.java
@@ -8,14 +8,18 @@ import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.startsWith;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.slf4j.LoggerFactory.getLogger;
 import static uk.nhs.digital.ps.test.acceptance.util.FileHelper.waitUntilFileAppears;
 
 import cucumber.api.DataTable;
-import cucumber.api.java.en.And;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
@@ -23,8 +27,6 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
-import org.openqa.selenium.support.ui.WebDriverWait;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import uk.nhs.digital.ps.test.acceptance.config.AcceptanceTestProperties;
@@ -42,7 +44,7 @@ import java.util.stream.Stream;
 
 public class SiteSteps extends AbstractSpringSteps {
 
-    private final static Logger log = getLogger(SiteSteps.class);
+    private static final Logger log = getLogger(SiteSteps.class);
 
     @Autowired
     private SitePage sitePage;
@@ -57,67 +59,65 @@ public class SiteSteps extends AbstractSpringSteps {
     private TestContentUrls urlLookup;
 
     @Given("^I navigate to (?:the )?\"([^\"]+)\" (?:.* )?page$")
-    public void iNavigateToPage(String pageName) throws Throwable {
+    public void givenINavigateToPage(String pageName) throws Throwable {
         sitePage.openByPageName(pageName);
     }
 
     /**
-     *
      * Then I can click on link "foo bar"
      * When I click on "foo bar" button
      */
     @When("^I (?:can )?click on(?: the| link)? \"([^\"]+)\"(?: link| button)?$")
-    public void iClickOn(String linkTitle) throws Throwable {
+    public void whenIClickOn(String linkTitle) throws Throwable {
         WebElement element = sitePage.findElementWithTitle(linkTitle);
 
         assertThat("I can find element with title: " + linkTitle,
             element, is(notNullValue()));
 
-
         sitePage.clickOnElement(element);
     }
 
     @Then("^I (?:can )?see \"([^\"]+)\" (?:link|button|image)$")
-    public void iSeeLink(String linkTitle) throws Throwable {
+    public void thenISeeLink(String linkTitle) throws Throwable {
         assertNotNull("Can see element", sitePage.findElementWithTitle(linkTitle));
     }
 
     @Then("^I (?:can )?see labelled element \"([^\"]+)\" with content \"([^\"]+)\"$")
-    public void iSeeElementWithUiPathAndContent(String uiPath, String content) throws Throwable {
+    public void thenISeeElementWithUiPathAndContent(String uiPath, String content) throws Throwable {
         assertNotNull("Can see element with data-uipath: " + uiPath, sitePage.findElementWithUiPath(uiPath));
         assertThat(sitePage.findElementWithUiPath(uiPath).getText(), containsString(content));
     }
 
     @Then("^I (?:can )?see element with data-uipath \"([^\"]+)\"$")
-    public void iSeeElementWithUiPath(String uiPath) throws Throwable {
+    public void thenISeeElementWithUiPath(String uiPath) throws Throwable {
         assertNotNull("Can see element with data-uipath: " + uiPath, sitePage.findElementWithUiPath(uiPath));
     }
 
     @Then("^I click on the accept cookie banner")
-    public void iShouldSeeCookieBanner() throws Throwable {
+    public void thenIShouldSeeCookieBanner() throws Throwable {
         sitePage.findPageElementById("cookieAcceptButton").click();
     }
 
     @Then("^I should see (?:.* )?page titled \"([^\"]+)\"$")
-    public void iShouldSeePageTitled(String pageTitle) throws Throwable {
+    public void thenIShouldSeePageTitled(String pageTitle) throws Throwable {
         assertThat("I should see page titled.", sitePage.getDocumentTitle(), is(pageTitle));
     }
 
-    @And("^I should see the content \"([^\"]*)\"$")
-    public void iShouldSeeTheContent(String content) throws Throwable {
+    @Then("^I should see the content \"([^\"]*)\"$")
+    public void thenIShouldSeeTheContent(String content) throws Throwable {
         assertThat("Document content is as expected", sitePage.getDocumentContent(), getMatcherForText(content));
     }
 
     @Then("^I should see the \"page not found\" error page$")
-    public void iShouldSeeThePageNotFoundErrorPage() throws Throwable {
+    public void thenIShouldSeeThePageNotFoundErrorPage() throws Throwable {
         // Ideally we would check the HTTP response code is 404 as well but it's not
         // currently possible to do this with the Selinium Web Driver.
         // See https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/141
-        iShouldSeePageTitled("Page not found");
+        thenIShouldSeePageTitled("Page not found");
     }
 
     @Then("^I should (?:also )?see:?$")
-    public void iShouldAlsoSee(final DataTable pageSections) throws Throwable {
+    public void thenIShouldAlsoSee(final DataTable pageSections) throws Throwable {
         String elementName = null;
         for (List<String> elementsContent : pageSections.raw()) {
             elementName = elementsContent.get(0);
@@ -133,7 +133,7 @@ public class SiteSteps extends AbstractSpringSteps {
     }
 
     @Then("^I should(?: also)? see \"([^\"]+)\" with:")
-    public void iShouldSeeItemsOf(String pageElementName, final DataTable elementItems) throws Throwable  {
+    public void thenIShouldSeeItemsOf(String pageElementName, final DataTable elementItems) throws Throwable  {
         WebElement pageElement = sitePage.findPageElement(pageElementName);
 
         assertNotNull("I should find page element: " + pageElementName, pageElement);
@@ -148,7 +148,7 @@ public class SiteSteps extends AbstractSpringSteps {
     }
 
     @Then("^I should not see headers?:$")
-    public void iShouldNotSeeHeaders(DataTable headersTable) throws Throwable {
+    public void thenIShouldNotSeeHeaders(DataTable headersTable) throws Throwable {
         List<String> headers = headersTable.asList(String.class);
         for (String header : headers) {
             assertNull("Header should not be displayed", sitePage.findElementWithText(header));
@@ -156,7 +156,7 @@ public class SiteSteps extends AbstractSpringSteps {
     }
 
     @Then("^I should see headers?:$")
-    public void iShouldSeeHeaders(DataTable headersTable) throws Throwable {
+    public void thenIShouldSeeHeaders(DataTable headersTable) throws Throwable {
         List<String> headers = headersTable.asList(String.class);
         for (String header : headers) {
             assertNotNull("Header should be displayed: " + header, sitePage.findElementWithText(header));
@@ -164,24 +164,26 @@ public class SiteSteps extends AbstractSpringSteps {
     }
 
     @Then("^I should(?: also)? see multiple \"([^\"]+)\" with:")
-    public void iShouldSeeMultipleItemsOf(String pageElementName, final DataTable elementItems) throws Throwable  {
-        int i = 0;
+    public void thenIShouldSeeMultipleItemsOf(String pageElementName, final DataTable elementItems) throws Throwable  {
 
-        for (List<String> elementItem : elementItems.raw()) {
-            WebElement pageElement = sitePage.findPageElement(pageElementName, i++);
+        final List<List<String>> rawElementItems = elementItems.raw();
+        for (int i = 0; i < rawElementItems.size(); i++) {
+            List<String> elementItem = rawElementItems.get(i);
+            WebElement pageElement = sitePage.findPageElement(pageElementName, i);
             assertThat("I should find page element: " + pageElementName,
                 pageElement, is(notNullValue()));
 
             String expectedItemText = elementItem.get(0);
 
-            assertThat("Page element " + pageElementName + " contain item with text: " + expectedItemText,
+            assertThat(
+                "Page element " + pageElementName + " contain item with text: " + expectedItemText,
                 getElementText(pageElement),
                 getMatcherForText(expectedItemText));
         }
     }
 
     @Then("I can download(?: following files)?:")
-    public void iCanDownload(final DataTable downloadTitles) throws Throwable {
+    public void thenICanDownload(final DataTable downloadTitles) throws Throwable {
         for (List<String> downloadLink : downloadTitles.asLists(String.class)) {
             String linkText = downloadLink.get(0);
             String linkFileName = downloadLink.get(1);
@@ -216,7 +218,7 @@ public class SiteSteps extends AbstractSpringSteps {
     }
 
     @Then("^I should see the footer$")
-    public void iShouldSeeTheFooter() throws Throwable {
+    public void thenIShouldSeeTheFooter() throws Throwable {
         assertNotNull("Footer is present", sitePage.findFooter());
 
         assertNotNull("Can find terms and conditions link",
@@ -241,7 +243,7 @@ public class SiteSteps extends AbstractSpringSteps {
      * this gives you 60s to inspect the page
      */
     @Then("^I wait (\\d+)s$")
-    public void iWait(int sec) throws InterruptedException {
+    public void thenIWait(int sec) throws InterruptedException {
         Thread.sleep(sec * 1000);
     }
 
@@ -268,13 +270,13 @@ public class SiteSteps extends AbstractSpringSteps {
     }
 
     @Then("^I should see the \"([^\"]*)\" list (containing|(?:not )?including):$")
-    public void iShouldSeeTheListWith(String title, String qualifier, DataTable listItems) throws Throwable {
+    public void thenIShouldSeeTheListWith(String title, String qualifier, DataTable listItems) throws Throwable {
         List<String> items = listItems.asList(String.class);
         listMatchesItems(qualifier, items, sitePage.findPageElement(title));
     }
 
     @Then("^I should see the list with title \"([^\"]*)\" (containing|(?:not )?including):$")
-    public void iShouldSeeTheListWithTitle(String title, String qualifier, DataTable listItems) throws Throwable {
+    public void thenIShouldSeeTheListWithTitle(String title, String qualifier, DataTable listItems) throws Throwable {
         List<String> items = listItems.asList(String.class);
         listMatchesItems(qualifier, items, sitePage.findElementWithTitle(title));
     }
@@ -307,12 +309,12 @@ public class SiteSteps extends AbstractSpringSteps {
     }
 
     @Then("^I should not see element with title \"([^\"]*)\"$")
-    public void iShouldNotSeeElementTitled(String title) throws Throwable {
+    public void thenIShouldNotSeeElementTitled(String title) throws Throwable {
         assertNull("Element is not on page", sitePage.findElementWithTitle(title));
     }
 
     @Then("^I can see the full taxonomy in the faceted navigation$")
-    public void iCanSeeTheFullTaxonomyInTheFacetedNavigation() throws Throwable {
+    public void thenICanSeeTheFullTaxonomyInTheFacetedNavigation() throws Throwable {
         Taxonomy taxonomy = testDataRepo.getCurrentPublication().getTaxonomy();
 
         List<String> expectedTaxonomy = asList(
@@ -324,8 +326,8 @@ public class SiteSteps extends AbstractSpringSteps {
     }
 
     @Then("^I can click on the publication$")
-    public void iCanClickOnThePublication() throws Throwable {
+    public void thenICanClickOnThePublication() throws Throwable {
         String title = testDataRepo.getCurrentPublication().getTitle();
-        iClickOn(title);
+        whenIClickOn(title);
     }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/ps/PublicationSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/ps/PublicationSteps.java
@@ -3,6 +3,7 @@ package uk.nhs.digital.ps.test.acceptance.steps.site.ps;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.slf4j.LoggerFactory.getLogger;
 import static uk.nhs.digital.ps.test.acceptance.util.FileHelper.readFileAsByteArray;
@@ -34,7 +35,7 @@ import java.util.stream.Collectors;
 
 public class PublicationSteps extends AbstractSpringSteps {
 
-    private final static Logger log = getLogger(PublicationSteps.class);
+    private static final Logger log = getLogger(PublicationSteps.class);
 
     @Autowired
     private TestDataRepo testDataRepo;
@@ -70,7 +71,7 @@ public class PublicationSteps extends AbstractSpringSteps {
         assertThat("Granularity is as expected", publicationPage.getGranularity(),
             is(publication.getGranularity().getDisplayValue()));
 
-        iCanSeeTheSectionedPublicationBody();
+        thenICanSeeTheSectionedPublicationBody();
 
         assertAttachmentsUpload(publication.getAttachments());
     }
@@ -123,8 +124,8 @@ public class PublicationSteps extends AbstractSpringSteps {
 
     private void assertDisplayedAttachmentDetails(final Attachment attachment, final AttachmentWidget
         attachmentWidget) {
-        assertThat("Attachment " + attachment.getFullName() +" is displayed",
-            attachmentWidget != null, is(true));
+        assertThat("Attachment " + attachment.getFullName() + " is displayed",
+            attachmentWidget, is(notNullValue()));
 
         assertThat("Correct size of attachment " + attachment.getFullName() + " is displayed",
             attachmentWidget.getSizeText(),
@@ -132,13 +133,13 @@ public class PublicationSteps extends AbstractSpringSteps {
     }
 
     @Given("^I have a sectioned publication$")
-    public void iHaveASectionedPublication() throws Throwable {
+    public void givenIHaveASectionedPublication() throws Throwable {
         PublicationBuilder sectionedPublication = ExpectedTestDataProvider.getSectionedPublication();
         testDataRepo.setPublication(sectionedPublication.build());
     }
 
     @Then("^I can see the sectioned publication body$")
-    public void iCanSeeTheSectionedPublicationBody() throws Throwable {
+    public void thenICanSeeTheSectionedPublicationBody() throws Throwable {
         Publication publication = testDataRepo.getCurrentPublication();
 
         List<Matcher<? super SectionWidget>> matchers = publication.getBodySections()

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/AssertionHelper.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/AssertionHelper.java
@@ -1,14 +1,14 @@
 package uk.nhs.digital.ps.test.acceptance.util;
 
-import org.hamcrest.Matcher;
-
-import java.time.Instant;
-import java.util.function.Supplier;
-
 import static java.text.MessageFormat.format;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertThat;
+
+import org.hamcrest.Matcher;
+
+import java.time.Instant;
+import java.util.function.Supplier;
 
 public abstract class AssertionHelper {
 
@@ -39,7 +39,7 @@ public abstract class AssertionHelper {
 
                 assertThat(assertionFailureMessage, actualValueSupplier.get(), matcher);
 
-            } catch (final Exception | AssertionError e) {
+            } catch (final Exception | AssertionError exception) {
                 // We don't want to suppress java.lang.Error instances other than AssertionError, hence going with the
                 // above selection rather than with blanket Throwable; this is so that we do not snuff out unexpected
                 // errors (we do expect Exceptions and AssertionErrors during normal course of resolving assertions
@@ -51,7 +51,7 @@ public abstract class AssertionHelper {
                 } catch (final InterruptedException ie) {
                     throw new Error(ie);
                 }
-                throwable = e;
+                throwable = exception;
             }
         }
         while (throwable != null && Instant.now().isBefore(timeout));

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/FileHelper.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/FileHelper.java
@@ -1,5 +1,7 @@
 package uk.nhs.digital.ps.test.acceptance.util;
 
+import static java.nio.file.Files.readAllBytes;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import uk.nhs.digital.ps.test.acceptance.models.FileType;
@@ -9,8 +11,6 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
-import static java.nio.file.Files.readAllBytes;
 
 public class FileHelper {
 
@@ -24,16 +24,16 @@ public class FileHelper {
 
             return tempFile;
 
-        } catch (final IOException e) {
-            throw new UncheckedIOException(e);
+        } catch (final IOException exception) {
+            throw new UncheckedIOException(exception);
         }
     }
 
     public static byte[] readFileAsByteArray(final Path path) {
         try {
             return readAllBytes(path);
-        } catch (final IOException e) {
-            throw new UncheckedIOException(e);
+        } catch (final IOException exception) {
+            throw new UncheckedIOException(exception);
         }
     }
 

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/RandomHelper.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/RandomHelper.java
@@ -1,14 +1,14 @@
 package uk.nhs.digital.ps.test.acceptance.util;
 
+import static java.util.Collections.shuffle;
+import static java.util.stream.Collectors.toList;
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.RandomUtils;
 
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.IntStream;
-
-import static java.util.Collections.shuffle;
-import static java.util.stream.Collectors.toList;
 
 public class RandomHelper {
 
@@ -55,6 +55,7 @@ public class RandomHelper {
     public static int getRandomInt(int max) {
         return getRandomInt(0, max);
     }
+
     public static int getRandomInt(int min, int max) {
         return min + (int) (Math.random() * (1 + max - min));
     }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
@@ -97,7 +97,13 @@ public class TestContentUrls {
         // CI Hub/Landing
         add("SHMI landing", "/data-and-information/publications/ci-hub/summary-hospital-level-mortality-indicator-shmi");
         add("SHMI_publication_timetable.xlsx",
-            "/binaries/content/documents/corporate-website/publication-system/ci-hub/summary-hospital-level-mortality-indicator-shmi/summary-hospital-level-mortality-indicator-shmi/publicationsystem%3Acilandingasset/publicationsystem%3AAttachments/publicationsystem%3AattachmentResource");
+            "/binaries/content/documents/corporate-website/publication-system/ci-hub"
+                + "/summary-hospital-level-mortality-indicator-shmi"
+                + "/summary-hospital-level-mortality-indicator-shmi"
+                + "/publicationsystem%3Acilandingasset"
+                + "/publicationsystem%3AAttachments"
+                + "/publicationsystem%3AattachmentResource"
+        );
         add("ci hub root", "/data-and-information/publications/ci-hub");
 
         // attachments

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/webdriver/WebDriverProvider.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/webdriver/WebDriverProvider.java
@@ -1,19 +1,15 @@
 package uk.nhs.digital.ps.test.acceptance.webdriver;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
-import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
-import static org.slf4j.LoggerFactory.getLogger;
 
 /**
  * Manages WebDriver (the client component of the WebDriver).
@@ -26,7 +22,7 @@ import static org.slf4j.LoggerFactory.getLogger;
  */
 public class WebDriverProvider {
 
-    private final static Logger log = getLogger(WebDriverProvider.class);
+    private static final Logger log = getLogger(WebDriverProvider.class);
 
     private final WebDriverServiceProvider webDriverServiceProvider;
 

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/webdriver/WebDriverServiceProvider.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/webdriver/WebDriverServiceProvider.java
@@ -1,5 +1,7 @@
 package uk.nhs.digital.ps.test.acceptance.webdriver;
 
+import static java.nio.file.Files.isDirectory;
+
 import org.openqa.selenium.chrome.ChromeDriverService;
 
 import java.io.File;
@@ -8,8 +10,6 @@ import java.io.UncheckedIOException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
-import static java.nio.file.Files.isDirectory;
 
 /**
  * Manages WebDriver service (the server component of WebDriver).
@@ -44,8 +44,8 @@ public class WebDriverServiceProvider {
 
         try {
             chromeDriverService.start();
-        } catch (final IOException e) {
-            throw new UncheckedIOException(e);
+        } catch (final IOException exception) {
+            throw new UncheckedIOException(exception);
         }
     }
 

--- a/cms/src/test/java/uk/nhs/digital/externalstorage/resource/S3NodeMetadataTest.java
+++ b/cms/src/test/java/uk/nhs/digital/externalstorage/resource/S3NodeMetadataTest.java
@@ -19,7 +19,7 @@ public class S3NodeMetadataTest {
     private static final String VALUE_MIME_TYPE = "application/pdf";
 
     @Test
-    public void shouldGiveAccessToFields () {
+    public void shouldGiveAccessToFields() {
         S3NodeMetadata actualMetadata = new S3NodeMetadata(getNode());
 
         assertThat("metadata contains valid .", actualMetadata.getFileName(), equalTo(VALUE_FILE_NAME));

--- a/cms/src/test/java/uk/nhs/digital/externalstorage/s3/BlockingPooledS3ConnectorTest.java
+++ b/cms/src/test/java/uk/nhs/digital/externalstorage/s3/BlockingPooledS3ConnectorTest.java
@@ -1,5 +1,12 @@
 package uk.nhs.digital.externalstorage.s3;
 
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.MockitoAnnotations.initMocks;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -12,13 +19,6 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.mock;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 public class BlockingPooledS3ConnectorTest {
 

--- a/cms/src/test/java/uk/nhs/digital/externalstorage/s3/S3SdkConnectorTest.java
+++ b/cms/src/test/java/uk/nhs/digital/externalstorage/s3/S3SdkConnectorTest.java
@@ -93,7 +93,6 @@ public class S3SdkConnectorTest {
         final byte[][] expectedChunks = {fullChunk, partialChunk};
         final long contentLength = fullChunk.length + partialChunk.length;
 
-
         given(s3ObjectKeyGenerator.generateObjectKey(fileName)).willReturn(objectKey);
 
         final InitiateMultipartUploadResult result = mock(InitiateMultipartUploadResult.class);
@@ -229,7 +228,6 @@ public class S3SdkConnectorTest {
         final S3Object s3ResponseObject = mock(S3Object.class);
         given(s3ResponseObject.getObjectContent()).willReturn(expectedDownloadedFileInputStream);
         given(s3ResponseObject.getObjectMetadata()).willReturn(objectMetadata);
-
 
         given(s3.getObject(bucketName, objectKey)).willReturn(s3ResponseObject);
 

--- a/cms/src/test/java/uk/nhs/digital/externalstorage/workflow/externalFilePublish/ExternalFilePublishTaskTest.java
+++ b/cms/src/test/java/uk/nhs/digital/externalstorage/workflow/externalFilePublish/ExternalFilePublishTaskTest.java
@@ -80,11 +80,12 @@ public class ExternalFilePublishTaskTest {
     private List<Node> getQueryResults() throws RepositoryException {
         List<Node> nodes = new ArrayList<>();
 
-        Node r = rootNode.addNode("resources");
+        Node node = rootNode
+            .addNode("resources")
+            .addNode("one");
+        node.setProperty(ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_REFERENCE, "the/one");
 
-        Node o = r.addNode("one");
-        o.setProperty(ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_REFERENCE, "the/one");
-        nodes.add(o);
+        nodes.add(node);
 
         return nodes;
     }

--- a/cms/src/test/java/uk/nhs/digital/externalstorage/workflow/externalFileUnpublish/ExternalFileUnpublishTaskTest.java
+++ b/cms/src/test/java/uk/nhs/digital/externalstorage/workflow/externalFileUnpublish/ExternalFileUnpublishTaskTest.java
@@ -81,11 +81,12 @@ public class ExternalFileUnpublishTaskTest {
     private List<Node> getQueryResults() throws RepositoryException {
         List<Node> nodes = new ArrayList<>();
 
-        Node r = rootNode.addNode("resources");
+        Node node = rootNode
+            .addNode("resources")
+            .addNode("one");
+        node.setProperty(ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_REFERENCE, "the/one");
 
-        Node o = r.addNode("one");
-        o.setProperty(ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_REFERENCE, "the/one");
-        nodes.add(o);
+        nodes.add(node);
 
         return nodes;
     }

--- a/cms/src/test/java/uk/nhs/digital/ps/BlankAttachmentFieldValidatorTest.java
+++ b/cms/src/test/java/uk/nhs/digital/ps/BlankAttachmentFieldValidatorTest.java
@@ -1,5 +1,17 @@
 package uk.nhs.digital.ps;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.MockitoAnnotations.initMocks;
+
 import org.apache.wicket.Page;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.protocol.http.WebApplication;
@@ -17,22 +29,12 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 
-import javax.jcr.Node;
-import javax.jcr.Property;
 import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.hamcrest.core.Is.is;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.mock;
-import static org.mockito.MockitoAnnotations.initMocks;
+import javax.jcr.Node;
+import javax.jcr.Property;
 
 public class BlankAttachmentFieldValidatorTest {
 

--- a/cms/src/test/java/uk/nhs/digital/ps/BlankRelatedLinkFieldValidatorTest.java
+++ b/cms/src/test/java/uk/nhs/digital/ps/BlankRelatedLinkFieldValidatorTest.java
@@ -1,6 +1,18 @@
 package uk.nhs.digital.ps;
 
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.MockitoAnnotations.initMocks;
+
 import org.apache.wicket.Page;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.protocol.http.WebApplication;
@@ -18,22 +30,12 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 
-import javax.jcr.Node;
-import javax.jcr.Property;
 import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.hamcrest.core.Is.is;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.mock;
-import static org.mockito.MockitoAnnotations.initMocks;
+import javax.jcr.Node;
+import javax.jcr.Property;
 
 public class BlankRelatedLinkFieldValidatorTest {
 

--- a/cms/src/test/java/uk/nhs/digital/ps/BlankStaticDropdownSelectionFieldValidatorTest.java
+++ b/cms/src/test/java/uk/nhs/digital/ps/BlankStaticDropdownSelectionFieldValidatorTest.java
@@ -1,5 +1,19 @@
 package uk.nhs.digital.ps;
 
+import static java.text.MessageFormat.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.MockitoAnnotations.initMocks;
+
 import org.apache.wicket.Page;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.protocol.http.WebApplication;
@@ -19,22 +33,10 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 
-import javax.jcr.Value;
 import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
-
-import static java.text.MessageFormat.format;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.hamcrest.core.Is.is;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.MockitoAnnotations.initMocks;
+import javax.jcr.Value;
 
 public class BlankStaticDropdownSelectionFieldValidatorTest {
 
@@ -44,8 +46,7 @@ public class BlankStaticDropdownSelectionFieldValidatorTest {
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
-    @Mock
-    private IFieldValidator fieldValidator;
+    @Mock private IFieldValidator fieldValidator;
     @Mock private IFieldDescriptor fieldDescriptor;
     @Mock private ITypeDescriptor typeDescriptor;
     @Mock private JcrNodeModel documentNodeModel;

--- a/cms/src/test/java/uk/nhs/digital/ps/CoverageDatesValidatorTest.java
+++ b/cms/src/test/java/uk/nhs/digital/ps/CoverageDatesValidatorTest.java
@@ -1,5 +1,19 @@
 package uk.nhs.digital.ps;
 
+import static java.text.MessageFormat.format;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.MockitoAnnotations.initMocks;
+
 import org.apache.wicket.Page;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.protocol.http.WebApplication;
@@ -18,23 +32,12 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
 import javax.jcr.Node;
 import javax.jcr.Property;
-import java.util.*;
-
-import static java.text.MessageFormat.format;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.core.Is.is;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 public class CoverageDatesValidatorTest {
 
@@ -93,7 +96,6 @@ public class CoverageDatesValidatorTest {
 
         // then
         // expectations as specified in 'given'
-
     }
 
     @Test
@@ -112,7 +114,6 @@ public class CoverageDatesValidatorTest {
         given(nominalDateProperty.getDate()).willReturn(generateHippoDateTodayAddDays(10));
         given(documentNode.getProperty(HIPPO_NOMINAL_DATE_PROPERTY_NAME)).willReturn(nominalDateProperty);
 
-
         given(documentNodeModel.getNode()).willReturn(documentNode);
 
         // when
@@ -126,7 +127,6 @@ public class CoverageDatesValidatorTest {
 
         assertThat("No violation has been reported.", actualValidationViolations, is(empty()));
     }
-
 
     @Test
     public void reportsError_whenEndDateLessThanStartDate() throws Exception {
@@ -145,7 +145,6 @@ public class CoverageDatesValidatorTest {
         final Property nominalDateProperty = mock(Property.class);
         given(nominalDateProperty.getDate()).willReturn(generateHippoDateEmpty());
         given(documentNode.getProperty(HIPPO_NOMINAL_DATE_PROPERTY_NAME)).willReturn(nominalDateProperty);
-
 
         given(documentNodeModel.getNode()).willReturn(documentNode);
 
@@ -189,7 +188,6 @@ public class CoverageDatesValidatorTest {
 
         given(documentNodeModel.getNode()).willReturn(documentNode);
 
-
         given(fieldValidator.newValueViolation(eq(documentNodeModel), isA(IModel.class)))
             .willReturn(expectedViolation);
 
@@ -227,7 +225,6 @@ public class CoverageDatesValidatorTest {
         final Property nominalDateProperty = mock(Property.class);
         given(nominalDateProperty.getDate()).willReturn(generateHippoDateEmpty());
         given(documentNode.getProperty(HIPPO_NOMINAL_DATE_PROPERTY_NAME)).willReturn(nominalDateProperty);
-
 
         given(documentNodeModel.getNode()).willReturn(documentNode);
 
@@ -268,7 +265,6 @@ public class CoverageDatesValidatorTest {
         final Property nominalDateProperty = mock(Property.class);
         given(nominalDateProperty.getDate()).willReturn(generateHippoDateTodayAddDays(2));
         given(documentNode.getProperty(HIPPO_NOMINAL_DATE_PROPERTY_NAME)).willReturn(nominalDateProperty);
-
 
         given(documentNodeModel.getNode()).willReturn(documentNode);
 

--- a/cms/src/test/java/uk/nhs/digital/ps/JcrProvider.java
+++ b/cms/src/test/java/uk/nhs/digital/ps/JcrProvider.java
@@ -33,19 +33,19 @@ public class JcrProvider {
                     (String) object.get("primaryType"),
                     (Map<String, Object>) object.getOrDefault("properties", emptyMap())
                 );
-                Node n = rootNode.addNode(node.path, node.primaryType);
+                Node secondaryNode = rootNode.addNode(node.path, node.primaryType);
                 for (Map.Entry<String, Object> entry : node.properties.entrySet()) {
                     if (entry.getValue() instanceof Boolean) {
-                        n.setProperty(entry.getKey(), (Boolean) entry.getValue());
+                        secondaryNode.setProperty(entry.getKey(), (Boolean) entry.getValue());
                     } else {
-                        n.setProperty(entry.getKey(), entry.getValue().toString());
+                        secondaryNode.setProperty(entry.getKey(), entry.getValue().toString());
                     }
                 }
             }
 
             session.save();
-        } catch (RepositoryException e) {
-            throw new RuntimeException("Failed to set property on JCR node", e);
+        } catch (RepositoryException exception) {
+            throw new RuntimeException("Failed to set property on JCR node", exception);
         }
 
         return session;

--- a/cms/src/test/java/uk/nhs/digital/ps/workflow/searchableFlag/SearchableFlagTaskTest.java
+++ b/cms/src/test/java/uk/nhs/digital/ps/workflow/searchableFlag/SearchableFlagTaskTest.java
@@ -1,5 +1,6 @@
 package uk.nhs.digital.ps.workflow.searchableFlag;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -34,7 +35,7 @@ public class SearchableFlagTaskTest {
     private Session session;
     private Node rootNode = null;
 
-    private final static String RPS_ROOT_FOLDER = "/content/documents/corporate-website/publication-system";
+    private static final String RPS_ROOT_FOLDER = "/content/documents/corporate-website/publication-system";
 
     @Before
     public void setUp() throws Exception {
@@ -62,7 +63,7 @@ public class SearchableFlagTaskTest {
 
     @Test
     @UseDataProvider("unpublishDocuments")
-    public void shouldUpdateDatasetOnDepublishTest(ArrayList<String> changed, ArrayList<String> unchanged) throws Exception {
+    public void shouldUpdateDatasetOnDepublishTest(List<String> changed, List<String> unchanged) throws Exception {
         // mock query results
         MockJcr.setQueryResult(session, getQueryResults(singletonList(
             RPS_ROOT_FOLDER + "/accessible-publication-with-datasets/dataset/dataset"
@@ -88,7 +89,7 @@ public class SearchableFlagTaskTest {
 
     @Test
     @UseDataProvider("datasetDocumentState")
-    public void shouldUpdateDocumentWithGivenStatusTest(final String state, ArrayList<String> changed, ArrayList<String> unchanged) throws Exception {
+    public void shouldUpdateDocumentWithGivenStatusTest(final String state, List<String> changed, List<String> unchanged) throws Exception {
 
         // process publication and datasets
         execute("/publication-with-datasets/dataset", state, false);
@@ -110,7 +111,7 @@ public class SearchableFlagTaskTest {
 
     @Test
     @UseDataProvider("datasetInSubfolder")
-    public void shouldUpdateDatasetFromSubfolder(final String state, ArrayList<String> changed, ArrayList<String> unchanged) throws Exception {
+    public void shouldUpdateDatasetFromSubfolder(final String state, List<String> changed, List<String> unchanged) throws Exception {
 
         // process datasets from within subfolder
         execute("/publication-with-datasets/subfolder/dataset", state, false);
@@ -146,38 +147,38 @@ public class SearchableFlagTaskTest {
         return new Object[][] {
             {
                 "draft",
-                new ArrayList() {{
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/dataset/dataset[2]");
-                }},
-                new ArrayList() {{
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/content/content");
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/content/content[2]");
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/content/content[3]");
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/dataset/dataset");
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/dataset/dataset[3]");
+                asList(
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/dataset/dataset[2]"
+                ),
+                asList(
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/content/content",
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/content/content[2]",
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/content/content[3]",
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/dataset/dataset",
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/dataset/dataset[3]",
                     // unrelated dataset should not be changed
-                    add(RPS_ROOT_FOLDER + "/random-folder/dataset/dataset");
-                    add(RPS_ROOT_FOLDER + "/random-folder/dataset/dataset[2]");
-                    add(RPS_ROOT_FOLDER + "/random-folder/dataset/dataset[3]");
-                }}
+                    RPS_ROOT_FOLDER + "/random-folder/dataset/dataset",
+                    RPS_ROOT_FOLDER + "/random-folder/dataset/dataset[2]",
+                    RPS_ROOT_FOLDER + "/random-folder/dataset/dataset[3]"
+                )
             },
             {
                 "published",
-                new ArrayList() {{
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/dataset/dataset");
-                }},
-                new ArrayList() {{
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/content/content");
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/content/content[2]");
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/content/content[3]");
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/dataset/dataset[2]");
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/dataset/dataset[3]");
+                asList(
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/dataset/dataset"
+                ),
+                asList(
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/content/content",
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/content/content[2]",
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/content/content[3]",
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/dataset/dataset[2]",
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/dataset/dataset[3]",
                     // unrelated dataset should not be changed
-                    add(RPS_ROOT_FOLDER + "/random-folder/dataset/dataset");
-                    add(RPS_ROOT_FOLDER + "/random-folder/dataset/dataset[2]");
-                    add(RPS_ROOT_FOLDER + "/random-folder/dataset/dataset[3]");
-                }}
-            },
+                    RPS_ROOT_FOLDER + "/random-folder/dataset/dataset",
+                    RPS_ROOT_FOLDER + "/random-folder/dataset/dataset[2]",
+                    RPS_ROOT_FOLDER + "/random-folder/dataset/dataset[3]"
+                )
+            }
         };
     }
 
@@ -185,19 +186,19 @@ public class SearchableFlagTaskTest {
     public static Object[][] unpublishDocuments() {
         return new Object[][] {
             {
-                new ArrayList() {{
-                    add(RPS_ROOT_FOLDER + "/accessible-publication-with-datasets/dataset/dataset");
-                }},
-                new ArrayList() {{
-                    add(RPS_ROOT_FOLDER + "/accessible-publication-with-datasets/content/content[2]");
-                    add(RPS_ROOT_FOLDER + "/accessible-publication-with-datasets/content/content[3]");
-                    add(RPS_ROOT_FOLDER + "/accessible-publication-with-datasets/dataset/dataset[2]");
-                    add(RPS_ROOT_FOLDER + "/accessible-publication-with-datasets/dataset/dataset[3]");
+                asList(
+                    RPS_ROOT_FOLDER + "/accessible-publication-with-datasets/dataset/dataset"
+                ),
+                asList(
+                    RPS_ROOT_FOLDER + "/accessible-publication-with-datasets/content/content[2]",
+                    RPS_ROOT_FOLDER + "/accessible-publication-with-datasets/content/content[3]",
+                    RPS_ROOT_FOLDER + "/accessible-publication-with-datasets/dataset/dataset[2]",
+                    RPS_ROOT_FOLDER + "/accessible-publication-with-datasets/dataset/dataset[3]",
                     // unrelated dataset should not be changed
-                    add(RPS_ROOT_FOLDER + "/random-folder/dataset/dataset");
-                    add(RPS_ROOT_FOLDER + "/random-folder/dataset/dataset[2]");
-                    add(RPS_ROOT_FOLDER + "/random-folder/dataset/dataset[3]");
-                }}
+                    RPS_ROOT_FOLDER + "/random-folder/dataset/dataset",
+                    RPS_ROOT_FOLDER + "/random-folder/dataset/dataset[2]",
+                    RPS_ROOT_FOLDER + "/random-folder/dataset/dataset[3]"
+                )
             }
         };
     }
@@ -207,26 +208,26 @@ public class SearchableFlagTaskTest {
         return new Object[][] {
             {
                 "draft",
-                new ArrayList<String>() {{
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/subfolder/dataset/dataset[2]");
-                }},
-                new ArrayList<String>() {{
+                asList(
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/subfolder/dataset/dataset[2]"
+                ),
+                asList(
                     // publication unchanged
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/content/content");
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/content/content[2]");
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/content/content[3]");
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/content/content",
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/content/content[2]",
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/content/content[3]",
                     // the second dataset attached to parent publication unchanged
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/dataset/dataset");
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/dataset/dataset[2]");
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/dataset/dataset[3]");
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/dataset/dataset",
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/dataset/dataset[2]",
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/dataset/dataset[3]",
                     // draft and live version unchanged
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/subfolder/dataset/dataset");
-                    add(RPS_ROOT_FOLDER + "/publication-with-datasets/subfolder/dataset/dataset[3]");
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/subfolder/dataset/dataset",
+                    RPS_ROOT_FOLDER + "/publication-with-datasets/subfolder/dataset/dataset[3]",
                     // unrelated dataset should not be changed
-                    add(RPS_ROOT_FOLDER + "/random-folder/dataset/dataset");
-                    add(RPS_ROOT_FOLDER + "/random-folder/dataset/dataset[2]");
-                    add(RPS_ROOT_FOLDER + "/random-folder/dataset/dataset[3]");
-                }}
+                    RPS_ROOT_FOLDER + "/random-folder/dataset/dataset",
+                    RPS_ROOT_FOLDER + "/random-folder/dataset/dataset[2]",
+                    RPS_ROOT_FOLDER + "/random-folder/dataset/dataset[3]"
+                )
             }
         };
     }
@@ -234,7 +235,7 @@ public class SearchableFlagTaskTest {
     public List<Node> getQueryResults(List<String> paths) throws RepositoryException {
         List<Node> nodes = new ArrayList<>();
 
-        for (int i=0; i < paths.size(); i++) {
+        for (int i = 0; i < paths.size(); i++) {
             nodes.add(getNode(paths.get(i)));
         }
 

--- a/cms/src/test/java/uk/nhs/digital/ps/workflow/searchableTaxonomy/SearchableTaxonomyTaskTest.java
+++ b/cms/src/test/java/uk/nhs/digital/ps/workflow/searchableTaxonomy/SearchableTaxonomyTaskTest.java
@@ -114,8 +114,8 @@ public class SearchableTaxonomyTaskTest {
             .map(value -> {
                 try {
                     return value.getString();
-                } catch (RepositoryException e) {
-                    throw new RuntimeException(e);
+                } catch (RepositoryException repositoryException) {
+                    throw new RuntimeException(repositoryException);
                 }
             }).collect(toList());
     }
@@ -135,11 +135,11 @@ public class SearchableTaxonomyTaskTest {
 
     @Test
     public void settingNewPropertyOnCorrectNodes() throws RepositoryException, WorkflowException {
-        String docName = "publishedDocument";
-        Node documentNode = rootNode.addNode(docName);
-        Node published = addSubDocument(documentNode, PUBLISHED, "");
-        Node unpublished = addSubDocument(documentNode, UNPUBLISHED, "[2]");
-        Node draft = addSubDocument(documentNode, DRAFT, "[3]");
+        final String docName = "publishedDocument";
+        final Node documentNode = rootNode.addNode(docName);
+        final Node published = addSubDocument(documentNode, PUBLISHED, "");
+        final Node unpublished = addSubDocument(documentNode, UNPUBLISHED, "[2]");
+        final Node draft = addSubDocument(documentNode, DRAFT, "[3]");
 
         performTask(documentNode);
 
@@ -174,12 +174,12 @@ public class SearchableTaxonomyTaskTest {
             return;
         }
 
-        for (int i=1; i<=3; i++) {
+        for (int i = 1; i <= 3; i++) {
             String childKey = parentKey + "_" + i;
             Node child = parent.addNode(childKey, TAXONOMY_CATEGORY_NODE_TYPE);
             child.setProperty(TAXONOMY_KEY_PROPERTY, childKey);
             child.addNode("unrelated", "unrelated:node");
-            createTaxonomyTree(child, childKey, depth+1);
+            createTaxonomyTree(child, childKey, depth + 1);
 
             Node info = child.addNode(TAXONOMY_CATEGORY_INFOS_PROPERTY).addNode("en");
             info.setProperty(TAXONOMY_NAME_PROPERTY, convertKeyToName(childKey));

--- a/pom.xml
+++ b/pom.xml
@@ -412,6 +412,7 @@
                             <consoleOutput>false</consoleOutput>
                             <failsOnError>true</failsOnError>
                             <violationSeverity>warning</violationSeverity>
+                            <includeTestSourceDirectory>true</includeTestSourceDirectory>
                             <linkXRef>false</linkXRef>
                         </configuration>
                         <goals>

--- a/repository-data/webfiles/src/test/java/resources/site/freemarker/FreemarkerFileTest.java
+++ b/repository-data/webfiles/src/test/java/resources/site/freemarker/FreemarkerFileTest.java
@@ -1,20 +1,22 @@
 package resources.site.freemarker;
 
+import static org.apache.commons.io.FilenameUtils.getExtension;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.core.Is.is;
+
 import org.junit.Test;
+
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.stream.Stream;
-import java.nio.file.*;
+import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.apache.commons.io.FilenameUtils.getExtension;
-import static org.hamcrest.core.Is.is;
+import java.util.stream.Stream;
 
 /**
  * Test to check freemarker .ftl templates have correct output formatting and auto escaping set as the first line
@@ -26,9 +28,9 @@ import static org.hamcrest.core.Is.is;
  */
 public class FreemarkerFileTest {
 
-    private final static String FTL_FILES_DIRECTORY = System.getProperty("user.dir") + "/src/main/resources/site/freemarker";
-    private final static String DIRECTIVE_OUTPUT_FORMAT_HTML = "<#ftl output_format=\"HTML\"";
-    private final static String DIRECTIVE_OUTPUT_FORMAT_PLAIN_TEXT = "<#ftl output_format=\"plainText\"";
+    private static final String FTL_FILES_DIRECTORY = System.getProperty("user.dir") + "/src/main/resources/site/freemarker";
+    private static final String DIRECTIVE_OUTPUT_FORMAT_HTML = "<#ftl output_format=\"HTML\"";
+    private static final String DIRECTIVE_OUTPUT_FORMAT_PLAIN_TEXT = "<#ftl output_format=\"plainText\"";
 
     @Test
     public void checkOutputFormatDirectiveIncluded() {
@@ -36,7 +38,7 @@ public class FreemarkerFileTest {
         // given (files in freemarker directory)
 
         // when
-        final List<String> filesMissingOutputFormatDirective = CheckFtlFilesForMissingOutputFormatDirective(FTL_FILES_DIRECTORY);
+        final List<String> filesMissingOutputFormatDirective = checkFtlFilesForMissingOutputFormatDirective(FTL_FILES_DIRECTORY);
 
         // then
         assertThat("Output Format correctly set in all freemarker templates.",
@@ -44,14 +46,13 @@ public class FreemarkerFileTest {
             is(empty()));
     }
 
-    private List<String> CheckFtlFilesForMissingOutputFormatDirective(final String pathToCheck) {
+    private List<String> checkFtlFilesForMissingOutputFormatDirective(final String pathToCheck) {
 
         final List<String> filesMissingOutputFormatDirective = new ArrayList<>();
 
         try {
             // Check for files in this folder and all sub folders
-            Files.walkFileTree(Paths.get(pathToCheck), new SimpleFileVisitor<Path>()
-            {
+            Files.walkFileTree(Paths.get(pathToCheck), new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
                     throws IOException {
@@ -70,15 +71,15 @@ public class FreemarkerFileTest {
                                 .map(f -> file.getFileName())
                                 .forEach(element -> filesMissingOutputFormatDirective.add(element.toString()));
 
-                        } catch (final Exception e) {
-                            throw new RuntimeException(e);
+                        } catch (final Exception exception) {
+                            throw new RuntimeException(exception);
                         }
                     }
                     return FileVisitResult.CONTINUE;
                 }
             });
-        } catch (final Exception e) {
-            throw new RuntimeException("Failed to check ftl files in " + pathToCheck, e);
+        } catch (final Exception exception) {
+            throw new RuntimeException("Failed to check ftl files in " + pathToCheck, exception);
         }
 
         return filesMissingOutputFormatDirective;

--- a/site/src/test/java/uk/nhs/digital/common/contentrewriters/GoogleAnalyticsContentRewriterTest.java
+++ b/site/src/test/java/uk/nhs/digital/common/contentrewriters/GoogleAnalyticsContentRewriterTest.java
@@ -1,5 +1,9 @@
 package uk.nhs.digital.common.contentrewriters;
 
+import static org.mockito.BDDMockito.given;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static uk.nhs.digital.common.contentrewriters.GoogleAnalyticsContentRewriter.getHtmlCleaner;
+
 import org.hippoecm.hst.configuration.hosting.Mount;
 import org.hippoecm.hst.content.beans.ObjectBeanManagerException;
 import org.hippoecm.hst.content.beans.manager.ObjectConverter;
@@ -11,13 +15,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
-import javax.jcr.Node;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static org.mockito.BDDMockito.given;
-import static org.mockito.MockitoAnnotations.initMocks;
-import static uk.nhs.digital.common.contentrewriters.GoogleAnalyticsContentRewriter.getHtmlCleaner;
+import javax.jcr.Node;
 
 public class GoogleAnalyticsContentRewriterTest {
 
@@ -31,7 +31,7 @@ public class GoogleAnalyticsContentRewriterTest {
 
 
     @Before
-    public void setUp() throws ObjectBeanManagerException{
+    public void setUp() throws ObjectBeanManagerException {
         initMocks(this);
 
         given(requestContext.getContentBeansTool()).willReturn(contentBeansTool);
@@ -41,7 +41,7 @@ public class GoogleAnalyticsContentRewriterTest {
     }
 
     @Test
-    public void rewriteTest(){
+    public void rewriteTest() {
 
         GoogleAnalyticsContentRewriter rewriter = new GoogleAnalyticsContentRewriter();
 
@@ -51,14 +51,15 @@ public class GoogleAnalyticsContentRewriterTest {
 
         TagNode rootNode = getHtmlCleaner().clean(result);
         TagNode[] links = rootNode.getElementsByName("a", true);
+
+        String regex = "logGoogleAnalyticsEvent";
+        Pattern pattern = Pattern.compile(regex);
+
         for (TagNode link : links) {
             String onClickEvent = link.getAttributeByName("onClick");
-            String regex = "logGoogleAnalyticsEvent";
-
-            Pattern pattern = Pattern.compile(regex);
             Matcher matcher = pattern.matcher(onClickEvent);
 
-            assert(matcher.find());
+            assert matcher.find();
         }
     }
 

--- a/site/src/test/java/uk/nhs/digital/common/valve/ArticleValveTest.java
+++ b/site/src/test/java/uk/nhs/digital/common/valve/ArticleValveTest.java
@@ -1,5 +1,11 @@
 package uk.nhs.digital.common.valve;
-import org.hippoecm.hst.configuration.hosting.Mount;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
 import org.hippoecm.hst.content.beans.query.HstQuery;
 import org.hippoecm.hst.content.beans.query.HstQueryManager;
 import org.hippoecm.hst.content.beans.query.HstQueryResult;
@@ -7,7 +13,6 @@ import org.hippoecm.hst.content.beans.query.filter.Filter;
 import org.hippoecm.hst.content.beans.standard.HippoBean;
 import org.hippoecm.hst.content.beans.standard.HippoBeanIterator;
 import org.hippoecm.hst.core.container.ContainerException;
-import org.hippoecm.hst.core.container.HstContainerURL;
 import org.hippoecm.hst.core.container.ValveContext;
 import org.hippoecm.hst.core.linking.HstLink;
 import org.hippoecm.hst.core.linking.HstLinkCreator;
@@ -16,14 +21,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import uk.nhs.digital.common.valves.ArticleValve;
+
+import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 public class ArticleValveTest {
 

--- a/site/src/test/java/uk/nhs/digital/common/valve/PublicationValveTest.java
+++ b/site/src/test/java/uk/nhs/digital/common/valve/PublicationValveTest.java
@@ -1,6 +1,11 @@
 package uk.nhs.digital.common.valve;
 
-import org.hippoecm.hst.configuration.hosting.Mount;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
 import org.hippoecm.hst.content.beans.query.HstQuery;
 import org.hippoecm.hst.content.beans.query.HstQueryManager;
 import org.hippoecm.hst.content.beans.query.HstQueryResult;
@@ -8,7 +13,6 @@ import org.hippoecm.hst.content.beans.query.filter.Filter;
 import org.hippoecm.hst.content.beans.standard.HippoBean;
 import org.hippoecm.hst.content.beans.standard.HippoBeanIterator;
 import org.hippoecm.hst.core.container.ContainerException;
-import org.hippoecm.hst.core.container.HstContainerURL;
 import org.hippoecm.hst.core.container.ValveContext;
 import org.hippoecm.hst.core.linking.HstLink;
 import org.hippoecm.hst.core.linking.HstLinkCreator;
@@ -18,15 +22,9 @@ import org.junit.Test;
 import org.mockito.Mock;
 import uk.nhs.digital.common.valves.PublicationValve;
 
+import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 public class PublicationValveTest {
 

--- a/site/src/test/java/uk/nhs/digital/externalstorage/s3/valves/S3ConnectorValveTest.java
+++ b/site/src/test/java/uk/nhs/digital/externalstorage/s3/valves/S3ConnectorValveTest.java
@@ -1,25 +1,5 @@
 package uk.nhs.digital.externalstorage.s3.valves;
 
-import org.hippoecm.hst.core.container.ValveContext;
-import org.hippoecm.hst.core.request.HstRequestContext;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
-import uk.nhs.digital.common.ServiceProvider;
-import uk.nhs.digital.externalstorage.s3.SchedulingS3Connector;
-import uk.nhs.digital.externalstorage.s3.S3File;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.function.Consumer;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.ServletOutputStream;
-
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
@@ -35,6 +15,26 @@ import static org.mockito.MockitoAnnotations.initMocks;
 import static uk.nhs.digital.test.util.RandomHelper.newRandomByteArray;
 import static uk.nhs.digital.test.util.RandomHelper.newRandomInt;
 import static uk.nhs.digital.test.util.RandomHelper.newRandomString;
+
+import org.hippoecm.hst.core.container.ValveContext;
+import org.hippoecm.hst.core.request.HstRequestContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import uk.nhs.digital.common.ServiceProvider;
+import uk.nhs.digital.externalstorage.s3.S3File;
+import uk.nhs.digital.externalstorage.s3.SchedulingS3Connector;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.Consumer;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 public class S3ConnectorValveTest {
 
@@ -120,7 +120,7 @@ public class S3ConnectorValveTest {
     }
 
     @Test
-    public void reportsBadRequest_onNotCMSRequest() throws Exception {
+    public void reportsBadRequest_onNotCmsRequest() throws Exception {
 
         // given
         given(hstRequestContext.isCmsRequest()).willReturn(false);
@@ -201,23 +201,23 @@ public class S3ConnectorValveTest {
         private int closedCount = 0;
 
         @Override
-        public void write(final int b) throws IOException {
+        public void write(final int bytes) throws IOException {
             throw new UnsupportedOperationException("Not applicable in this test.");
         }
 
         @Override
-        public void write(final byte[] b, final int off, final int len) throws IOException {
-            byteArrayOutputStream.write(b, off, len);
-        }
-
-        byte[] getContent() {
-            return byteArrayOutputStream.toByteArray();
+        public void write(final byte[] bytes, final int off, final int len) throws IOException {
+            byteArrayOutputStream.write(bytes, off, len);
         }
 
         @Override
         public void close() throws IOException {
             byteArrayOutputStream.close();
             closedCount++;
+        }
+
+        byte[] getContent() {
+            return byteArrayOutputStream.toByteArray();
         }
 
         int getClosedCount() {
@@ -244,12 +244,6 @@ public class S3ConnectorValveTest {
             return byteArrayInputStream.read(buffer);
         }
 
-        void throwExceptionIfProgrammedTo() {
-            if (expectedException != null) {
-                throw expectedException;
-            }
-        }
-
         @Override
         public int read() throws IOException {
             throw new UnsupportedOperationException("Not applicable in this test.");
@@ -267,6 +261,12 @@ public class S3ConnectorValveTest {
 
         void willThrowException(final RuntimeException expectedException) {
             this.expectedException = expectedException;
+        }
+
+        private void throwExceptionIfProgrammedTo() {
+            if (expectedException != null) {
+                throw expectedException;
+            }
         }
     }
 }

--- a/site/src/test/java/uk/nhs/digital/ps/beans/DatasetTest.java
+++ b/site/src/test/java/uk/nhs/digital/ps/beans/DatasetTest.java
@@ -1,5 +1,17 @@
 package uk.nhs.digital.ps.beans;
 
+import static java.util.Arrays.asList;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.MockitoAnnotations.initMocks;
+
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
@@ -8,7 +20,6 @@ import org.hippoecm.hst.content.beans.manager.ObjectConverter;
 import org.hippoecm.hst.content.beans.query.HstQuery;
 import org.hippoecm.hst.content.beans.query.HstQueryResult;
 import org.hippoecm.hst.content.beans.query.builder.HstQueryBuilder;
-import org.hippoecm.hst.content.beans.standard.HippoBean;
 import org.hippoecm.hst.content.beans.standard.HippoFolder;
 import org.hippoecm.hst.core.request.HstRequestContext;
 import org.hippoecm.hst.mock.core.request.MockHstRequestContext;
@@ -25,23 +36,15 @@ import org.powermock.modules.junit4.PowerMockRunnerDelegate;
 import uk.nhs.digital.ps.site.exceptions.DataRestrictionViolationException;
 import uk.nhs.digital.ps.test.util.ReflectionHelper;
 
-import javax.jcr.Node;
-import javax.jcr.NodeIterator;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.*;
-
-import static java.util.Arrays.asList;
-import static java.util.Arrays.stream;
-import static java.util.stream.Collectors.toList;
-import static org.hamcrest.Matchers.*;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.MockitoAnnotations.initMocks;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
 
 
 @RunWith(PowerMockRunner.class)
@@ -123,17 +126,17 @@ public class DatasetTest {
             // then
             fail("No exception was thrown from getter " + forbiddenGetter);
 
-        } catch (final InvocationTargetException e) {
-            assertThat("Getter " + forbiddenGetter + " throws exception of correct type.", e.getCause(),
+        } catch (final InvocationTargetException exception) {
+            assertThat("Getter " + forbiddenGetter + " throws exception of correct type.", exception.getCause(),
                 instanceOf(DataRestrictionViolationException.class)
             );
-            assertThat("Getter " + forbiddenGetter + " throws exception with correct message.", e.getCause().getMessage(),
+            assertThat("Getter " + forbiddenGetter + " throws exception with correct message.", exception.getCause().getMessage(),
                 startsWith("Property is not available when parent publication is flagged as 'not publicly accessible':")
             );
-        } catch (final Exception e) {
-            System.out.println(e.getMessage());
-            throw new Error("Failed to test '" + forbiddenGetter + " because of an error;" +
-                " see stack trace below for details.", e
+        } catch (final Exception exception) {
+            System.out.println(exception.getMessage());
+            throw new Error("Failed to test '" + forbiddenGetter + " because of an error;"
+                + " see stack trace below for details.", exception
             );
         }
     }
@@ -156,11 +159,11 @@ public class DatasetTest {
 
             // then
             // pass
-        } catch (final Throwable e) {
-            e.printStackTrace(); // helps with debugging
+        } catch (final Throwable throwable) {
+            throwable.printStackTrace(); // helps with debugging
             throw new AssertionError(
-                "No exception was expected to be thrown from '" + permittedGetter + "' but one was emitted;" +
-                    " see stack trace below for details.", e
+                "No exception was expected to be thrown from '" + permittedGetter + "' but one was emitted;"
+                    + " see stack trace below for details.", throwable
             );
         }
     }

--- a/site/src/test/java/uk/nhs/digital/ps/beans/PublicationTest.java
+++ b/site/src/test/java/uk/nhs/digital/ps/beans/PublicationTest.java
@@ -182,17 +182,16 @@ public class PublicationTest {
             // then
             fail("No exception was thrown from getter " + forbiddenGetter);
 
-        } catch (final InvocationTargetException e) {
-            assertThat("Getter " + forbiddenGetter + " throws exception of correct type.", e.getCause(),
+        } catch (final InvocationTargetException exception) {
+            assertThat("Getter " + forbiddenGetter + " throws exception of correct type.", exception.getCause(),
                 instanceOf(DataRestrictionViolationException.class)
             );
-            assertThat("Getter " + forbiddenGetter + " throws exception with correct message.", e.getCause().getMessage(),
+            assertThat("Getter " + forbiddenGetter + " throws exception with correct message.", exception.getCause().getMessage(),
                 startsWith("Property is not available when publication is flagged as 'not publicly accessible':")
             );
-        } catch (final Exception e) {
-            throw new Error("Failed to test '" + forbiddenGetter + " because of an error;" +
-                " see stack trace below for details.", e
-            );
+        } catch (final Exception exception) {
+            throw new Error("Failed to test '" + forbiddenGetter + " because of an error;"
+                + " see stack trace below for details.", exception);
         }
     }
 
@@ -214,11 +213,11 @@ public class PublicationTest {
 
             // then
             // pass
-        } catch (final Throwable e) {
-            e.printStackTrace(); // helps with debugging
+        } catch (final Throwable throwable) {
+            throwable.printStackTrace(); // helps with debugging
             throw new AssertionError(
-                "No exception was expected to be thrown from '" + permittedGetter + "' but one was emitted;" +
-                    " see stack trace below for details.", e
+                "No exception was expected to be thrown from '" + permittedGetter + "' but one was emitted;"
+                    + " see stack trace below for details.", throwable
             );
         }
     }

--- a/site/src/test/java/uk/nhs/digital/ps/beans/RestrictableDateTest.java
+++ b/site/src/test/java/uk/nhs/digital/ps/beans/RestrictableDateTest.java
@@ -1,15 +1,15 @@
 package uk.nhs.digital.ps.beans;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.nhs.digital.ps.site.exceptions.DataRestrictionViolationException;
 
-import java.time.*;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import java.time.LocalDate;
 
 public class RestrictableDateTest {
 
@@ -55,8 +55,8 @@ public class RestrictableDateTest {
         final RestrictableDate restrictableDate = RestrictableDate.restrictedDateFrom(localDate);
 
         expectedException.expect(DataRestrictionViolationException.class);
-        expectedException.expectMessage("Restricted date does not contain day of month component." +
-            " Consult 'isRestricted()' before requesting day of month value.");
+        expectedException.expectMessage("Restricted date does not contain day of month component."
+            + " Consult 'isRestricted()' before requesting day of month value.");
 
         // when
         restrictableDate.getDayOfMonth();

--- a/site/src/test/java/uk/nhs/digital/ps/beans/structuredText/StructuredTextTest.java
+++ b/site/src/test/java/uk/nhs/digital/ps/beans/structuredText/StructuredTextTest.java
@@ -1,15 +1,18 @@
 package uk.nhs.digital.ps.beans.structuredText;
 
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.*;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RunWith(DataProviderRunner.class)
 public class StructuredTextTest {
@@ -22,13 +25,12 @@ public class StructuredTextTest {
         final StructuredText actual = new StructuredText(input);
 
         // when
-        List<Element> actualElement = actual.getElements();
+        List<Element> actualElements = actual.getElements();
 
         // then
-        int i = 0;
-        for(Element element: actualElement) {
+        for (int i = 0; i < actualElements.size(); i++) {
             assertThat("Paragraph element matches",
-                element.toString(), is(expectedElements.get(i++).toString()));
+                expectedElements.get(i).toString(), is(expectedElements.get(i).toString()));
         }
     }
 
@@ -40,13 +42,14 @@ public class StructuredTextTest {
         final StructuredText actual = new StructuredText(input);
 
         // when
-        List<Element> actualElement = actual.getElements();
+        List<Element> actualElements = actual.getElements();
 
         // then
-        int i = 0;
-        for(Element element: actualElement) {
+        for (int i = 0; i < actualElements.size(); i++) {
             assertThat("Paragraph element matches",
-                element.getClass().getSimpleName(), is(expectedElements.get(i++).getClass().getSimpleName()));
+                expectedElements.get(i).getClass().getSimpleName(),
+                is(expectedElements.get(i).getClass().getSimpleName())
+            );
         }
     }
 
@@ -56,68 +59,68 @@ public class StructuredTextTest {
             {
                 "First paragraph lorem ipsum dolor.",
 
-                new ArrayList() {{
-                    add(new Paragraph("First paragraph lorem ipsum dolor."));
-                }}
+                asList(
+                    new Paragraph("First paragraph lorem ipsum dolor.")
+                )
             },
             {
-                "First paragraph lorem ipsum dolor.\n" +
-                "\n\n\n\n",
+                "First paragraph lorem ipsum dolor.\n"
+                    + "\n\n\n\n",
 
-                new ArrayList() {{
-                    add(new Paragraph("First paragraph lorem ipsum dolor."));
-                }}
+                asList(
+                    new Paragraph("First paragraph lorem ipsum dolor.")
+                )
             },
             {
-                "\n\n\n\n" +
-                "First paragraph lorem ipsum dolor." +
-                "\n\n\n\n",
+                "\n\n\n\n"
+                    + "First paragraph lorem ipsum dolor."
+                    + "\n\n\n\n",
 
-                new ArrayList() {{
-                    add(new Paragraph("First paragraph lorem ipsum dolor."));
-                }}
+                asList(
+                    new Paragraph("First paragraph lorem ipsum dolor.")
+                )
             },
             {
-                "\n\n  \n\n" +
-                "First paragraph lorem ipsum dolor." +
-                "\n\n    \n\n   \n\n\n  ",
+                "\n\n  \n\n"
+                    + "First paragraph lorem ipsum dolor."
+                    + "\n\n    \n\n   \n\n\n  ",
 
-                new ArrayList() {{
-                    add(new Paragraph("First paragraph lorem ipsum dolor."));
-                }}
+                asList(
+                    new Paragraph("First paragraph lorem ipsum dolor.")
+                )
             },
             {
-                "First paragraph lorem ipsum dolor.\n" +
-                "\n" +
-                "Second paragraph",
+                "First paragraph lorem ipsum dolor.\n"
+                    + "\n"
+                    + "Second paragraph",
 
-                new ArrayList() {{
-                    add(new Paragraph("First paragraph lorem ipsum dolor."));
-                    add(new Paragraph("Second paragraph"));
-                }}
+                asList(
+                    new Paragraph("First paragraph lorem ipsum dolor."),
+                    new Paragraph("Second paragraph")
+                )
             },
             {
-                "First paragraph lorem ipsum dolor.\n" +
-                "\n\n\n\n" +
-                "Second paragraph",
+                "First paragraph lorem ipsum dolor.\n"
+                    + "\n\n\n\n"
+                    + "Second paragraph",
 
-                new ArrayList() {{
-                    add(new Paragraph("First paragraph lorem ipsum dolor."));
-                    add(new Paragraph("Second paragraph"));
-                }}
+                asList(
+                    new Paragraph("First paragraph lorem ipsum dolor."),
+                    new Paragraph("Second paragraph")
+                )
             },
             {
-                "First paragraph.\n" +
-                "\n\n\n\n" +
-                "Second paragraph." +
-                "\n\n\n" +
-                "Third paragraph.",
+                "First paragraph.\n"
+                    + "\n\n\n\n"
+                    + "Second paragraph."
+                    + "\n\n\n"
+                    + "Third paragraph.",
 
-                new ArrayList() {{
-                    add(new Paragraph("First paragraph."));
-                    add(new Paragraph("Second paragraph."));
-                    add(new Paragraph("Third paragraph."));
-                }}
+                asList(
+                    new Paragraph("First paragraph."),
+                    new Paragraph("Second paragraph."),
+                    new Paragraph("Third paragraph.")
+                )
             },
         };
     }
@@ -126,42 +129,49 @@ public class StructuredTextTest {
     public static Object[][] paragraphsAndLists() {
         return new Object[][]{
             {
-                "First paragraph lorem ipsum dolor.\n" +
-                "\n" +
-                "* first list item\n" +
-                "* second list item",
-
-                new ArrayList() {{
-                    add(new Paragraph("First paragraph lorem ipsum dolor."));
-                    add(new BulletList("* first list item\n* second list item"));
-                }}
+                asOneString(
+                    "First paragraph lorem ipsum dolor.\n",
+                    "\n",
+                    "* first list item\n",
+                    "* second list item"
+                ),
+                asList(
+                    new Paragraph("First paragraph lorem ipsum dolor."),
+                    new BulletList("* first list item\n* second list item")
+                )
             },
             {
-                "First paragraph lorem ipsum dolor.\n" +
-                "\n" +
-                "* first list item\n" +
-                "* second list item\n" +
-                "\n",
-                "Second paragraph sit ament.\n",
-
-                new ArrayList() {{
-                    add(new Paragraph("First paragraph lorem ipsum dolor."));
-                    add(new BulletList("* first list item\n* second list item"));
-                    add(new Paragraph("Second paragraph sit ament."));
-                }}
+                asOneString(
+                    "First paragraph lorem ipsum dolor.\n",
+                    "\n",
+                    "* first list item\n",
+                    "* second list item\n",
+                    "\n",
+                    "Second paragraph sit ament.\n"
+                ),
+                asList(
+                    new Paragraph("First paragraph lorem ipsum dolor."),
+                    new BulletList("* first list item\n* second list item"),
+                    new Paragraph("Second paragraph sit ament.")
+                )
             },
             {
-                "\n\n  \n\n" +
-                "* first list item\n" +
-                "* second list item\n" +
-                "\n"+
-                "First paragraph lorem ipsum dolor.\n",
-
-                new ArrayList() {{
-                    add(new BulletList("* first list item\n* second list item"));
-                    add(new Paragraph("First paragraph lorem ipsum dolor."));
-                }}
+                asOneString(
+                    "\n\n  \n\n",
+                    "* first list item\n",
+                    "* second list item\n",
+                    "\n",
+                    "First paragraph lorem ipsum dolor.\n"
+                ),
+                asList(
+                    new BulletList("* first list item\n* second list item"),
+                    new Paragraph("First paragraph lorem ipsum dolor.")
+                )
             }
         };
+    }
+
+    private static String asOneString(final String... text) {
+        return Arrays.stream(text).collect(Collectors.joining(""));
     }
 }

--- a/site/src/test/java/uk/nhs/digital/ps/beans/structuredText/UnorderedListTest.java
+++ b/site/src/test/java/uk/nhs/digital/ps/beans/structuredText/UnorderedListTest.java
@@ -1,16 +1,18 @@
 package uk.nhs.digital.ps.beans.structuredText;
 
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
+import java.util.stream.Collectors;
 
 @RunWith(DataProviderRunner.class)
 public class UnorderedListTest {
@@ -26,10 +28,9 @@ public class UnorderedListTest {
         List<String> actualItems = actual.getItems();
 
         // then
-        int i = 0;
-        for(String item: actualItems) {
+        for (int i = 0; i < actualItems.size(); i++) {
             assertThat("List Item matches: " + expectedElements.get(i),
-                item, is(expectedElements.get(i++)));
+                actualItems.get(i), is(expectedElements.get(i++)));
         }
     }
 
@@ -39,55 +40,63 @@ public class UnorderedListTest {
             {
                 "* First item.",
 
-                new ArrayList() {{
-                    add("First item.");
-                }}
+                asList(
+                    "First item."
+                )
             },
             {
-                "* First item.\n" +
-                "* Second item.\n" +
-                "* Third item.",
-
-                new ArrayList() {{
-                    add("First item.");
-                    add("Second item.");
-                    add("Third item.");
-                }}
+                asOneString(
+                    "* First item.\n",
+                    "* Second item.\n",
+                    "* Third item."
+                ),
+                asList(
+                    "First item.",
+                    "Second item.",
+                    "Third item."
+                )
             },
             {
-                "  *  First item.\n" +
-                "  *  Second item.\n" +
-                "  *  Third item.",
-
-                new ArrayList() {{
-                    add("First item.");
-                    add("Second item.");
-                    add("Third item.");
-                }}
+                asOneString(
+                    "  *  First item.\n",
+                    "  *  Second item.\n",
+                    "  *  Third item."
+                ),
+                asList(
+                    "First item.",
+                    "Second item.",
+                    "Third item."
+                )
             },
             {
-                " * First item\n" +
-                "   with long text.\n" +
-                " * Second item.\n" +
-                " * Third item.",
-
-                new ArrayList() {{
-                    add("First item with long text.");
-                    add("Second item.");
-                    add("Third item.");
-                }}
+                asOneString(
+                    " * First item\n",
+                    "   with long text.\n",
+                    " * Second item.\n",
+                    " * Third item."
+                ),
+                asList(
+                    "First item with long text.",
+                    "Second item.",
+                    "Third item."
+                )
             },
             {
-                "*  First item.\n" +
-                "*  Second item with * character.\n" +
-                "*  Third item.\n",
-
-                new ArrayList() {{
-                    add("First item.");
-                    add("Second item with * character.");
-                    add("Third item.");
-                }}
+                asOneString(
+                    "*  First item.\n",
+                    "*  Second item with * character.\n",
+                    "*  Third item.\n"
+                ),
+                asList(
+                    "First item.",
+                    "Second item with * character.",
+                    "Third item."
+                )
             },
         };
+    }
+
+    private static String asOneString(final String... text) {
+        return Arrays.stream(text).collect(Collectors.joining(""));
     }
 }

--- a/site/src/test/java/uk/nhs/digital/ps/directives/FileSizeFormatterDirectiveTest.java
+++ b/site/src/test/java/uk/nhs/digital/ps/directives/FileSizeFormatterDirectiveTest.java
@@ -1,10 +1,17 @@
 package uk.nhs.digital.ps.directives;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import freemarker.core.Environment;
-import freemarker.template.*;
+import freemarker.template.SimpleNumber;
+import freemarker.template.Template;
+import freemarker.template.TemplateDirectiveBody;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateModel;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -14,9 +21,6 @@ import org.junit.runner.RunWith;
 import java.io.Writer;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 @RunWith(DataProviderRunner.class)
 public class FileSizeFormatterDirectiveTest {
@@ -101,8 +105,8 @@ public class FileSizeFormatterDirectiveTest {
         parameters.remove(BYTES_COUNT_PARAM_NAME);
 
         expectedException.expect(TemplateException.class);
-        expectedException.expectMessage("Required parameter 'bytesCount' was not provided to template uk.nhs.digital" +
-            ".ps.directives.FileSizeFormatterDirective.");
+        expectedException.expectMessage("Required parameter 'bytesCount' was not provided to template uk.nhs.digital"
+            + ".ps.directives.FileSizeFormatterDirective.");
 
         // when
         fileSizeFormatterDirective.execute(environment, parameters, loopVariables, body);

--- a/site/src/test/java/uk/nhs/digital/ps/directives/RestrictableDateFormatterDirectiveTest.java
+++ b/site/src/test/java/uk/nhs/digital/ps/directives/RestrictableDateFormatterDirectiveTest.java
@@ -1,5 +1,22 @@
 package uk.nhs.digital.ps.directives;
 
+import static java.text.MessageFormat.format;
+import static java.time.Month.APRIL;
+import static java.time.Month.AUGUST;
+import static java.time.Month.DECEMBER;
+import static java.time.Month.FEBRUARY;
+import static java.time.Month.JANUARY;
+import static java.time.Month.JULY;
+import static java.time.Month.JUNE;
+import static java.time.Month.MARCH;
+import static java.time.Month.MAY;
+import static java.time.Month.NOVEMBER;
+import static java.time.Month.OCTOBER;
+import static java.time.Month.SEPTEMBER;
+import static java.util.stream.Collectors.toList;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.MockitoAnnotations.initMocks;
+
 import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
@@ -7,7 +24,11 @@ import freemarker.core.Environment;
 import freemarker.ext.beans.BeansWrapper;
 import freemarker.ext.beans.BeansWrapperBuilder;
 import freemarker.ext.beans.StringModel;
-import freemarker.template.*;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateDirectiveBody;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateModel;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -21,13 +42,11 @@ import java.io.Writer;
 import java.time.LocalDate;
 import java.time.Month;
 import java.time.format.TextStyle;
-import java.util.*;
-
-import static java.text.MessageFormat.format;
-import static java.time.Month.*;
-import static java.util.stream.Collectors.toList;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.MockitoAnnotations.initMocks;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 @RunWith(DataProviderRunner.class)
 public class RestrictableDateFormatterDirectiveTest {

--- a/site/src/test/java/uk/nhs/digital/ps/test/util/ReflectionHelper.java
+++ b/site/src/test/java/uk/nhs/digital/ps/test/util/ReflectionHelper.java
@@ -18,7 +18,7 @@ public class ReflectionHelper {
         field.setAccessible(true);
         try {
             field.set(null, targetValue);
-        } catch (final IllegalAccessException e) {
+        } catch (final IllegalAccessException exception) {
             throw new RuntimeException("Failed to assign value " + targetValue + " to field " + field);
         }
     }

--- a/site/src/test/java/uk/nhs/digital/test/util/RandomHelper.java
+++ b/site/src/test/java/uk/nhs/digital/test/util/RandomHelper.java
@@ -1,14 +1,14 @@
 package uk.nhs.digital.test.util;
 
+import static java.util.Collections.shuffle;
+import static java.util.stream.Collectors.toList;
+
 import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 import java.util.stream.IntStream;
-
-import static java.util.Collections.shuffle;
-import static java.util.stream.Collectors.toList;
 
 public class RandomHelper {
 


### PR DESCRIPTION
Option 'includeTestSourceDirectory' makes the code style checker Maven
plugin to include test code in its audit; this has now been enabled.

The actual change that activates the above is one line in the parent pom.xml;
nearly all remaining changes are formatting-related to bring the test code into
compliance with the code style policy.

----

Also, rebase (rather than merge) is now enabled as a default action performed
by `git pull` - but only for repositories freshly initialised with
`make init`. To enable it for an already initialised local repository
execute `git config --local --add pull.rebase true`. This prevents
developers accidentally merging by executing 'git pull' where they
should have used `git rebase`, thus saving some headache in cleaning
up such merges.