### PR TITLE
[RPS-450] S3 upload cap fix

### DIFF
--- a/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/AbstractExternalFileTask.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/AbstractExternalFileTask.java
@@ -8,7 +8,7 @@ import org.onehippo.repository.documentworkflow.DocumentVariant;
 import org.onehippo.repository.documentworkflow.task.AbstractDocumentTask;
 import org.onehippo.repository.events.HippoWorkflowEvent;
 import uk.nhs.digital.externalstorage.ExternalStorageConstants;
-import uk.nhs.digital.externalstorage.s3.S3Connector;
+import uk.nhs.digital.externalstorage.s3.SchedulingS3Connector;
 
 import java.rmi.RemoteException;
 import javax.jcr.Node;
@@ -21,13 +21,13 @@ public abstract class AbstractExternalFileTask extends AbstractDocumentTask {
 
     private String variantState;
 
-    private S3Connector s3Connector;
+    private SchedulingS3Connector s3Connector;
 
     public AbstractExternalFileTask() {
         super();
     }
 
-    public void setS3Connector(S3Connector s3Connector) {
+    public void setS3Connector(SchedulingS3Connector s3Connector) {
         this.s3Connector = s3Connector;
     }
 
@@ -77,7 +77,7 @@ public abstract class AbstractExternalFileTask extends AbstractDocumentTask {
         return res.getNodes();
     }
 
-    protected abstract void setTargetStatus(S3Connector s3, final String objectKey);
+    protected abstract void setTargetStatus(SchedulingS3Connector s3, String objectKey);
 
     public void logInCmsActivityStream(final String documentPath, final String message) {
         final HippoEventBus eventBus = HippoServiceRegistry.getService(HippoEventBus.class);

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFilePublish/ExternalFilePublishAction.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFilePublish/ExternalFilePublishAction.java
@@ -5,8 +5,7 @@ import org.apache.commons.scxml2.model.ModelException;
 import org.hippoecm.repository.HippoStdNodeType;
 import org.onehippo.cms7.services.HippoServiceRegistry;
 import org.onehippo.repository.documentworkflow.action.AbstractDocumentTaskAction;
-
-import uk.nhs.digital.externalstorage.s3.S3Connector;
+import uk.nhs.digital.externalstorage.s3.SchedulingS3Connector;
 
 public class ExternalFilePublishAction extends AbstractDocumentTaskAction<ExternalFilePublishTask> {
 
@@ -18,7 +17,7 @@ public class ExternalFilePublishAction extends AbstractDocumentTaskAction<Extern
     @Override
     protected void initTask(ExternalFilePublishTask task) throws ModelException, SCXMLExpressionException {
         super.initTask(task);
-        task.setS3Connector(HippoServiceRegistry.getService(S3Connector.class));
+        task.setS3Connector(HippoServiceRegistry.getService(SchedulingS3Connector.class));
         task.setVariantState(HippoStdNodeType.UNPUBLISHED);
     }
 }

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFilePublish/ExternalFilePublishTask.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFilePublish/ExternalFilePublishTask.java
@@ -1,11 +1,11 @@
 package uk.nhs.digital.externalstorage.workflow.externalFilePublish;
 
-import uk.nhs.digital.externalstorage.s3.S3Connector;
+import uk.nhs.digital.externalstorage.s3.SchedulingS3Connector;
 import uk.nhs.digital.externalstorage.workflow.AbstractExternalFileTask;
 
 public class ExternalFilePublishTask extends AbstractExternalFileTask {
 
-    protected void setTargetStatus(S3Connector s3Connector, final String resource) {
+    protected void setTargetStatus(final SchedulingS3Connector s3Connector, final String resource) {
         s3Connector.publishResource(resource);
     }
 }

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFileUnpublish/ExternalFileUnpublishAction.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFileUnpublish/ExternalFileUnpublishAction.java
@@ -5,7 +5,7 @@ import org.apache.commons.scxml2.model.ModelException;
 import org.hippoecm.repository.HippoStdNodeType;
 import org.onehippo.cms7.services.HippoServiceRegistry;
 import org.onehippo.repository.documentworkflow.action.AbstractDocumentTaskAction;
-import uk.nhs.digital.externalstorage.s3.S3Connector;
+import uk.nhs.digital.externalstorage.s3.SchedulingS3Connector;
 
 public class ExternalFileUnpublishAction extends AbstractDocumentTaskAction<ExternalFileUnpublishTask> {
 
@@ -17,7 +17,7 @@ public class ExternalFileUnpublishAction extends AbstractDocumentTaskAction<Exte
     @Override
     protected void initTask(ExternalFileUnpublishTask task) throws ModelException, SCXMLExpressionException {
         super.initTask(task);
-        task.setS3Connector(HippoServiceRegistry.getService(S3Connector.class));
+        task.setS3Connector(HippoServiceRegistry.getService(SchedulingS3Connector.class));
         task.setVariantState(HippoStdNodeType.PUBLISHED);
     }
 }

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFileUnpublish/ExternalFileUnpublishTask.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFileUnpublish/ExternalFileUnpublishTask.java
@@ -1,11 +1,11 @@
 package uk.nhs.digital.externalstorage.workflow.externalFileUnpublish;
 
-import uk.nhs.digital.externalstorage.s3.S3Connector;
+import uk.nhs.digital.externalstorage.s3.SchedulingS3Connector;
 import uk.nhs.digital.externalstorage.workflow.AbstractExternalFileTask;
 
 public class ExternalFileUnpublishTask extends AbstractExternalFileTask {
 
-    protected void setTargetStatus(S3Connector s3Connector, final String resource) {
+    protected void setTargetStatus(final SchedulingS3Connector s3Connector, final String resource) {
         s3Connector.unpublishResource(resource);
     }
 }

--- a/cms/src/test/java/uk/nhs/digital/externalstorage/workflow/externalFilePublish/ExternalFilePublishTaskTest.java
+++ b/cms/src/test/java/uk/nhs/digital/externalstorage/workflow/externalFilePublish/ExternalFilePublishTaskTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.onehippo.repository.documentworkflow.DocumentHandle;
 import uk.nhs.digital.externalstorage.ExternalStorageConstants;
-import uk.nhs.digital.externalstorage.s3.S3Connector;
+import uk.nhs.digital.externalstorage.s3.SchedulingS3Connector;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +25,7 @@ import javax.jcr.Session;
 
 public class ExternalFilePublishTaskTest {
 
-    @Mock private S3Connector s3Connector;
+    @Mock private SchedulingS3Connector s3Connector;
     @Mock private WorkflowContext workflowContext;
 
     private ExternalFilePublishTask externalFilePublishTask;

--- a/cms/src/test/java/uk/nhs/digital/externalstorage/workflow/externalFileUnpublish/ExternalFileUnpublishTaskTest.java
+++ b/cms/src/test/java/uk/nhs/digital/externalstorage/workflow/externalFileUnpublish/ExternalFileUnpublishTaskTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.onehippo.repository.documentworkflow.DocumentHandle;
 import uk.nhs.digital.externalstorage.ExternalStorageConstants;
-import uk.nhs.digital.externalstorage.s3.S3Connector;
+import uk.nhs.digital.externalstorage.s3.SchedulingS3Connector;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +25,7 @@ import javax.jcr.Session;
 
 public class ExternalFileUnpublishTaskTest {
 
-    @Mock private S3Connector s3Connector;
+    @Mock private SchedulingS3Connector s3Connector;
     @Mock private WorkflowContext workflowContext;
 
     private ExternalFileUnpublishTask externalFileUnpublishTask;


### PR DESCRIPTION
Fixes an NPE in workflow publish and unpublish external resource
tasks.

Workflow Task classes were getting null instead of expected instance
of S3Connector. This was due to the fact that the previous changes of
RPS-450 story stopped registering S3Connector in Hippo service registry,
registering an instance of SchedulingS3Connector instead; the affected
workflow Action and Task classes were not updated to start using the
replacement interface.