### PR TITLE
[RPS-437] S3 Peformance test

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -89,6 +89,13 @@
             <artifactId>junit</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>3.1.0</version>
+            <scope>test</scope>
+        </dependency>
+
         <!--
         Dependencies required in Cargo deployment.
 
@@ -317,6 +324,9 @@
                                 </deployable>
                             </deployables>
                             <container>
+                                <zipUrlInstaller>
+                                    <url>${tomcatDistributionUrl}</url>
+                                </zipUrlInstaller>
                                 <systemProperties>
                                     <log4j.configurationFile>file://${website.basedir}/conf/log4j2-dev.xml</log4j.configurationFile>
                                     <!-- enables auto export and web files watch: -->

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/config/AcceptanceTestConfiguration.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/config/AcceptanceTestConfiguration.java
@@ -1,5 +1,6 @@
 package uk.nhs.digital.ps.test.acceptance.config;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import org.slf4j.Logger;
@@ -7,6 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import uk.nhs.digital.ps.test.acceptance.data.TestDataRepo;
+import uk.nhs.digital.ps.test.acceptance.data.WebDriversRepo;
 import uk.nhs.digital.ps.test.acceptance.pages.ContentPage;
 import uk.nhs.digital.ps.test.acceptance.pages.DashboardPage;
 import uk.nhs.digital.ps.test.acceptance.pages.LoginPage;
