### PR TITLE
[RPS-480] Restrict SVG upload to Hippo CMS

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/frontend/cms.yaml
@@ -20,6 +20,12 @@ definitions:
       - jpg
       - png
       max.file.size: 3000M
+    /hippo:configuration/hippo:frontend/cms/cms-services/imageValidationService:
+      extensions.allowed:
+      - jpg
+      - jpeg
+      - gif
+      - png
     /hippo:configuration/hippo:frontend/cms/cms-services/localeProviderService:
       /en:
         country: gb


### PR DESCRIPTION
Configuration of ImageValidationService has been updated to prevent
uploads of image files with extension 'svg', regardless of whether they
contain a script or not.