@@ -31,30 +33,38 @@ public class AcceptanceTestConfiguration {
     private static final Logger log = getLogger(AcceptanceTestConfiguration.class);
 
     @Bean
-    public LoginPage loginPage(final WebDriverProvider webDriverProvider, PageHelper helper) {
-        return new LoginPage(webDriverProvider, helper);
+    public LoginPage loginPage(final WebDriverProvider webDriverProvider,
+                               final PageHelper pageHelper,
+                               final AcceptanceTestProperties acceptanceTestProperties) {
+        return new LoginPage(webDriverProvider, pageHelper, acceptanceTestProperties.getCmsUrl());
     }
 
     @Bean
-    public DashboardPage dashboardPage(final WebDriverProvider webDriverProvider, final PageHelper pageHelper) {
-        return new DashboardPage(webDriverProvider, pageHelper);
+    public DashboardPage dashboardPage(final WebDriverProvider webDriverProvider,
+                                       final PageHelper pageHelper,
+                                       final AcceptanceTestProperties acceptanceTestProperties) {
+        return new DashboardPage(webDriverProvider, pageHelper, acceptanceTestProperties.getCmsUrl());
     }
 
     @Bean
-    public ContentPage contentPage(final WebDriverProvider webDriverProvider, final PageHelper pageHelper) {
-        return new ContentPage(webDriverProvider, pageHelper);
+    public ContentPage contentPage(final WebDriverProvider webDriverProvider,
+                                   final PageHelper pageHelper,
+                                   final AcceptanceTestProperties acceptanceTestProperties) {
+        return new ContentPage(webDriverProvider, pageHelper, acceptanceTestProperties.getCmsUrl());
     }
 
     @Bean
     public PublicationPage publicationPage(final WebDriverProvider webDriverProvider,
-                                                     final PageHelper pageHelper) {
-        return new PublicationPage(webDriverProvider, pageHelper);
+                                           final PageHelper pageHelper,
+                                           final AcceptanceTestProperties acceptanceTestProperties) {
+        return new PublicationPage(webDriverProvider, pageHelper, acceptanceTestProperties.getSiteUrl());
     }
 
     @Bean
     public SearchPage searchResultsPage(final WebDriverProvider webDriverProvider,
-                                        final PageHelper pageHelper) {
-        return new SearchPage(webDriverProvider, pageHelper);
+                                        final PageHelper pageHelper,
+                                        final AcceptanceTestProperties acceptanceTestProperties) {
+        return new SearchPage(webDriverProvider, pageHelper, acceptanceTestProperties.getCmsUrl());
     }
 
     @Bean
@@ -68,8 +78,16 @@ public class AcceptanceTestConfiguration {
     }
 
     @Bean
-    public TestContentUrls testContentUrls() {
-        return new TestContentUrls();
+    public WebDriversRepo testUserRepo() {
+        return new WebDriversRepo();
+    }
+
+    @Bean
+    public TestContentUrls testContentUrls(final AcceptanceTestProperties acceptanceTestProperties) {
+        return new TestContentUrls(
+            acceptanceTestProperties.getCmsUrl(),
+            acceptanceTestProperties.getSiteUrl()
+        );
     }
 
     @Bean
@@ -99,11 +117,16 @@ public class AcceptanceTestConfiguration {
         // buildDirectory - full path to a directory that the build process generates artefacts into, one that the
         //                  tests can safely write temporary content to and expected that it'll be gone on clean build.
         //                  In Maven this would typically be 'target' directory of the current module.
+        // cmsUrl         - URL of the CMS application. Optional, if missing, defaults to http://localhost:8080/cms
+        // siteUrl        - URL of the Site application. Optional, if missing, defaults to http://localhost:8080
 
         final AcceptanceTestProperties acceptanceTestProperties = new AcceptanceTestProperties(
             Boolean.parseBoolean(environment.getProperty("headless", "true")),
             Paths.get(buildDirectory, "download"),
-            Paths.get(buildDirectory));
+            Paths.get(buildDirectory),
+            getProperty(environment, "cmsUrl", "http://localhost:8080/cms"),
+            getProperty(environment, "siteUrl", "http://localhost:8080")
+        );
 
         log.info("Applying test properties: {}", acceptanceTestProperties);
 
@@ -111,20 +134,28 @@ public class AcceptanceTestConfiguration {
     }
 
     @Bean
-    public SitePage sitePage(final WebDriverProvider webDriverProvider, final PageHelper pageHelper) {
-        return new SitePage(webDriverProvider, pageHelper);
+    public SitePage sitePage(final WebDriverProvider webDriverProvider,
+                             final PageHelper pageHelper,
+                             final AcceptanceTestProperties acceptanceTestProperties,
+                             final TestContentUrls testContentUrls) {
+        return new SitePage(webDriverProvider, pageHelper, acceptanceTestProperties.getCmsUrl(), testContentUrls);
     }
 
     @Bean
     public ServicePage servicePage(final WebDriverProvider webDriverProvider,
-                                   final PageHelper pageHelper) {
-        return new ServicePage(webDriverProvider, pageHelper);
+                                   final AcceptanceTestProperties acceptanceTestProperties) {
+        return new ServicePage(webDriverProvider, acceptanceTestProperties.getCmsUrl());
     }
 
     @Bean
     public HomePage homePage(final WebDriverProvider webDriverProvider,
-                             final PageHelper pageHelper) {
-        return new HomePage(webDriverProvider, pageHelper);
+                             final AcceptanceTestProperties acceptanceTestProperties) {
+        return new HomePage(webDriverProvider, acceptanceTestProperties.getCmsUrl());
     }
 
+    private String getProperty(Environment environment, String propertyKey, String defaultPropertyValue) {
+        final String resolvedPropertyValue = environment.getProperty(propertyKey);
+
+        return isNotBlank(resolvedPropertyValue) ? resolvedPropertyValue : defaultPropertyValue;
+    }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/config/AcceptanceTestProperties.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/config/AcceptanceTestProperties.java
@@ -8,11 +8,19 @@ public class AcceptanceTestProperties {
     private final boolean headlessMode;
     private final Path downloadDir;
     private final Path tempDir;
+    private final String cmsUrl;
+    private final String siteUrl;
 
-    AcceptanceTestProperties(final boolean headlessMode, final Path downloadDir, final Path tempDir) {
+    AcceptanceTestProperties(final boolean headlessMode,
+                             final Path downloadDir,
+                             final Path tempDir,
+                             final String cmsUrl,
+                             final String siteUrl) {
         this.headlessMode = headlessMode;
         this.downloadDir = downloadDir;
         this.tempDir = tempDir;
+        this.cmsUrl = cmsUrl;
+        this.siteUrl = siteUrl;
     }
 
     /**
@@ -47,5 +55,19 @@ public class AcceptanceTestProperties {
             + ", downloadDir=" + downloadDir
             + ", tempDir=" + tempDir
             + '}';
+    }
+
+    /**
+     * @return URL of CMS application.
+     */
+    public String getCmsUrl() {
+        return cmsUrl;
+    }
+
+    /**
+     * @return URL of CMS application.
+     */
+    public String getSiteUrl() {
+        return siteUrl;
     }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/data/WebDriversRepo.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/data/WebDriversRepo.java
@@ -1,0 +1,26 @@
+package uk.nhs.digital.ps.test.acceptance.data;
+
+import static java.util.Collections.synchronizedList;
+import static java.util.Collections.unmodifiableCollection;
+
+import org.openqa.selenium.WebDriver;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class WebDriversRepo {
+
+    private Collection<WebDriver> webDrivers = synchronizedList(new ArrayList<>());
+
+    public void addWebDriver(final WebDriver webDriver) {
+        this.webDrivers.add(webDriver);
+    }
+
+    public Collection<WebDriver> getAll() {
+        return unmodifiableCollection(webDrivers);
+    }
+
+    public int size() {
+        return webDrivers.size();
+    }
+}

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/section/ImageSection.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/models/section/ImageSection.java
@@ -9,7 +9,7 @@ import uk.nhs.digital.ps.test.acceptance.util.TestContentUrls;
 
 public class ImageSection extends BodySection {
 
-    private static final TestContentUrls urlLookup = new TestContentUrls();
+    private final TestContentUrls testContentUrls;
 
     private final String imageName;
     private final String altText;
@@ -21,10 +21,11 @@ public class ImageSection extends BodySection {
         this.altText = altText;
         this.caption = caption;
         this.link = link;
+        testContentUrls = TestContentUrls.instance();
     }
 
     public String getSource() {
-        return urlLookup.lookupUrl(imageName);
+        return testContentUrls.lookupSiteUrl(imageName);
     }
 
     public String getAltText() {

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/AbstractCmsPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/AbstractCmsPage.java
@@ -4,13 +4,11 @@ import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverProvider;
 
 public class AbstractCmsPage extends AbstractPage {
 
-    protected static final String URL = "http://localhost:8080/cms";
-
-    AbstractCmsPage(final WebDriverProvider webDriverProvider) {
-        super(webDriverProvider);
+    AbstractCmsPage(final WebDriverProvider webDriverProvider, String cmsUrl) {
+        super(webDriverProvider, cmsUrl);
     }
 
     public void openCms() {
-        getWebDriver().get(URL);
+        getWebDriver().get(getUrl());
     }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/AbstractPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/AbstractPage.java
@@ -10,12 +10,25 @@ import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverProvider;
 public abstract class AbstractPage {
 
     private final WebDriverProvider webDriverProvider;
+    private final String applicationUrl;
 
-    public AbstractPage(final WebDriverProvider webDriverProvider) {
+    public AbstractPage(final WebDriverProvider webDriverProvider, final String applicationUrl) {
         this.webDriverProvider = webDriverProvider;
+        this.applicationUrl = applicationUrl;
     }
 
     protected WebDriver getWebDriver() {
         return webDriverProvider.getWebDriver();
+    }
+
+    /**
+     * See {@linkplain WebDriverProvider#newWebDriver(String)} for details.
+     */
+    protected WebDriver getNewWebDriver(String userName) {
+        return webDriverProvider.newWebDriver(userName);
+    }
+
+    protected String getUrl() {
+        return applicationUrl;
     }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ContentPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/ContentPage.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.toList;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 import org.openqa.selenium.support.ui.ExpectedConditions;
@@ -26,8 +27,10 @@ public class ContentPage extends AbstractCmsPage {
 
     private PageHelper helper;
 
-    public ContentPage(final WebDriverProvider webDriverProvider, final PageHelper helper) {
-        super(webDriverProvider);
+    public ContentPage(final WebDriverProvider webDriverProvider,
+                       final PageHelper helper,
+                       final String cmsUrl) {
+        super(webDriverProvider, cmsUrl);
         this.helper = helper;
     }
 
@@ -534,5 +537,16 @@ public class ContentPage extends AbstractCmsPage {
 
         // Confirm
         clickButtonOnModalDialog("OK");
+    }
+
+    public void openDocumentByUrlForPreview(final WebDriver webDriver,
+                                            final String url,
+                                            final String expectedTitle) {
+        webDriver.get(url);
+        webDriver.findElement(By.xpath("//span[text()='" + expectedTitle + "']"));
+    }
+
+    public WebElement findFileDownloadLink(final WebDriver webDriver, final String fileName) {
+        return webDriver.findElement(By.linkText(fileName));
     }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/DashboardPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/DashboardPage.java
@@ -13,8 +13,10 @@ public class DashboardPage extends AbstractCmsPage {
 
     private final PageHelper helper;
 
-    public DashboardPage(final WebDriverProvider webDriverProvider, final PageHelper helper) {
-        super(webDriverProvider);
+    public DashboardPage(final WebDriverProvider webDriverProvider,
+                         final PageHelper helper,
+                         final String cmsUrl) {
+        super(webDriverProvider, cmsUrl);
         this.helper = helper;
     }
 

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/LoginPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/LoginPage.java
@@ -1,20 +1,33 @@
 package uk.nhs.digital.ps.test.acceptance.pages;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
+import org.slf4j.Logger;
 import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverProvider;
 
 public class LoginPage extends AbstractCmsPage {
 
+    private static final Logger log = getLogger(LoginPage.class);
+
+    private static final By USERNAME_FIELD_SELECTOR = By.name("username");
+    private static final By PASSWORD_FIELD_SELECTOR = By.name("password");
+    private static final By SUBMIT_BUTTON_SELECTOR = By.name("p::submit");
+    private static final By LOGOUT_BUTTON_SELECTOR = By.className("hippo-logout");
+
     private PageHelper helper;
 
-    public LoginPage(final WebDriverProvider webDriverProvider, PageHelper helper) {
-        super(webDriverProvider);
+    public LoginPage(final WebDriverProvider webDriverProvider,
+                     final PageHelper helper,
+                     final String cmsUrl) {
+        super(webDriverProvider, cmsUrl);
         this.helper = helper;
     }
 
     public void open() {
-        getWebDriver().get(URL);
+        getWebDriver().get(getUrl());
 
         if (isLoggedIn()) {
             helper.findElement(By.className("hippo-user-icon")).click();
@@ -30,16 +43,72 @@ public class LoginPage extends AbstractCmsPage {
         findLoginButton().click();
     }
 
+    /**
+     * <p>
+     * Logs the user with given credentials, creating a brand new session and
+     * returning a WebDriver instance particular to this user.
+     * </p><p>
+     * <strong>To be only used in tests where it's necessary to simulate traffic from
+     * many users simultaneously</strong> such as is in performance tests. In 'normal',
+     * single user scenarios keep using {@linkplain #loginWith(String, String)}.
+     * </p><p>
+     * Each instance of WebDriver represents a separate user session and so all
+     * interactions with the UI that should be executed as a given user, should
+     * be performed using the returned instance of the WebDriver.
+     * </p>
+     */
+    public WebDriver loginWithNewSession(final String userName,
+                                         final String userPassword
+    ) {
+        log.info("{} logs in", userName);
+
+        final WebDriver webDriver = getNewWebDriver(userName);
+
+        webDriver.get(getUrl());
+
+        // Uncommenting the following two lines will ensure that all requests
+        // executed via the current WebDriver will be directed to the node given by
+        // the cookie value.
+        //
+        // webDriver.manage().addCookie(new Cookie("BACKEND", "cms1"));
+        // webDriver.get(getUrl());
+
+        findUsernameField(webDriver).sendKeys(userName);
+        findPasswordField(webDriver).sendKeys(userPassword);
+        findLoginButton(webDriver).click();
+
+        waitForLoginToComplete(webDriver);
+
+        log.info("{} logged in via node '{}'",
+            userName,
+            webDriver.manage().getCookieNamed("BACKEND")
+        );
+
+        return webDriver;
+    }
+
     private WebElement findLoginButton() {
-        return helper.findElement(By.name("p::submit"));
+        return helper.findElement(SUBMIT_BUTTON_SELECTOR);
+    }
+
+    private WebElement findLoginButton(final WebDriver webDriver) {
+        return helper.findElement(webDriver, SUBMIT_BUTTON_SELECTOR);
     }
 
     private WebElement findPasswordField() {
-        return helper.findElement(By.name("password"));
+        return helper.findElement(PASSWORD_FIELD_SELECTOR);
+    }
+
+    private WebElement findPasswordField(final WebDriver webDriver) {
+        return helper.findElement(webDriver, PASSWORD_FIELD_SELECTOR);
     }
 
     private WebElement findUsernameField() {
-        return helper.findElement(By.name("username"));
+        return helper.findElement(USERNAME_FIELD_SELECTOR);
+    }
+
+    private WebElement findUsernameField(final WebDriver webDriver) {
+        return helper.findElement(webDriver, USERNAME_FIELD_SELECTOR);
     }
 
     public boolean isOpen() {
@@ -54,12 +123,19 @@ public class LoginPage extends AbstractCmsPage {
         return helper.findChildElement(hippoLoginFeedbackPanel, By.tagName("span")).getText();
     }
 
+    private void waitForLoginToComplete(final WebDriver webDriver) {
+        helper.waitUntilTrue(webDriver, () -> findLogoutButton(webDriver) != null);
+    }
+
     public boolean isLoggedIn() {
         return findLogoutButton() != null;
     }
 
-    private WebElement findLogoutButton() {
-        return helper.findOptionalElement(By.className("hippo-logout"));
+    private WebElement findLogoutButton(final WebDriver webDriver) {
+        return helper.findOptionalElement(webDriver, LOGOUT_BUTTON_SELECTOR);
     }
 
+    private WebElement findLogoutButton() {
+        return helper.findOptionalElement(LOGOUT_BUTTON_SELECTOR);
+    }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/AbstractSitePage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/AbstractSitePage.java
@@ -5,9 +5,7 @@ import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverProvider;
 
 public abstract class AbstractSitePage extends AbstractPage {
 
-    public static final String URL = "http://localhost:8080";
-
-    public AbstractSitePage(WebDriverProvider webDriverProvider) {
-        super(webDriverProvider);
+    public AbstractSitePage(WebDriverProvider webDriverProvider, String siteUrl) {
+        super(webDriverProvider, siteUrl);
     }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/HomePage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/HomePage.java
@@ -1,17 +1,12 @@
 package uk.nhs.digital.ps.test.acceptance.pages.site;
 
 import org.openqa.selenium.By;
-import uk.nhs.digital.ps.test.acceptance.pages.PageHelper;
 import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverProvider;
 
 public class HomePage extends AbstractSitePage {
 
-    private PageHelper helper;
-
-
-    public HomePage(WebDriverProvider webDriverProvider, final PageHelper helper) {
-        super(webDriverProvider);
-        this.helper = helper;
+    public HomePage(WebDriverProvider webDriverProvider, String siteUrl) {
+        super(webDriverProvider, siteUrl);
     }
 
     public String getPageTitle() {

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ServicePage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ServicePage.java
@@ -1,17 +1,12 @@
 package uk.nhs.digital.ps.test.acceptance.pages.site;
 
 import org.openqa.selenium.By;
-import uk.nhs.digital.ps.test.acceptance.pages.PageHelper;
 import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverProvider;
 
 public class ServicePage extends AbstractSitePage {
 
-    private PageHelper helper;
-
-
-    public ServicePage(WebDriverProvider webDriverProvider, final PageHelper helper) {
-        super(webDriverProvider);
-        this.helper = helper;
+    public ServicePage(WebDriverProvider webDriverProvider, String siteUrl) {
+        super(webDriverProvider, siteUrl);
     }
 
     public String getPageTitle() {

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/SitePage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/SitePage.java
@@ -21,11 +21,15 @@ public class SitePage extends AbstractSitePage {
     private TestContentUrls urlLookup;
     private List<PageElements> pagesElements;
 
-    public SitePage(WebDriverProvider webDriverProvider, final PageHelper helper) {
-        super(webDriverProvider);
+    public SitePage(final WebDriverProvider webDriverProvider,
+                    final PageHelper helper,
+                    final String siteUrl,
+                    final TestContentUrls testContentUrls) {
+        super(webDriverProvider, siteUrl);
+
         this.helper = helper;
-        this.urlLookup = new TestContentUrls();
         this.pagesElements = new ArrayList<>();
+        urlLookup = testContentUrls;
 
         // load pageElement
         pagesElements.add(new ArchivePageElements());
@@ -37,7 +41,7 @@ public class SitePage extends AbstractSitePage {
     }
 
     public void openByPageName(final String pageName) {
-        String lookupUrl = urlLookup.lookupUrl(pageName);
+        String lookupUrl = urlLookup.lookupSiteUrl(pageName);
         getWebDriver().get(lookupUrl);
     }
 

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/common/SearchPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/common/SearchPage.java
@@ -16,8 +16,8 @@ public class SearchPage extends AbstractSitePage {
 
     private PageHelper helper;
 
-    public SearchPage(final WebDriverProvider webDriverProvider, PageHelper helper) {
-        super(webDriverProvider);
+    public SearchPage(final WebDriverProvider webDriverProvider, PageHelper helper, String siteUrl) {
+        super(webDriverProvider, siteUrl);
         this.helper = helper;
     }
 

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ps/PublicationPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/ps/PublicationPage.java
@@ -22,14 +22,16 @@ public class PublicationPage extends AbstractSitePage {
     private PageHelper helper;
     private List<PageElements> pageElements;
 
-    public PublicationPage(WebDriverProvider webDriverProvider, final PageHelper helper) {
-        super(webDriverProvider);
+    public PublicationPage(final WebDriverProvider webDriverProvider,
+                           final PageHelper helper,
+                           final String siteUrl) {
+        super(webDriverProvider, siteUrl);
         this.helper = helper;
         this.pageElements = asList(new SeriesPageElements(), new PublicationPageElements());
     }
 
     public void open(final Publication publication) {
-        getWebDriver().get(URL + "/publications/acceptance-tests/" + publication.getPublicationUrlName());
+        getWebDriver().get(getUrl() + "/publications/acceptance-tests/" + publication.getPublicationUrlName());
     }
 
     public String getSummaryText() {

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/TestDataSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/TestDataSteps.java
@@ -4,14 +4,19 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import cucumber.api.java.After;
 import cucumber.api.java.Before;
+import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import uk.nhs.digital.ps.test.acceptance.config.AcceptanceTestProperties;
 import uk.nhs.digital.ps.test.acceptance.data.TestDataRepo;
 import uk.nhs.digital.ps.test.acceptance.models.Dataset;
 import uk.nhs.digital.ps.test.acceptance.models.Publication;
 import uk.nhs.digital.ps.test.acceptance.models.PublicationArchive;
 import uk.nhs.digital.ps.test.acceptance.models.PublicationSeries;
 import uk.nhs.digital.ps.test.acceptance.pages.ContentPage;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
 
 public class TestDataSteps extends AbstractSpringSteps {
 
@@ -23,6 +28,9 @@ public class TestDataSteps extends AbstractSpringSteps {
     @Autowired
     private TestDataRepo testDataRepo;
 
+    @Autowired
+    private AcceptanceTestProperties acceptanceTestProperties;
+
     /**
      * Resets the test data repository before every scenario to prevent data leaking between scenarios, unless given
      * scenario is tagged with {@code @NeedsExistingTestData}.
@@ -31,6 +39,12 @@ public class TestDataSteps extends AbstractSpringSteps {
     public void clearTestData() {
         log.debug("Disposing of test data.");
         testDataRepo.clear();
+
+        try {
+            FileUtils.deleteDirectory(acceptanceTestProperties.getDownloadDir().toFile());
+        } catch (IOException ioe) {
+            throw new UncheckedIOException(ioe);
+        }
     }
 
     /**

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/WebDriverSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/WebDriverSteps.java
@@ -2,7 +2,9 @@ package uk.nhs.digital.ps.test.acceptance.steps;
 
 import cucumber.api.java.After;
 import cucumber.api.java.Before;
+import org.openqa.selenium.WebDriver;
 import org.springframework.beans.factory.annotation.Autowired;
+import uk.nhs.digital.ps.test.acceptance.data.WebDriversRepo;
 import uk.nhs.digital.ps.test.acceptance.webdriver.WebDriverProvider;
 
 /**
@@ -14,6 +16,9 @@ public class WebDriverSteps extends AbstractSpringSteps {
     @Autowired
     private WebDriverProvider webDriverProvider;
 
+    @Autowired
+    private WebDriversRepo webDriversRepo;
+
     @Before
     public void initialise() {
         webDriverProvider.initialise();
@@ -23,5 +28,6 @@ public class WebDriverSteps extends AbstractSpringSteps {
     @After(order = 0)
     public void dispose() {
         webDriverProvider.dispose();
+        webDriversRepo.getAll().forEach(WebDriver::close);
     }
 }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/SiteSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/SiteSteps.java
@@ -192,7 +192,7 @@ public class SiteSteps extends AbstractSpringSteps {
                 downloadElement, is(notNullValue()));
 
             String url = downloadElement.getAttribute("href");
-            assertEquals("I can find link with expected URL for file " + linkFileName, urlLookup.lookupUrl(linkFileName), url);
+            assertEquals("I can find link with expected URL for file " + linkFileName, urlLookup.lookupSiteUrl(linkFileName), url);
 
             if (acceptanceTestProperties.isHeadlessMode()) {
                 // At the moment of writing, there doesn't seem to be any easy way available to force Chromedriver

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
@@ -2,174 +2,203 @@ package uk.nhs.digital.ps.test.acceptance.util;
 
 import static org.openqa.selenium.net.Urls.urlEncode;
 
-import uk.nhs.digital.ps.test.acceptance.pages.site.AbstractSitePage;
-
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class TestContentUrls {
 
+    private static final AtomicReference<TestContentUrls> instance = new AtomicReference<>();
+
     private static final String S3_BUCKET_URL = "https://files.local.nhsd.io/";
 
-    private final Map<String, String> urlLookup = new HashMap();
+    private final Map<String, String> siteUrlLookup = new HashMap<>();
+    private final Map<String, String> cmsUrlLookup = new HashMap<>();
 
-    public TestContentUrls() {
-        setup();
+    private final String cmsUrl;
+    private final String siteUrl;
+
+    public TestContentUrls(final String cmsUrl, final String siteUUrl) {
+        this.cmsUrl = cmsUrl;
+        this.siteUrl = siteUUrl;
+        instance.set(this);
+        setupSiteUrls();
+        setupCmsUrls();
     }
 
-    public String lookupUrl(String pageName) {
-        String url = urlLookup.get(pageName.toLowerCase());
-        if (url == null) {
+    public static TestContentUrls instance() {
+        return instance.get();
+    }
+
+    public String lookupSiteUrl(String pageName) {
+        final String lowerCasedPageName = pageName.toLowerCase();
+
+        if (!siteUrlLookup.containsKey(lowerCasedPageName)) {
             throw new RuntimeException("Unknown pageName: " + pageName);
         }
 
+        String url = siteUrlLookup.get(lowerCasedPageName);
         if (!url.startsWith("http")) {
-            url = AbstractSitePage.URL + url;
-        }
+            url = siteUrl + url;
+        } // else: URL is direct/absolute and should be returned verbatim
 
         return url;
     }
 
-    private void setup() {
-        add("home", "/");
+    public String lookupCmsUrl(String pageName) {
+        final String lowerCasedPageName = pageName.toLowerCase();
 
-        add("search", "/search");
+        if (!cmsUrlLookup.containsKey(lowerCasedPageName)) {
+            throw new RuntimeException("Unknown pageName: " + pageName);
+        }
 
-        add("shmi", "/shmi");
+        return cmsUrl
+            + "/?1&path=/content/documents/corporate-website"
+            + cmsUrlLookup.get(lowerCasedPageName);
+    }
+
+    private void setupSiteUrls() {
+        addSiteUrl("home", "/");
+
+        addSiteUrl("search", "/search");
+
+        addSiteUrl("shmi", "/shmi");
 
         // data sets pages
-        add("publication with datasets",
+        addSiteUrl("publication with datasets",
             "/data-and-information/publications/acceptance-tests/publication-with-datasets");
-        add("publication with datasets dataset",
+        addSiteUrl("publication with datasets dataset",
             "/data-and-information/publications/acceptance-tests/publication-with-datasets/datasets-subfolder/publication-with-datasets-dataset");
-        add("series with publication with datasets",
+        addSiteUrl("series with publication with datasets",
             "/data-and-information/publications/acceptance-tests/series-with-publication-with-datasets");
 
         // folder
-        add("acceptence tests folder", "/data-and-information/publications/acceptance-tests");
+        addSiteUrl("acceptence tests folder", "/data-and-information/publications/acceptance-tests");
 
         // series page
-        add("valid publication series",
+        addSiteUrl("valid publication series",
             "/data-and-information/publications/valid-publication-series");
-        add("valid publication series direct",
+        addSiteUrl("valid publication series direct",
             "/data-and-information/publications/valid-publication-series/content");
-        add("valid publication series old url",
+        addSiteUrl("valid publication series old url",
             "/publications/valid-publication-series/content");
 
-        add("series without latest",
+        addSiteUrl("series without latest",
             "/data-and-information/publications/acceptance-tests/series-without-latest");
 
         // archive page
-        add("valid publication archive",
+        addSiteUrl("valid publication archive",
             "/data-and-information/publications/acceptance-tests/valid-publication-archive");
-        add("valid publication archive direct",
+        addSiteUrl("valid publication archive direct",
             "/data-and-information/publications/acceptance-tests/valid-publication-archive/content");
 
-        add("publication with rich content",
+        addSiteUrl("publication with rich content",
             "/data-and-information/publications/acceptance-tests/publication-rich");
 
         // unpublished dataset
-        add("upcoming publication dataset",
+        addSiteUrl("upcoming publication dataset",
             "/data-and-information/publications/acceptance-tests/upcoming-publication/upcoming-dataset");
 
         // dataset with no parent publication
-        add("dataset without publication",
+        addSiteUrl("dataset without publication",
             "/data-and-information/publications/acceptance-tests/dataset-without-publication/dataset-without-publication");
 
         // attachment tests
-        add("attachment test publication",
+        addSiteUrl("attachment test publication",
             "/data-and-information/publications/acceptance-tests/attachment-test");
-        add("attachment test dataset",
+        addSiteUrl("attachment test dataset",
             "/data-and-information/publications/acceptance-tests/attachment-test/dataset");
 
         // coverage date test
-        add("coverage date publication",
+        addSiteUrl("coverage date publication",
             "/data-and-information/publications/acceptance-tests/coveragedates-test/coverage-test");
 
         // bare minimum documents
-        add("bare minimum publication",
+        addSiteUrl("bare minimum publication",
             "/data-and-information/publications/acceptance-tests/bare-minimum-publication");
-        add("bare minimum dataset",
+        addSiteUrl("bare minimum dataset",
             "/data-and-information/publications/acceptance-tests/bare-minimum-publication/bare-minimum-dataset");
 
         // invalid urls
-        add("invalid root", "/invalid");
-        add("invalid document", "/data-and-information/publications/invalid");
-        add("invalid sub document", "/data-and-information/publications/acceptance-tests/invalid");
+        addSiteUrl("invalid root", "/invalid");
+        addSiteUrl("invalid document", "/data-and-information/publications/invalid");
+        addSiteUrl("invalid sub document", "/data-and-information/publications/acceptance-tests/invalid");
 
         // about pages
-        add("terms and conditions", "/about/terms-and-conditions");
+        addSiteUrl("terms and conditions", "/about/terms-and-conditions");
 
         // CI Hub/Landing
-        add("SHMI landing", "/data-and-information/publications/ci-hub/summary-hospital-level-mortality-indicator-shmi");
-        add("SHMI_publication_timetable.xlsx",
+        addSiteUrl("SHMI landing", "/data-and-information/publications/ci-hub/summary-hospital-level-mortality-indicator-shmi");
+        addSiteUrl("SHMI_publication_timetable.xlsx",
             S3_BUCKET_URL + "24/66E68E/SHMI_publication_timetable.xlsx");
-        add("ci hub root", "/data-and-information/publications/ci-hub");
+        addSiteUrl("ci hub root", "/data-and-information/publications/ci-hub");
 
         // attachments
-        add("attachment-text.pdf",
+        addSiteUrl("attachment-text.pdf",
             S3_BUCKET_URL + "C0/F03E64/attachment-text.pdf");
-        add("attachment.pdf",
+        addSiteUrl("attachment.pdf",
             S3_BUCKET_URL + "B4/CEEAE4/attachment.pdf");
 
-        add("dataset-attachment-text.pdf",
+        addSiteUrl("dataset-attachment-text.pdf",
             S3_BUCKET_URL + "42/F961C2/dataset-attachment-text.pdf");
-        add("dataset-attachment.pdf",
+        addSiteUrl("dataset-attachment.pdf",
             S3_BUCKET_URL + "2E/636380/dataset-attachment.pdf");
 
         // Ordered publication
-        add("ordered publication",
+        addSiteUrl("ordered publication",
             "/data-and-information/publications/acceptance-tests/ordered-publication");
 
         // Sectioned publication
-        add("sectioned publication",
+        addSiteUrl("sectioned publication",
             "/data-and-information/publications/acceptance-tests/sectioned-publication");
-        add("sectioned publication page robots",
+        addSiteUrl("sectioned publication page robots",
             getAttachmentUrl("sectioned-publication/first-page/first-page", "bodySections[2]", "image"));
-        add("sectioned publication page snowman",
+        addSiteUrl("sectioned publication page snowman",
             getAttachmentUrl("sectioned-publication/first-page/first-page", "bodySections[5]", "image"));
-        add("sectioned publication robots",
+        addSiteUrl("sectioned publication robots",
             getAttachmentUrl("sectioned-publication/content/content", "KeyFactImages", "image"));
-        add("sectioned publication snowman",
+        addSiteUrl("sectioned publication snowman",
             getAttachmentUrl("sectioned-publication/content/content", "KeyFactImages[2]", "image"));
 
         // Publication with National Statistic logo
-        add("national statistic publication",
+        addSiteUrl("national statistic publication",
             "/data-and-information/publications/lorem-ipsum-content/morbi-tempor-euismod-vehicula");
 
         // National Indicator Library
-        add("nihub", "/data-and-information/national-indicator-library/nihub");
-        add("sample-indicator", "/data-and-information/national-indicator-library/sample-indicator");
+        addSiteUrl("nihub", "/data-and-information/national-indicator-library/nihub");
+        addSiteUrl("sample-indicator", "/data-and-information/national-indicator-library/sample-indicator");
 
         // Legacy publication
-        add("legacy publication",
+        addSiteUrl("legacy publication",
             "/data-and-information/publications/acceptance-tests/legacy-series/legacy-publication");
-        add("legacy publication direct",
+        addSiteUrl("legacy publication direct",
             "/data-and-information/publications/acceptance-tests/legacy-series/legacy-publication/content");
 
-        add("service with rich content - parent",
+        addSiteUrl("service with rich content - parent",
             "/services/service-document-1/");
 
-        add("homeland",
+        addSiteUrl("homeland",
             "/homeland");
 
-        add("Data and information",
+        addSiteUrl("Data and information",
             "/data-and-information");
 
         // Geographic coverage publications
-        add("Geographic Coverage - Great Britain",
+        addSiteUrl("Geographic Coverage - Great Britain",
             "/data-and-information/publications/acceptance-tests/geographiccoverage-test/great-britain");
-        add("Geographic Coverage - United Kingdom",
+        addSiteUrl("Geographic Coverage - United Kingdom",
             "/data-and-information/publications/acceptance-tests/geographiccoverage-test/united-kingdom");
-        add("Geographic Coverage - British Isles",
+        addSiteUrl("Geographic Coverage - British Isles",
             "/data-and-information/publications/acceptance-tests/geographiccoverage-test/british-isles");
-        add("Geographic Coverage - Other combination",
+        addSiteUrl("Geographic Coverage - Other combination",
             "/data-and-information/publications/acceptance-tests/geographiccoverage-test/other-combination");
 
     }
 
-    private String getAttachmentUrl(String siteUrl, String attachmentTag) {
-        return getAttachmentUrl(siteUrl, attachmentTag, "attachmentResource");
+    private void setupCmsUrls() {
+        // has to correspond to values in YAML generated by GenerateTestDocsForS3ConcurrentTest.groovy
+        addCmsUrl("Legacy Publication X",
+            "/publication-system/acceptance-tests/concurrent-s3-access-test/legacy-publication-");
     }
 
     private String getAttachmentUrl(String siteUrl, String attachmentTag, String resourceTag) {
@@ -179,7 +208,11 @@ public class TestContentUrls {
             + urlEncode("publicationsystem:" + resourceTag);
     }
 
-    private void add(String pageName, String url) {
-        urlLookup.put(pageName.toLowerCase(), url);
+    private void addSiteUrl(String pageName, String url) {
+        siteUrlLookup.put(pageName.toLowerCase(), url);
+    }
+
+    private void addCmsUrl(String pageName, String url) {
+        cmsUrlLookup.put(pageName.toLowerCase(), url);
     }
 }

--- a/acceptance-tests/src/test/resources/s3-performance/s3-performance.feature
+++ b/acceptance-tests/src/test/resources/s3-performance/s3-performance.feature
@@ -1,0 +1,27 @@
+Feature: S3 integration performance
+    As a product owner, I want to simulate heavy usage of the S3 file transfers
+    So that we can test if the application can cope with the load.
+
+    # Test objective:
+    # Given a number of concurrent transfers of files stored in S3 via CMS
+    # When a user tries using CMS and Site
+    # Then the CMS and Site are available (not necessarily quick, we just check they don't die)
+
+    # Scenarios in this file are intended to only run in ad-hoc performance tests rather
+    # than regularly, say as part of regular builds.
+    #
+    # Typically they would be run individually, using @WIP tag.
+
+    # With many stable, slow, downloads, not saturating the pool -
+    # does the application respond to other requests?
+    Scenario: Concurrent CMS preview file downloads
+        Given 20 'user-' users are logged in
+        And each user has a Legacy Publication X open for CMS preview
+        Then all users download file file-500MB.zip in parallel, initiated 15 seconds apart
+
+    # With many small, quick downloads, exceeding pool capacity (set for this test to 10) -
+    # does the application respond to other requests?
+    Scenario: Concurrent CMS preview file downloads
+        Given 55 'user-' users are logged in
+        And each user has a Legacy Publication X open for CMS preview
+        Then all users download file file-5MB.zip in parallel, initiated 2 seconds apart

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/modules/S3ConnectorServiceRegistrationModuleParams.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/modules/S3ConnectorServiceRegistrationModuleParams.java
@@ -19,7 +19,7 @@ public class S3ConnectorServiceRegistrationModuleParams<T> {
     // DOWNLOAD PARAMS
 
     static final S3ConnectorServiceRegistrationModuleParams<Integer> DOWNLOAD_MAX_CONC_COUNT = init(
-        "externalstorage.download.maxConcurrent", "maxConcurrentDownloadsCount", Integer::valueOf, 0
+        "externalstorage.download.maxConcurrentDownloads", "maxConcurrentDownloadsCount", Integer::valueOf, 0
     );
     static final S3ConnectorServiceRegistrationModuleParams<Long> DOWNLOAD_SHUTDOWN_TIMEOUT_IN_SECS = init(
         "externalstorage.download.shutdown.timeoutInSecs", "downloadShutdownTimeoutInSecs", Long::valueOf, 0L
@@ -28,7 +28,7 @@ public class S3ConnectorServiceRegistrationModuleParams<T> {
     // UPLOAD PARAMS
 
     static final S3ConnectorServiceRegistrationModuleParams<Integer> UPLOAD_MAX_CONC_COUNT = init(
-        "externalstorage.upload.maxConcurrent", "maxConcurrentUploadsCount", Integer::valueOf, 0
+        "externalstorage.upload.maxConcurrentUploads", "maxConcurrentUploadsCount", Integer::valueOf, 0
     );
     static final S3ConnectorServiceRegistrationModuleParams<Long> UPLOAD_SHUTDOWN_TIMEOUT_IN_SECS = init(
         "externalstorage.upload.shutdown.timeoutInSecs", "uploadShutdownTimeoutInSecs", Long::valueOf, 0L

--- a/docs/what-if.md
+++ b/docs/what-if.md
@@ -10,3 +10,4 @@
 * [What If I want to add test content](what-if/add-test-content.md)
 * [What If I want to deploy to Test](what-if/deploy-to-test.md)
 * [What If I want to do a hot fix](what-if/hot-fix.md)
+* [What If I want to test performance of S3 integration](what-if/test-s3-performance.md)

--- a/docs/what-if/test-s3-performance.md
+++ b/docs/what-if/test-s3-performance.md
@@ -1,0 +1,115 @@
+# Testing performance of S3 integration
+
+Test exercising impact on the running application incurred by S3 transfers performed
+via CMS has been implemented as a Cucumber-driven test, whose feature file(s) can be
+found under `/acceptance-tests/src/test/resources/features/s3-performance`. The test
+does not run automatically as part of the build, it has to be triggered manually.
+
+At the moment of writing, the test focuses on downloads initiated from 'CMS preview'
+mode. See the actual scenarios and [S3 performance test Confluence page] for more details and
+assumptions made.
+
+The test simulates a number of users concurrently logging in, each opening their
+own, pre-defined test document in 'CMS preview' and attempting to download a file
+'attached' to the document, where the file itself is stored in S3.
+
+The entire test process comprises the following phases:
+1. Creation of test data (documents) and test config (users in group 'author'),
+1. Loading of the documents into the tested environment,
+1. Running Cucumber scenarios that trigger multiple, concurrent S3 file transfers,
+1. Manually interacting with CMS and Site (performing typical navigate/search/edit
+   documents activities), looking for any noticeable slow-downs coming from the multiple
+   transfers going in the background,
+1. Reviewing the number of failed automated downloads/interactions,
+1. Potentially tweaking scenarios and/or [S3 configuration][S3 Confluence page] and re-running the
+   test.
+
+
+## To create test documents and users
+
+### Ensure files are available in S3 for download
+Test documents prepared for testing download expect a set of files to already be available in
+S3. See template files for what files and at what locations they expect (e.g.
+`legacy-publication-download.yaml.template`). If corresponding files are not there, generate and
+upload them.
+
+The following command can be used on Linux to generate a file of required size with random content
+(update `count` argument and the file name with the number of megabytes needed):
+```bash
+dd if=/dev/urandom of=file-100MB.zip bs=1M count=100  
+```
+ 
+
+### Generate YAML files
+Execute:
+```bash
+make prep.s3-perf-test-docs TEST_DOCS_COUNT=X
+```
+
+
+This will generate 'X' number of `*.yaml` files under
+`repository-data/local/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/concurrent-s3-access-test` 
+making them ready to bootstrap the next time the local instance of the application
+is started from scratch. The argument is optional and, if missing, defaults to 100.
+
+Make sure to not to commit the generated test `*.yaml` files as, given their (typically large)
+number, they would noticeably slow down application startup (splitting them into multiple folders
+could *potentially* remedy that). 
+
+The generated files represent:
+* X 'download' users (named `user-N`) 
+* X 'upload' users (named `user-upload-N`)
+* X Legacy Publications prepared for testing download (named `legacy-publication-N`) 
+* X Legacy Publications prepared for testing upload (named `legacy-publication-N`)
+* folder containing the files (`Publication System > Acceptance Tests > Concurrent S3 Access Test`) 
+* group definition assigning all test users to group 'author'
+... where `N` is a value from `1` to `X`
+
+Documents prepared for *upload* don't specify any attachments. Documents prepared for *download*
+specify a set of attachments, the same set in each doc. There is one document per each test user to
+enable parallel interactions (while it's possible for many users download from the same document
+during preview, only one user can interact with given document in edit mode, hence the 1:1 mapping).
+
+
+
+### Bootstrap YAML files
+
+Build and start local instance from scratch to bootstrap all the test users and documents.
+
+If your're planning to run the test against a non-local system, export the bootstrapped data
+from your local Hippo Console as XML Export and import it to the remote system. The nodes to
+be migrated this way are:
+* users
+* group 'author'
+* folder
+  `/content/documents/corporate-website/publication-system/acceptance-tests/concurrent-s3-access-test/`
+  containing test documents 
+
+Note that migrating entire 'users' node and entire group definition has a potential of overwriting
+existing users and existing group definition in the target system - assuming it's even possible
+to import a node when node with matching path already exists. This has not been tested and during
+past test run the users and the group were modified manually, only having documents migrated in
+bulk.
+
+
+## To execute the tests
+
+If running the tests against local instance, make sure the application is running with your
+AWS credentials that allow it to access S3 bucket; if you have them configured in file `env.mk`
+and you started the application with `make run` they will be applied correctly.
+
+In performance tests you'll typically run a single scenario at a time; for this reason, make
+sure to annotate chosen scenario with `@WIP` tag otherwise the following command won't find
+any scenarios to run. 
+
+To run the tests execute:
+```bash
+make test.s3-perf CMS_URL=<your-url-here> SITE_URL=<your-site-url-here>
+```     
+Where `CMS_URL` and `SITE_URL` specify URLs of CMS and Site applications and are only needed
+if you run tests against aremote instance; if not provided the URLs default to localhost.  
+
+				
+		
+[S3 performance test Confluence page]: https://confluence.digital.nhs.uk/display/CW/S3+integration+impact+on+CMS+performance+test
+[S3 Confluence page]:                  https://confluence.digital.nhs.uk/display/CW/S3+Integration

--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@
         <externalstorage.aws.bucket></externalstorage.aws.bucket>
         <externalstorage.aws.region></externalstorage.aws.region>
         <externalstorage.aws.s3.endpoint></externalstorage.aws.s3.endpoint>
+        <tomcatDistributionUrl>https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.48/bin/apache-tomcat-8.0.48.tar.gz</tomcatDistributionUrl>
     </properties>
 
     <repositories>
@@ -354,6 +355,11 @@
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.gmavenplus</groupId>
+                    <artifactId>gmavenplus-plugin</artifactId>
+                    <version>1.6</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -589,6 +595,9 @@
                                 </deployable>
                             </deployables>
                             <container>
+                                <zipUrlInstaller>
+                                    <url>${tomcatDistributionUrl}</url>
+                                </zipUrlInstaller>
                                 <systemProperties>
                                     <log4j.configurationFile>file://${project.basedir}/conf/log4j2-dev.xml</log4j.configurationFile>
                                     <!-- enables auto export and web files watch: -->

--- a/repository-data/local/pom.xml
+++ b/repository-data/local/pom.xml
@@ -16,6 +16,20 @@
     <description>NHS Digital Website Repository Data For Local</description>
     <artifactId>website-repository-data-local</artifactId>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.19</version>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>2.4.12</version>
+            <scope>runtime</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <defaultGoal>install</defaultGoal>
         <plugins>
@@ -40,20 +54,32 @@
             <plugin>
                 <groupId>org.codehaus.gmavenplus</groupId>
                 <artifactId>gmavenplus-plugin</artifactId>
-                <version>1.6</version>
                 <executions>
                     <execution>
+                        <id>format-yaml</id>
                         <phase>verify</phase>
                         <goals>
                             <goal>execute</goal>
                         </goals>
+                        <configuration>
+                            <scripts>
+                                <script>file:///${project.basedir}/script/YamlFormatter.groovy</script>
+                            </scripts>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>generate-s3-perf-test-docs</id>
+                        <phase>none</phase>
+                        <goals>
+                            <goal>execute</goal>
+                        </goals>
+                        <configuration>
+                            <scripts>
+                                <script>file:///${project.basedir}/src/test/groovy/GenerateTestDocsForTestingS3Concurrent.groovy</script>
+                            </scripts>
+                        </configuration>
                     </execution>
                 </executions>
-                <configuration>
-                    <scripts>
-                        <script>file:///${project.basedir}/script/YamlFormatter.groovy</script>
-                    </scripts>
-                </configuration>
                 <dependencies>
                     <dependency>
                         <groupId>org.yaml</groupId>
@@ -70,19 +96,5 @@
             </plugin>
         </plugins>
     </build>
-
-    <dependencies>
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>1.19</version>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>2.4.12</version>
-            <scope>runtime</scope>
-        </dependency>
-    </dependencies>
 
 </project>

--- a/repository-data/local/src/main/resources/test-util/test-docs-templates/s3-performance/concurrent-s3-access-test.yaml.template
+++ b/repository-data/local/src/main/resources/test-util/test-docs-templates/s3-performance/concurrent-s3-access-test.yaml.template
@@ -1,0 +1,13 @@
+---
+/content/documents/corporate-website/publication-system/acceptance-tests/concurrent-s3-access-test:
+  hippo:name: Concurrent S3 Access Test
+  hippostd:foldertype:
+  - new-statistical-publications-and-clinical-indicators-folder
+  - new-statistical-publications-and-clinical-indicators-document
+  hippotranslation:id: 51e4e05d-a296-4513-ba64-766377116241
+  hippotranslation:locale: en
+  jcr:mixinTypes:
+  - hippo:named
+  - hippotranslation:translated
+  - mix:versionable
+  jcr:primaryType: hippostd:folder

--- a/repository-data/local/src/main/resources/test-util/test-docs-templates/s3-performance/legacy-publication-download.yaml.template
+++ b/repository-data/local/src/main/resources/test-util/test-docs-templates/s3-performance/legacy-publication-download.yaml.template
@@ -1,0 +1,189 @@
+---
+/content/documents/corporate-website/publication-system/acceptance-tests/concurrent-s3-access-test/legacy-publication-{DOCUMENT_INDEX}:
+  /legacy-publication-{DOCUMENT_INDEX}[1]:
+    /publicationsystem:Attachments-v3:
+      /publicationsystem:attachmentResource:
+        externalstorage:reference: s3-performance-test/file-1MB.zip
+        externalstorage:size: 1048576
+        externalstorage:url: https://files.local.nhsd.io/s3-performance-test/file-1MB.zip
+        hippo:filename: file-1MB.zip
+        jcr:data:
+          resource: /content/documents/corporate-website/publication-system/acceptance-tests/concurrent-s3-access-test/legacy-publication-{DOCUMENT_INDEX}/legacy-publication-{DOCUMENT_INDEX}[1]/Attachments-v3/attachmentResource/data.bin
+          type: binary
+        jcr:encoding: UTF-8
+        jcr:lastModified: 2018-04-13T20:41:05.692Z
+        jcr:mimeType: application/zip
+        jcr:primaryType: externalstorage:resource
+      jcr:primaryType: publicationsystem:extattachment
+      publicationsystem:displayName: ''
+    /publicationsystem:KeyFacts:
+      hippostd:content: ''
+      jcr:primaryType: hippostd:html
+    /publicationsystem:Summary:
+      hippostd:content: ''
+      jcr:primaryType: hippostd:html
+    common:FacetType: publication
+    common:searchRank: 4
+    common:searchable: true
+    hippo:availability: []
+    hippostd:state: draft
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-04-13T20:40:40.944Z
+    hippostdpubwf:lastModificationDate: 2018-04-13T20:40:40.945Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: b0747d74-8dbf-487a-8b1e-95d676c115f6
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:legacypublication
+    publicationsystem:AdministrativeSources: ''
+    publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+    publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+    publicationsystem:NominalDate: 2018-04-13T00:00:00Z
+    publicationsystem:PubliclyAccessible: false
+    publicationsystem:Title: Legacy Publication {DOCUMENT_INDEX}
+    publicationsystem:gossid: 0
+    publicationsystem:publicationid: ''
+  /legacy-publication-{DOCUMENT_INDEX}[2]:
+    /publicationsystem:Attachments-v3:
+      /publicationsystem:attachmentResource:
+        externalstorage:reference: s3-performance-test/file-1MB.zip
+        externalstorage:size: 1048576
+        externalstorage:url: https://files.local.nhsd.io/s3-performance-test/file-1MB.zip
+        hippo:filename: file-1MB.zip
+        jcr:data:
+          resource: /content/documents/corporate-website/publication-system/acceptance-tests/concurrent-s3-access-test/legacy-publication-{DOCUMENT_INDEX}/legacy-publication-{DOCUMENT_INDEX}[2]/Attachments-v3/attachmentResource/data.bin
+          type: binary
+        jcr:encoding: UTF-8
+        jcr:lastModified: 2018-04-13T20:41:05.692Z
+        jcr:mimeType: application/zip
+        jcr:primaryType: externalstorage:resource
+      jcr:primaryType: publicationsystem:extattachment
+      publicationsystem:displayName: ''
+    /publicationsystem:Attachments-v3[2]:
+      /publicationsystem:attachmentResource:
+        externalstorage:reference: s3-performance-test/file-5MB.zip
+        externalstorage:size: 5242880
+        externalstorage:url: https://files.local.nhsd.io/s3-performance-test/file-5MB.zip
+        hippo:filename: file-5MB.zip
+        jcr:data:
+          resource: /content/documents/corporate-website/publication-system/acceptance-tests/concurrent-s3-access-test/legacy-publication-{DOCUMENT_INDEX}/legacy-publication-{DOCUMENT_INDEX}[2]/Attachments-v3/attachmentResource/data.bin
+          type: binary
+        jcr:encoding: UTF-8
+        jcr:lastModified: 2018-04-13T20:41:05.692Z
+        jcr:mimeType: application/zip
+        jcr:primaryType: externalstorage:resource
+      jcr:primaryType: publicationsystem:extattachment
+      publicationsystem:displayName: ''
+    /publicationsystem:Attachments-v3[3]:
+      /publicationsystem:attachmentResource:
+        externalstorage:reference: s3-performance-test/file-10MB.zip
+        externalstorage:size: 10485760
+        externalstorage:url: https://files.local.nhsd.io/s3-performance-test/file-10MB.zip
+        hippo:filename: file-10MB.zip
+        jcr:data:
+          resource: /content/documents/corporate-website/publication-system/acceptance-tests/concurrent-s3-access-test/legacy-publication-{DOCUMENT_INDEX}/legacy-publication-{DOCUMENT_INDEX}[2]/Attachments-v3/attachmentResource/data.bin
+          type: binary
+        jcr:encoding: UTF-8
+        jcr:lastModified: 2018-04-13T20:41:05.692Z
+        jcr:mimeType: application/zip
+        jcr:primaryType: externalstorage:resource
+      jcr:primaryType: publicationsystem:extattachment
+      publicationsystem:displayName: ''
+    /publicationsystem:Attachments-v3[4]:
+      /publicationsystem:attachmentResource:
+        externalstorage:reference: s3-performance-test/file-25MB.zip
+        externalstorage:size: 26214400
+        externalstorage:url: https://files.local.nhsd.io/s3-performance-test/file-25MB.zip
+        hippo:filename: file-25MB.zip
+        jcr:data:
+          resource: /content/documents/corporate-website/publication-system/acceptance-tests/concurrent-s3-access-test/legacy-publication-{DOCUMENT_INDEX}/legacy-publication-{DOCUMENT_INDEX}[2]/Attachments-v3/attachmentResource/data.bin
+          type: binary
+        jcr:encoding: UTF-8
+        jcr:lastModified: 2018-04-13T20:41:05.692Z
+        jcr:mimeType: application/zip
+        jcr:primaryType: externalstorage:resource
+      jcr:primaryType: publicationsystem:extattachment
+      publicationsystem:displayName: ''
+    /publicationsystem:Attachments-v3[5]:
+      /publicationsystem:attachmentResource:
+        externalstorage:reference: s3-performance-test/file-50MB.zip
+        externalstorage:size: 52428800
+        externalstorage:url: https://files.local.nhsd.io/s3-performance-test/file-50MB.zip
+        hippo:filename: file-50MB.zip
+        jcr:data:
+          resource: /content/documents/corporate-website/publication-system/acceptance-tests/concurrent-s3-access-test/legacy-publication-{DOCUMENT_INDEX}/legacy-publication-{DOCUMENT_INDEX}[2]/Attachments-v3/attachmentResource/data.bin
+          type: binary
+        jcr:encoding: UTF-8
+        jcr:lastModified: 2018-04-13T20:41:05.692Z
+        jcr:mimeType: application/zip
+        jcr:primaryType: externalstorage:resource
+      jcr:primaryType: publicationsystem:extattachment
+      publicationsystem:displayName: ''
+    /publicationsystem:Attachments-v3[6]:
+      /publicationsystem:attachmentResource:
+        externalstorage:reference: s3-performance-test/file-100MB.zip
+        externalstorage:size: 104857600
+        externalstorage:url: https://files.local.nhsd.io/s3-performance-test/file-100MB.zip
+        hippo:filename: file-100MB.zip
+        jcr:data:
+          resource: /content/documents/corporate-website/publication-system/acceptance-tests/concurrent-s3-access-test/legacy-publication-{DOCUMENT_INDEX}/legacy-publication-{DOCUMENT_INDEX}[2]/Attachments-v3/attachmentResource/data.bin
+          type: binary
+        jcr:encoding: UTF-8
+        jcr:lastModified: 2018-04-13T20:41:05.692Z
+        jcr:mimeType: application/zip
+        jcr:primaryType: externalstorage:resource
+      jcr:primaryType: publicationsystem:extattachment
+      publicationsystem:displayName: ''
+    /publicationsystem:Attachments-v3[7]:
+      /publicationsystem:attachmentResource:
+        externalstorage:reference: s3-performance-test/file-500MB.zip
+        externalstorage:size: 524288000
+        externalstorage:url: https://files.local.nhsd.io/s3-performance-test/file-500MB.zip
+        hippo:filename: file-500MB.zip
+        jcr:data:
+          resource: /content/documents/corporate-website/publication-system/acceptance-tests/concurrent-s3-access-test/legacy-publication-{DOCUMENT_INDEX}/legacy-publication-{DOCUMENT_INDEX}[2]/Attachments-v3/attachmentResource/data.bin
+          type: binary
+        jcr:encoding: UTF-8
+        jcr:lastModified: 2018-04-13T20:41:05.692Z
+        jcr:mimeType: application/zip
+        jcr:primaryType: externalstorage:resource
+      jcr:primaryType: publicationsystem:extattachment
+      publicationsystem:displayName: ''
+    /publicationsystem:KeyFacts:
+      hippostd:content: ''
+      jcr:primaryType: hippostd:html
+    /publicationsystem:Summary:
+      hippostd:content: ''
+      jcr:primaryType: hippostd:html
+    common:FacetType: publication
+    common:searchRank: 4
+    common:searchable: true
+    hippo:availability:
+    - preview
+    hippostd:state: unpublished
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-04-13T20:40:40.944Z
+    hippostdpubwf:lastModificationDate: 2018-04-13T20:41:13.824Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: b0747d74-8dbf-487a-8b1e-95d676c115f6
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:legacypublication
+    publicationsystem:AdministrativeSources: ''
+    publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+    publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+    publicationsystem:NominalDate: 2018-04-13T00:00:00Z
+    publicationsystem:PubliclyAccessible: false
+    publicationsystem:Title: Legacy Publication {DOCUMENT_INDEX}
+    publicationsystem:gossid: 0
+    publicationsystem:publicationid: ''
+  hippo:name: Legacy Publication {DOCUMENT_INDEX}
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/local/src/main/resources/test-util/test-docs-templates/s3-performance/legacy-publication-upload.yaml.template
+++ b/repository-data/local/src/main/resources/test-util/test-docs-templates/s3-performance/legacy-publication-upload.yaml.template
@@ -1,0 +1,69 @@
+---
+/content/documents/corporate-website/publication-system/acceptance-tests/concurrent-s3-access-test/legacy-publication-upload-{DOCUMENT_INDEX}:
+  /legacy-publication-upload-{DOCUMENT_INDEX}[1]:
+    /publicationsystem:KeyFacts:
+      hippostd:content: ''
+      jcr:primaryType: hippostd:html
+    /publicationsystem:Summary:
+      hippostd:content: ''
+      jcr:primaryType: hippostd:html
+    common:FacetType: publication
+    common:searchRank: 4
+    common:searchable: true
+    hippo:availability: []
+    hippostd:state: draft
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-04-13T20:40:40.944Z
+    hippostdpubwf:lastModificationDate: 2018-04-13T20:40:40.945Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: b0747d74-8dbf-487a-8b1e-95d676c115f6
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    jcr:primaryType: publicationsystem:legacypublication
+    publicationsystem:AdministrativeSources: ''
+    publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+    publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+    publicationsystem:NominalDate: 2018-04-13T00:00:00Z
+    publicationsystem:PubliclyAccessible: false
+    publicationsystem:Title: Legacy Publication {DOCUMENT_INDEX}
+    publicationsystem:gossid: 0
+    publicationsystem:publicationid: ''
+  /legacy-publication-upload-{DOCUMENT_INDEX}[2]:
+    /publicationsystem:KeyFacts:
+      hippostd:content: ''
+      jcr:primaryType: hippostd:html
+    /publicationsystem:Summary:
+      hippostd:content: ''
+      jcr:primaryType: hippostd:html
+    common:FacetType: publication
+    common:searchRank: 4
+    common:searchable: true
+    hippo:availability:
+    - preview
+    hippostd:state: unpublished
+    hippostdpubwf:createdBy: admin
+    hippostdpubwf:creationDate: 2018-04-13T20:40:40.944Z
+    hippostdpubwf:lastModificationDate: 2018-04-13T20:41:13.824Z
+    hippostdpubwf:lastModifiedBy: admin
+    hippotranslation:id: b0747d74-8dbf-487a-8b1e-95d676c115f6
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippotaxonomy:classifiable
+    - mix:referenceable
+    - mix:versionable
+    jcr:primaryType: publicationsystem:legacypublication
+    publicationsystem:AdministrativeSources: ''
+    publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+    publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+    publicationsystem:NominalDate: 2018-04-13T00:00:00Z
+    publicationsystem:PubliclyAccessible: false
+    publicationsystem:Title: Legacy Publication Upload {DOCUMENT_INDEX}
+    publicationsystem:gossid: 0
+    publicationsystem:publicationid: ''
+  hippo:name: Legacy Publication Upload {DOCUMENT_INDEX}
+  jcr:mixinTypes:
+  - hippo:named
+  - mix:referenceable
+  jcr:primaryType: hippo:handle

--- a/repository-data/local/src/main/resources/test-util/test-docs-templates/s3-performance/s3-group-author.yaml.template
+++ b/repository-data/local/src/main/resources/test-util/test-docs-templates/s3-performance/s3-group-author.yaml.template
@@ -1,0 +1,7 @@
+---
+definitions:
+  config:
+    /hippo:configuration/hippo:groups/author:
+      hipposys:members:
+        operation: add
+        value: [{GROUP-MEMBERS}]

--- a/repository-data/local/src/main/resources/test-util/test-docs-templates/s3-performance/s3-user.yaml.template
+++ b/repository-data/local/src/main/resources/test-util/test-docs-templates/s3-performance/s3-user.yaml.template
@@ -1,0 +1,9 @@
+      /user-{USER-NUMBER}:
+        hipposys:active: true
+        hipposys:firstname: user
+        hipposys:lastname: '{USER-NUMBER}'
+        # Password: TestPassword0
+        hipposys:password: $SHA-256$DUBCeXuAHq4=$tVqd2UVvPRfL3a7iKW7i8MPgWfUfhglhBNg8iJjoapE=
+        hipposys:passwordlastmodified: 2018-04-16T09:54:42.776Z
+        hipposys:securityprovider: internal
+        jcr:primaryType: hipposys:user

--- a/repository-data/local/src/test/groovy/GenerateTestDocsForTestingS3Concurrent.groovy
+++ b/repository-data/local/src/test/groovy/GenerateTestDocsForTestingS3Concurrent.groovy
@@ -1,0 +1,117 @@
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.stream.Collectors
+
+final int DEFAULT_DOC_COUNT = 100
+
+final int documentCount = (System.properties['documentCount'] ?: DEFAULT_DOC_COUNT) as Integer
+
+final String moduleResourcesPath = "${project.basedir}/src/main/resources"
+final String templatesDirPath = "${moduleResourcesPath}/test-util/test-docs-templates/s3-performance"
+final String publicationsTargetDirPath = "${moduleResourcesPath}/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/concurrent-s3-access-test"
+
+final Path sourceDirYamlFile = Paths.get(templatesDirPath, 'concurrent-s3-access-test.yaml.template')
+final Path targetDirYamlFile = Paths.get(publicationsTargetDirPath, 'concurrent-s3-access-test.yaml')
+
+final Path targetDir = Paths.get(publicationsTargetDirPath)
+targetDir.toFile().deleteDir()
+Files.createDirectories(targetDir)
+
+Files.copy(sourceDirYamlFile, targetDirYamlFile)
+
+
+// CREATE LEGACY PUBLICATIONS - FOR DOWNLOAD
+final String legacyPublicationYamlTemplate = new File("${templatesDirPath}/legacy-publication-download.yaml.template").text
+(1..documentCount).forEach({ i ->
+    final String targetFileContent = legacyPublicationYamlTemplate.replaceAll("\\{DOCUMENT_INDEX\\}", "${i}")
+    final String targetFileName = "legacy-publication-${i}.yaml"
+
+    createLegacyDownloadPublication(targetDir, targetFileName, targetFileContent, i)
+
+    println "Created ${targetFileName}; ${documentCount - i}/${documentCount} to go."
+})
+
+private void createLegacyDownloadPublication(Path targetDir, String targetFileName, String targetFileContent, int documentIndex) {
+    final Path legacyPublicationFile = Paths.get(targetDir.toString(), targetFileName)
+    Files.createFile(legacyPublicationFile)
+    legacyPublicationFile.toFile().text = targetFileContent
+
+    createDataBinFile(targetDir, documentIndex, 1)
+    createDataBinFile(targetDir, documentIndex, 2)
+}
+
+private void createDataBinFile(Path targetDir, int documentIndex, int documentVariantIndex) {
+    final Path resourcePathOne = Files.createDirectories(Paths.get(
+        targetDir.toString(),
+        "legacy-publication-${documentIndex}",
+        "legacy-publication-${documentIndex}[${documentVariantIndex}]",
+        "Attachments-v3",
+        "attachmentResource"
+    ))
+    Files.createFile(Paths.get(resourcePathOne.toString(), "data.bin"))
+}
+
+// CREATE LEGACY PUBLICATIONS - FOR UPLOAD
+final String legacyUploadPublicationYamlTemplate = new File("${templatesDirPath}/legacy-publication-upload.yaml.template").text
+(1..documentCount).forEach({ i ->
+    final String targetFileContent = legacyUploadPublicationYamlTemplate.replaceAll("\\{DOCUMENT_INDEX\\}", "${i}")
+    final String targetFileName = "legacy-publication-upload-${i}.yaml"
+
+    createLegacyUploadPublication(targetDir, targetFileName, targetFileContent)
+
+    println "Created ${targetFileName}; ${documentCount - i}/${documentCount} to go."
+})
+
+private void createLegacyUploadPublication(Path targetDir, String targetFileName, String targetFileContent) {
+    final Path legacyPublicationFile = Paths.get(targetDir.toString(), targetFileName)
+    Files.createFile(legacyPublicationFile)
+    legacyPublicationFile.toFile().text = targetFileContent
+}
+
+// CREATE USERS
+final Path usersYamlFile = Paths.get("${moduleResourcesPath}/hcm-config/configuration/users", "s3-perf-test-users.yaml")
+final String userYamlTemplate = Paths.get(templatesDirPath, "s3-user.yaml.template").toFile().text
+
+Files.deleteIfExists(usersYamlFile)
+
+String usersYaml = '''
+---
+definitions:
+  config:
+    /hippo:configuration/hippo:users:
+'''
+
+final List<String> users = []
+// CREATE USERS FOR DOWNLOAD
+(1..documentCount).forEach({ i ->
+    final String userYaml = userYamlTemplate.replaceAll('\\{USER-NUMBER\\}', "${i}")
+
+    users << "user-${i}"
+
+    usersYaml = usersYaml + userYaml
+})
+
+// CREATE USERS FOR UPLOAD
+(1..documentCount).forEach({ i ->
+    final String userYaml = userYamlTemplate.replaceAll('\\{USER-NUMBER\\}', "upload-${i}")
+
+    users << "user-upload-${i}"
+
+    usersYaml = usersYaml + userYaml
+})
+Files.createFile(usersYamlFile)
+usersYamlFile.text = usersYaml
+
+
+// ADD USERS TO GROUP 'author'
+final Path groupYamlFile = Paths.get("${moduleResourcesPath}/hcm-config/configuration/groups", "s3-perf-test-group-author.yaml")
+Files.deleteIfExists(groupYamlFile)
+final String groupYamlTemplate = Paths.get(templatesDirPath, "s3-group-author.yaml.template").toFile().text
+
+final String groupYaml = groupYamlTemplate.replaceAll(
+    "\\{GROUP-MEMBERS\\}",
+    users.stream().map({ i -> "\"${i}\""}).collect(Collectors.joining(","))
+)
+Files.createFile(groupYamlFile)
+groupYamlFile.text = groupYaml


### PR DESCRIPTION
Cucumber-driven test has been added allowing to verify
impact of S3 transfers on CMS' and Site's performance.
Test can be run both against a local as well as remote
instances; usage described in `what-if/test-s3-performance.md`.
The test does not run automatically as part of the build,
it has to be triggered manually.

Base URLs for CMS and Site used in acceptance tests now
configurable via command line, arguments `-DcmsUrl` and
`-DsiteUrl` (some Make 'test' targets may need modifying
to make use of them but the one for S3 test already does).

Make serve.noexport now uses `run` goal, ensuring it uses
all the required command line args, including ones
specifying AWS credentials.

Version of Tomcat used in locally run instances has been
configured to match that in BloomReach onDemand environments.

WebDriverProvider.newWebDriver and WebDriversRepo now make
possible to simulate a number of concurrent users accessing
the application.