### PR TITLE
[RPS-365] Create breadcrumbs for CI pages

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
@@ -164,6 +164,14 @@ public class TestContentUrls {
         addSiteUrl("national statistic publication",
             "/data-and-information/publications/lorem-ipsum-content/morbi-tempor-euismod-vehicula");
 
+        // Breadcrumbs
+        addSiteUrl("series-publication-with-datasets Dataset",
+            "/data-and-information/publications/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/series-publication-with-datasets-dataset");
+        addSiteUrl("series publication with datasets",
+            "/data-and-information/publications/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets");
+        addSiteUrl("dataset under CI folder",
+            "/data-and-information/publications/clinical-indicators/ccg-outcomes-indicator-set/current/1.1-national-ccg-outcomes/ccg-dataset");
+
         // National Indicator Library
         addSiteUrl("nihub", "/data-and-information/national-indicator-library/nihub");
         addSiteUrl("sample-indicator", "/data-and-information/national-indicator-library/sample-indicator");

--- a/acceptance-tests/src/test/resources/features/site/ciBreadcrumb.feature
+++ b/acceptance-tests/src/test/resources/features/site/ciBreadcrumb.feature
@@ -1,0 +1,51 @@
+Feature: As a user navigating to clinical indicator content, I need logical breadcrumbs
+    to help me browse around the various (often related) content.
+
+    Scenario: Series, publication, dataset (not within ci folder) breadcrumb
+        Given I navigate to the "series with publication with datasets" page
+        Then I should see the list with title "Navigation" including:
+            | series-with-publication-with-datasets |
+        And I should see the list with title "Navigation" not including:
+            | Data and information                   |
+        When I navigate to the "series publication with datasets" page
+        Then I should see the list with title "Navigation" including:
+            | series-with-publication-with-datasets |
+            | series publication with datasets      |
+        And I should see the list with title "Navigation" not including:
+            | Data and information                   |
+        When I navigate to the "series-publication-with-datasets Dataset" page
+        Then I should see the list with title "Navigation" including:
+            | series-with-publication-with-datasets     |
+            | series publication with datasets          |
+            | series-publication-with-datasets Dataset  |
+        And I should see the list with title "Navigation" not including:
+            | Data and information                   |
+
+    Scenario: Dataset (within CI folder) breadcrumb
+        Given I navigate to the "dataset under CI folder" page
+        Then I should see the list with title "Navigation" including:
+            | Data and information           |
+            | CCG Outcomes - Indicator Set  |
+            | CCG series                    |
+            | CCG publication               |
+            | CCG dataset                   |
+
+    Scenario: CI landing page (i.e. SHMI landing) breadcrumb
+        Given I navigate to the "SHMI landing" page
+        Then I should see the list with title "Navigation" including:
+            | Data and information                               |
+            | Summary Hospital-level Mortality Indicator (SHMI) |
+
+    Scenario: NIL document (not within ci folder) breadcrumb
+        Given I navigate to the "sample-indicator" page
+        Then I should see the list with title "Navigation" including:
+            | People with stroke admitted to an acute stroke unit within 4 hours of arrival at hospital     |
+        And I should see the list with title "Navigation" not including:
+            | Data and information   |
+
+    Scenario: Legacy Publication (not within ci folder) breadcrumb
+        Given I navigate to the "legacy publication" page
+        Then I should see the list with title "Navigation" including:
+            | Legacy Publication    |
+        And I should see the list with title "Navigation" not including:
+            | Data and information   |

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/base/components/breadcrumb-ci-old-styling.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/base/components/breadcrumb-ci-old-styling.yaml
@@ -1,0 +1,7 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/base/hst:components/breadcrumb-ci-old-styling:
+      hst:componentclassname: uk.nhs.digital.ps.components.CiBreadcrumbComponent
+      hst:template: breadcrumb-ci-old-styling
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/base/components/breadcrumb-ci.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/base/components/breadcrumb-ci.yaml
@@ -1,0 +1,7 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/base/hst:components/breadcrumb-ci:
+      hst:componentclassname: uk.nhs.digital.ps.components.CiBreadcrumbComponent
+      hst:template: breadcrumb-ci
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/base/templates.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/base/templates.yaml
@@ -11,6 +11,12 @@ definitions:
       /breadcrumb:
         hst:renderpath: webfile:/freemarker/common/breadcrumb.ftl
         jcr:primaryType: hst:template
+      /breadcrumb-ci:
+        hst:renderpath: webfile:/freemarker/common/breadcrumb-ci.ftl
+        jcr:primaryType: hst:template
+      /breadcrumb-ci-old-styling:
+        hst:renderpath: webfile:/freemarker/common/breadcrumb-ci-old-styling.ftl
+        jcr:primaryType: hst:template
       /footer:
         hst:renderpath: webfile:/freemarker/common/base-footer.ftl
         jcr:primaryType: hst:template

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/abstractpages/basepage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/abstractpages/basepage.yaml
@@ -2,6 +2,9 @@
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:abstractpages/basepage:
+      /breadcrumb-ci-old-styling:
+        hst:referencecomponent: hst:components/breadcrumb-ci-old-styling
+        jcr:primaryType: hst:component
       /footer:
         hst:template: footer
         jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/abstractpages/pubs_apppage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/abstractpages/pubs_apppage.yaml
@@ -2,5 +2,8 @@
 definitions:
   config:
     /hst:hst/hst:configurations/common/hst:abstractpages/pubs_apppage:
+      /breadcrumb-ci:
+        hst:referencecomponent: hst:components/breadcrumb-ci
+        jcr:primaryType: hst:component
       hst:template: pubs_app-layout
       jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/cilanding.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/cilanding.yaml
@@ -54,6 +54,16 @@ definitions:
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
+          /urlNameOfContentFolder:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Url Name of content folder
+            field: urlNameOfContentFolder
+            hint: Specify the top level CI content folder where documents of this
+              type are stored.
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
         jcr:primaryType: editor:templateset
       /hipposysedit:nodetype:
         /hipposysedit:nodetype:
@@ -89,6 +99,14 @@ definitions:
             hipposysedit:primary: false
             hipposysedit:type: Text
             jcr:primaryType: hipposysedit:field
+          /urlNameOfContentFolder:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: publicationsystem:urlNameOfContentFolder
+            hipposysedit:primary: false
+            hipposysedit:type: String
+            jcr:primaryType: hipposysedit:field
           hipposysedit:node: true
           hipposysedit:supertype:
           - publicationsystem:basedocument
@@ -119,6 +137,7 @@ definitions:
           publicationsystem:actionLinkName: ''
           publicationsystem:actionLinkRelPath: ''
           publicationsystem:title: ''
+          publicationsystem:urlNameOfContentFolder: ''
         jcr:primaryType: hipposysedit:prototypeset
       jcr:mixinTypes:
       - editor:editable

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/ci-hub.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/ci-hub.yaml
@@ -36,7 +36,6 @@
         publicationsystem:title: ''
       common:searchable: true
       hippo:availability: []
-      hippostd:holder: admin
       hippostd:state: draft
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2018-01-23T14:54:36.279Z
@@ -51,6 +50,7 @@
       publicationsystem:actionLinkName: Browse CCG Outcomes
       publicationsystem:actionLinkRelPath: search/category/clinical-commissioning-groups-outcomes-framework/category/team/category/clinical-indicators?sort=relevance&area=data
       publicationsystem:title: CCG Outcomes - Indicator Set
+      publicationsystem:urlNameOfContentFolder: ccg-outcomes-indicator-set
     /ccg-outcomes[2]:
       /publicationsystem:cilandingasset:
         /publicationsystem:content:
@@ -102,6 +102,7 @@
       publicationsystem:actionLinkName: Browse CCG Outcomes
       publicationsystem:actionLinkRelPath: search/category/clinical-commissioning-groups-outcomes-framework/category/team/category/clinical-indicators?sort=relevance&area=data
       publicationsystem:title: CCG Outcomes - Indicator Set
+      publicationsystem:urlNameOfContentFolder: ccg-outcomes-indicator-set
     /ccg-outcomes[3]:
       /publicationsystem:cilandingasset:
         /publicationsystem:content:
@@ -153,6 +154,7 @@
       publicationsystem:actionLinkName: Browse CCG Outcomes
       publicationsystem:actionLinkRelPath: search/category/clinical-commissioning-groups-outcomes-framework/category/team/category/clinical-indicators?sort=relevance&area=data
       publicationsystem:title: CCG Outcomes - Indicator Set
+      publicationsystem:urlNameOfContentFolder: ccg-outcomes-indicator-set
     hippo:name: CCG Outcomes
     jcr:mixinTypes:
     - hippo:named
@@ -330,6 +332,7 @@
       publicationsystem:actionLinkName: Browse Compendium Indicators
       publicationsystem:actionLinkRelPath: search/category/compendium/category/team/category/clinical-indicators
       publicationsystem:title: Compendium of Population Health Indicators
+      publicationsystem:urlNameOfContentFolder: compendium-of-population-health-indicators
     /compendium-indicators[2]:
       /publicationsystem:cilandingasset:
         /publicationsystem:content:
@@ -502,6 +505,7 @@
       publicationsystem:actionLinkName: Browse Compendium Indicators
       publicationsystem:actionLinkRelPath: search/category/compendium/category/team/category/clinical-indicators
       publicationsystem:title: Compendium of Population Health Indicators
+      publicationsystem:urlNameOfContentFolder: compendium-of-population-health-indicators
     /compendium-indicators[3]:
       /publicationsystem:cilandingasset:
         /publicationsystem:content:
@@ -674,6 +678,7 @@
       publicationsystem:actionLinkName: Browse Compendium Indicators
       publicationsystem:actionLinkRelPath: search/category/compendium/category/team/category/clinical-indicators
       publicationsystem:title: Compendium of Population Health Indicators
+      publicationsystem:urlNameOfContentFolder: compendium-of-population-health-indicators
     hippo:name: Compendium Indicators
     jcr:mixinTypes:
     - hippo:named
@@ -732,6 +737,7 @@
       publicationsystem:actionLinkName: Browse NHS Outcomes
       publicationsystem:actionLinkRelPath: search/category/nhs-outcomes-framework/category/team/category/clinical-indicators
       publicationsystem:title: NHS Outcomes Framework
+      publicationsystem:urlNameOfContentFolder: nhs-outcomes-framework
     /nhs-outcomes-framework[2]:
       /publicationsystem:cilandingasset:
         /publicationsystem:content:
@@ -785,6 +791,7 @@
       publicationsystem:actionLinkName: Browse NHS Outcomes
       publicationsystem:actionLinkRelPath: search/category/nhs-outcomes-framework/category/team/category/clinical-indicators
       publicationsystem:title: NHS Outcomes Framework
+      publicationsystem:urlNameOfContentFolder: nhs-outcomes-framework
     /nhs-outcomes-framework[3]:
       /publicationsystem:cilandingasset:
         /publicationsystem:content:
@@ -838,6 +845,7 @@
       publicationsystem:actionLinkName: Browse NHS Outcomes
       publicationsystem:actionLinkRelPath: search/category/nhs-outcomes-framework/category/team/category/clinical-indicators
       publicationsystem:title: NHS Outcomes Framework
+      publicationsystem:urlNameOfContentFolder: nhs-outcomes-framework
     hippo:name: NHS Outcomes Framework
     jcr:mixinTypes:
     - hippo:named
@@ -1150,6 +1158,7 @@
       publicationsystem:actionLinkName: Browse Social Care
       publicationsystem:actionLinkRelPath: search/category/adult-social-outcomes-framework--ascof-/category/team/category/clinical-indicators
       publicationsystem:title: Social Care
+      publicationsystem:urlNameOfContentFolder: adult-social-care-outcomes-framework-ascof
     /social-care[2]:
       /publicationsystem:cilandingasset:
         /publicationsystem:content:
@@ -1209,6 +1218,7 @@
       publicationsystem:actionLinkName: Browse Social Care
       publicationsystem:actionLinkRelPath: search/category/adult-social-outcomes-framework--ascof-/category/team/category/clinical-indicators
       publicationsystem:title: Social Care
+      publicationsystem:urlNameOfContentFolder: adult-social-care-outcomes-framework-ascof
     /social-care[3]:
       /publicationsystem:cilandingasset:
         /publicationsystem:content:
@@ -1268,6 +1278,7 @@
       publicationsystem:actionLinkName: Browse Social Care
       publicationsystem:actionLinkRelPath: search/category/adult-social-outcomes-framework--ascof-/category/team/category/clinical-indicators
       publicationsystem:title: Social Care
+      publicationsystem:urlNameOfContentFolder: adult-social-care-outcomes-framework-ascof
     hippo:name: Social Care
     jcr:mixinTypes:
     - hippo:named
@@ -1353,6 +1364,7 @@
       publicationsystem:actionLinkName: Browse SHMI
       publicationsystem:actionLinkRelPath: search/category/summary-hospital-level-mortality-indicator--shmi-/category/team/category/clinical-indicators
       publicationsystem:title: Summary Hospital-level Mortality Indicator (SHMI)
+      publicationsystem:urlNameOfContentFolder: shmi
     /summary-hospital-level-mortality-indicator-shmi[2]:
       /publicationsystem:cilandingasset[1]:
         /publicationsystem:Attachments:
@@ -1433,6 +1445,7 @@
       publicationsystem:actionLinkName: Browse SHMI
       publicationsystem:actionLinkRelPath: search/category/summary-hospital-level-mortality-indicator--shmi-/category/team/category/clinical-indicators
       publicationsystem:title: Summary Hospital-level Mortality Indicator (SHMI)
+      publicationsystem:urlNameOfContentFolder: shmi
     /summary-hospital-level-mortality-indicator-shmi[3]:
       /publicationsystem:cilandingasset[1]:
         /publicationsystem:Attachments:
@@ -1513,6 +1526,7 @@
       publicationsystem:actionLinkName: Browse SHMI
       publicationsystem:actionLinkRelPath: search/category/summary-hospital-level-mortality-indicator--shmi-/category/team/category/clinical-indicators
       publicationsystem:title: Summary Hospital-level Mortality Indicator (SHMI)
+      publicationsystem:urlNameOfContentFolder: shmi
     hippo:name: Summary Hospital-level Mortality Indicator (SHMI)
     jcr:mixinTypes:
     - hippo:named

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/clinical-indicators.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/clinical-indicators.yaml
@@ -1,0 +1,293 @@
+---
+/content/documents/corporate-website/publication-system/clinical-indicators:
+  /ccg-outcomes-indicator-set:
+    /archive:
+      hippo:name: Archive
+      hippostd:foldertype:
+      - new-statistical-publications-and-clinical-indicators-folder
+      - new-statistical-publications-and-clinical-indicators-document
+      hippotranslation:id: a1e0168e-2532-4116-a443-f146502b4dbf
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippo:named
+      - hippotranslation:translated
+      - mix:versionable
+      jcr:primaryType: hippostd:folder
+    /current:
+      /1.1-national-ccg-outcomes:
+        /ccg-dataset:
+          /ccg-dataset[1]:
+            common:FacetType: dataset
+            common:searchRank: 3
+            common:searchable: true
+            hippo:availability: []
+            hippostd:state: draft
+            hippostdpubwf:createdBy: admin
+            hippostdpubwf:creationDate: 2018-04-20T19:44:52.537Z
+            hippostdpubwf:lastModificationDate: 2018-04-25T15:09:34.624Z
+            hippostdpubwf:lastModifiedBy: admin
+            hippotranslation:id: b5384c78-18af-42e1-95b1-1a6f5c5a6cd3
+            hippotranslation:locale: en
+            jcr:mixinTypes:
+            - hippotaxonomy:classifiable
+            - mix:referenceable
+            jcr:primaryType: publicationsystem:dataset
+            publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+            publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+            publicationsystem:GeographicCoverage: []
+            publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
+            publicationsystem:NominalDate: 2018-04-02T23:00:00Z
+            publicationsystem:Summary: Test CCG dataset document
+            publicationsystem:Title: CCG dataset
+          /ccg-dataset[2]:
+            common:FacetType: dataset
+            common:searchRank: 3
+            common:searchable: true
+            hippo:availability:
+            - preview
+            hippostd:state: unpublished
+            hippostdpubwf:createdBy: admin
+            hippostdpubwf:creationDate: 2018-04-20T19:44:52.537Z
+            hippostdpubwf:lastModificationDate: 2018-04-25T15:09:54.358Z
+            hippostdpubwf:lastModifiedBy: admin
+            hippotranslation:id: b5384c78-18af-42e1-95b1-1a6f5c5a6cd3
+            hippotranslation:locale: en
+            jcr:mixinTypes:
+            - hippotaxonomy:classifiable
+            - mix:referenceable
+            - mix:versionable
+            jcr:primaryType: publicationsystem:dataset
+            publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+            publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+            publicationsystem:GeographicCoverage: []
+            publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
+            publicationsystem:NominalDate: 2018-04-02T23:00:00Z
+            publicationsystem:Summary: Test CCG dataset document
+            publicationsystem:Title: CCG dataset
+          /ccg-dataset[3]:
+            common:FacetType: dataset
+            common:searchRank: 3
+            common:searchable: true
+            hippo:availability:
+            - live
+            hippostd:state: published
+            hippostdpubwf:createdBy: admin
+            hippostdpubwf:creationDate: 2018-04-20T19:44:52.537Z
+            hippostdpubwf:lastModificationDate: 2018-04-25T15:09:54.358Z
+            hippostdpubwf:lastModifiedBy: admin
+            hippostdpubwf:publicationDate: 2018-04-25T15:12:57.619Z
+            hippotranslation:id: b5384c78-18af-42e1-95b1-1a6f5c5a6cd3
+            hippotranslation:locale: en
+            jcr:mixinTypes:
+            - hippotaxonomy:classifiable
+            - mix:referenceable
+            jcr:primaryType: publicationsystem:dataset
+            publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+            publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+            publicationsystem:GeographicCoverage: []
+            publicationsystem:NextPublicationDate: 0001-01-01T12:00:00Z
+            publicationsystem:NominalDate: 2018-04-02T23:00:00Z
+            publicationsystem:Summary: Test CCG dataset document
+            publicationsystem:Title: CCG dataset
+          hippo:name: CCG dataset
+          jcr:mixinTypes:
+          - hippo:named
+          - mix:referenceable
+          jcr:primaryType: hippo:handle
+        /content:
+          /content[1]:
+            common:FacetType: publication
+            common:searchRank: 4
+            common:searchable: true
+            hippo:availability: []
+            hippostd:state: draft
+            hippostdpubwf:createdBy: admin
+            hippostdpubwf:creationDate: 2018-04-20T19:41:28.048Z
+            hippostdpubwf:lastModificationDate: 2018-04-25T15:13:03.419Z
+            hippostdpubwf:lastModifiedBy: admin
+            hippotranslation:id: f9588f77-95f3-49a4-8595-4c9b6de92db1
+            hippotranslation:locale: en
+            jcr:mixinTypes:
+            - hippotaxonomy:classifiable
+            - mix:referenceable
+            jcr:primaryType: publicationsystem:publication
+            publicationsystem:AdministrativeSources: ''
+            publicationsystem:CoverageEnd: 2018-04-19T23:00:00Z
+            publicationsystem:CoverageStart: 2018-04-19T23:00:00Z
+            publicationsystem:GeographicCoverage: []
+            publicationsystem:InformationType:
+            - Experimental statistics
+            publicationsystem:KeyFacts: some keyfacts here
+            publicationsystem:NominalDate: 2018-04-19T23:00:00Z
+            publicationsystem:PubliclyAccessible: true
+            publicationsystem:Summary: Test CCG publication document
+            publicationsystem:Title: CCG publication
+          /content[2]:
+            common:FacetType: publication
+            common:searchRank: 4
+            common:searchable: true
+            hippo:availability:
+            - preview
+            hippostd:state: unpublished
+            hippostdpubwf:createdBy: admin
+            hippostdpubwf:creationDate: 2018-04-20T19:41:28.048Z
+            hippostdpubwf:lastModificationDate: 2018-04-25T15:13:20.978Z
+            hippostdpubwf:lastModifiedBy: admin
+            hippotranslation:id: f9588f77-95f3-49a4-8595-4c9b6de92db1
+            hippotranslation:locale: en
+            jcr:mixinTypes:
+            - hippotaxonomy:classifiable
+            - mix:referenceable
+            - mix:versionable
+            jcr:primaryType: publicationsystem:publication
+            publicationsystem:AdministrativeSources: ''
+            publicationsystem:CoverageEnd: 2018-04-19T23:00:00Z
+            publicationsystem:CoverageStart: 2018-04-19T23:00:00Z
+            publicationsystem:GeographicCoverage: []
+            publicationsystem:InformationType:
+            - Experimental statistics
+            publicationsystem:KeyFacts: some keyfacts here
+            publicationsystem:NominalDate: 2018-04-19T23:00:00Z
+            publicationsystem:PubliclyAccessible: true
+            publicationsystem:Summary: Test CCG publication document
+            publicationsystem:Title: CCG publication
+          /content[3]:
+            common:FacetType: publication
+            common:searchRank: 4
+            common:searchable: true
+            hippo:availability:
+            - live
+            hippostd:state: published
+            hippostdpubwf:createdBy: admin
+            hippostdpubwf:creationDate: 2018-04-20T19:41:28.048Z
+            hippostdpubwf:lastModificationDate: 2018-04-25T15:13:20.978Z
+            hippostdpubwf:lastModifiedBy: admin
+            hippostdpubwf:publicationDate: 2018-04-25T15:13:23.358Z
+            hippotranslation:id: f9588f77-95f3-49a4-8595-4c9b6de92db1
+            hippotranslation:locale: en
+            jcr:mixinTypes:
+            - hippotaxonomy:classifiable
+            - mix:referenceable
+            jcr:primaryType: publicationsystem:publication
+            publicationsystem:AdministrativeSources: ''
+            publicationsystem:CoverageEnd: 2018-04-19T23:00:00Z
+            publicationsystem:CoverageStart: 2018-04-19T23:00:00Z
+            publicationsystem:GeographicCoverage: []
+            publicationsystem:InformationType:
+            - Experimental statistics
+            publicationsystem:KeyFacts: some keyfacts here
+            publicationsystem:NominalDate: 2018-04-19T23:00:00Z
+            publicationsystem:PubliclyAccessible: true
+            publicationsystem:Summary: Test CCG publication document
+            publicationsystem:Title: CCG publication
+          hippo:name: content
+          jcr:mixinTypes:
+          - hippo:named
+          - mix:referenceable
+          jcr:primaryType: hippo:handle
+        hippo:name: 1.1 national ccg outcomes
+        hippostd:foldertype:
+        - new-statistical-publications-and-clinical-indicators-folder
+        - new-statistical-publications-and-clinical-indicators-document
+        hippotranslation:id: 4bf51c4c-7526-41bb-9de7-cdfaf940ef99
+        hippotranslation:locale: en
+        jcr:mixinTypes:
+        - hippo:named
+        - hippotranslation:translated
+        - mix:versionable
+        jcr:primaryType: hippostd:folder
+      /content:
+        /content[1]:
+          common:FacetType: series
+          common:searchRank: 5
+          common:searchable: true
+          hippo:availability: []
+          hippostd:state: draft
+          hippostdpubwf:createdBy: admin
+          hippostdpubwf:creationDate: 2018-04-20T19:33:17.786Z
+          hippostdpubwf:lastModificationDate: 2018-04-25T15:06:19.083Z
+          hippostdpubwf:lastModifiedBy: admin
+          hippotranslation:id: cf7ba720-4134-4dd4-9496-e4e92b77b48a
+          hippotranslation:locale: en
+          jcr:mixinTypes:
+          - mix:referenceable
+          jcr:primaryType: publicationsystem:series
+          publicationsystem:ShowLatest: false
+          publicationsystem:Summary: Test CCG series document
+          publicationsystem:Title: CCG series
+        /content[2]:
+          common:FacetType: series
+          common:searchRank: 5
+          common:searchable: true
+          hippo:availability:
+          - preview
+          hippostd:state: unpublished
+          hippostdpubwf:createdBy: admin
+          hippostdpubwf:creationDate: 2018-04-20T19:33:17.786Z
+          hippostdpubwf:lastModificationDate: 2018-04-25T15:08:07.466Z
+          hippostdpubwf:lastModifiedBy: admin
+          hippotranslation:id: cf7ba720-4134-4dd4-9496-e4e92b77b48a
+          hippotranslation:locale: en
+          jcr:mixinTypes:
+          - mix:referenceable
+          - mix:versionable
+          jcr:primaryType: publicationsystem:series
+          publicationsystem:ShowLatest: false
+          publicationsystem:Summary: Test CCG series document
+          publicationsystem:Title: CCG series
+        /content[3]:
+          common:FacetType: series
+          common:searchRank: 5
+          common:searchable: true
+          hippo:availability:
+          - live
+          hippostd:state: published
+          hippostdpubwf:createdBy: admin
+          hippostdpubwf:creationDate: 2018-04-20T19:33:17.786Z
+          hippostdpubwf:lastModificationDate: 2018-04-25T15:08:07.466Z
+          hippostdpubwf:lastModifiedBy: admin
+          hippostdpubwf:publicationDate: 2018-04-25T15:08:11.130Z
+          hippotranslation:id: cf7ba720-4134-4dd4-9496-e4e92b77b48a
+          hippotranslation:locale: en
+          jcr:mixinTypes:
+          - mix:referenceable
+          jcr:primaryType: publicationsystem:series
+          publicationsystem:ShowLatest: false
+          publicationsystem:Summary: Test CCG series document
+          publicationsystem:Title: CCG series
+        jcr:mixinTypes:
+        - mix:referenceable
+        jcr:primaryType: hippo:handle
+      hippo:name: Current
+      hippostd:foldertype:
+      - new-statistical-publications-and-clinical-indicators-folder
+      - new-statistical-publications-and-clinical-indicators-document
+      hippotranslation:id: bed26eb6-4051-4c54-9eac-057b2b5fceea
+      hippotranslation:locale: en
+      jcr:mixinTypes:
+      - hippo:named
+      - hippotranslation:translated
+      - mix:versionable
+      jcr:primaryType: hippostd:folder
+    hippo:name: CCG Outcomes Indicator Set
+    hippostd:foldertype:
+    - new-statistical-publications-and-clinical-indicators-folder
+    - new-statistical-publications-and-clinical-indicators-document
+    hippotranslation:id: 817da31c-beef-40d7-a949-b053cda0b115
+    hippotranslation:locale: en
+    jcr:mixinTypes:
+    - hippo:named
+    - hippotranslation:translated
+    - mix:versionable
+    jcr:primaryType: hippostd:folder
+  hippo:name: Clinical Indicators
+  hippostd:foldertype:
+  - new-statistical-publications-and-clinical-indicators-folder
+  - new-statistical-publications-and-clinical-indicators-document
+  hippotranslation:id: 175b91bb-53aa-44ab-9dbe-b5289a63b6cb
+  hippotranslation:locale: en
+  jcr:mixinTypes:
+  - hippo:named
+  - hippotranslation:translated
+  - mix:versionable
+  jcr:primaryType: hippostd:folder

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/base-layout.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/base-layout.ftl
@@ -66,20 +66,7 @@
     </header>
 
     <div class="breadcrumb">
-        <ol class="breadcrumb">
-            <li class="breadcrumb__crumb">
-                <span class="label">You are here:</span>
-            </li>
-            <li class="breadcrumb__crumb">
-                <@hst.link var="homelink" path="/" />
-                <a href="${homelink}">Home</a>
-            </li>
-            <li class="separator">/</li>
-            <li class="breadcrumb__crumb">
-                <@hst.link var="cilink" path="/data-and-information#clinicalindicators" />
-                <a href="${cilink}">Clinical Indicators</a>
-            </li>
-        </ol>
+        <@hst.include ref="breadcrumb-ci-old-styling"/>
     </div>
 
     <@hst.include ref="top"/>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/breadcrumb-ci-old-styling.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/breadcrumb-ci-old-styling.ftl
@@ -1,0 +1,32 @@
+<#ftl output_format="HTML">
+<#include "../include/imports.ftl">
+
+<#if ciBreadcrumb?? && ciBreadcrumb.items?size gte 1>
+    <ul class="breadcrumb" title="Navigation">
+        <li class="breadcrumb__crumb">
+            <span class="label">You are here:</span>
+        </li>
+        <li class="breadcrumb__crumb">
+            <@hst.link var="homelink" path="/" />
+            <a href="${homelink}" title="NHS Digital">NHS Digital</a>
+        </li>
+
+        <#if ciBreadcrumb.clinicalIndicator>
+            <li class="separator">${ciBreadcrumb.separator}</li>
+            <li class="breadcrumb__crumb">
+                <@hst.link var="cilink" path="/data-and-information#clinicalindicators" />
+                <a href="${cilink}" title="Data and information">Data and information</a>
+            </li>
+        </#if>
+
+        <#list ciBreadcrumb.items as item>
+            <li class="separator">${ciBreadcrumb.separator}</li>
+            <#if !item?is_last>
+                <@hst.link var="link" link=item.link/>
+                <li><a href="${link}" class="breadcrumb__link">${item.title}</a></li>
+            <#else>
+                <li><span class="breadcrumb__link breadcrumb__link--secondary">${item.title}</span></li>
+            </#if>
+        </#list>
+    </ul>
+</#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/breadcrumb-ci.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/breadcrumb-ci.ftl
@@ -1,0 +1,44 @@
+<#ftl output_format="HTML">
+<#include "../include/imports.ftl">
+
+<div class="grid-wrapper">
+    <div class="grid-row">
+        <div class="column column--reset">
+            <div class="breadcrumb list list--inline list--reset">
+
+                <#if ciBreadcrumb?? && ciBreadcrumb.items?size gte 1>
+
+                    <ul class="breadcrumb" title="Navigation">
+
+                        <li class="breadcrumb__crumb">
+                            <a href="<@hst.link siteMapItemRefId='root'/>" class="breadcrumb__link">NHS Digital</a>
+                        </li>
+
+                        <#if ciBreadcrumb.clinicalIndicator>
+                            <li class="breadcrumb__crumb">
+                                <img src="<@hst.webfile  path="images/icon-arrow.png"/>" alt="" class="breadcrumb__sep"/>
+                                <@hst.link var="cilink" path="/data-and-information#clinicalindicators" />
+                                <a href="${cilink}" class="breadcrumb__link" title="Data and information">Data and information</a>
+                            </li>
+                        </#if>
+
+                        <#list ciBreadcrumb.items as item>
+                            <li class="breadcrumb__crumb">
+                                <img src="<@hst.webfile  path="images/icon-arrow.png"/>" alt="" class="breadcrumb__sep"/>
+                                <#if !item?is_last>
+                                    <@hst.link var="link" link=item.link/>
+                                    <a href="${link}" class="breadcrumb__link">${item.title}</a>
+                                <#else>
+                                    <span class="breadcrumb__link breadcrumb__link--secondary">${item.title}</span>
+                                </#if>
+                            </li>
+                        </#list>
+                    </ul>
+
+
+                </#if>
+
+            </div>
+        </div>
+    </div>
+</div>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/pubs_app-layout.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/pubs_app-layout.ftl
@@ -12,7 +12,7 @@
     <#-- Add site header with the search bar -->
     <@siteHeader true></@siteHeader>
 
-    <@hst.include ref="breadcrumb"/>
+    <@hst.include ref="breadcrumb-ci"/>
 
     <@hst.include ref="main" />
 

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/cilanding.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/cilanding.ftl
@@ -8,9 +8,6 @@
 <#include "../common/macro/metaTags.ftl">
 <@metaTags></@metaTags>
 
-<#include "../common/macro/pubsBreadcrumb.ftl">
-<@pubsBreadcrumb "Publications"></@pubsBreadcrumb>
-
 <#assign hasSubSections = document.subSections?has_content />
 <#assign foundSubsectionTitle = false />
 <#list document.subSections as section>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/legacy-publication.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/legacy-publication.ftl
@@ -8,9 +8,6 @@
 <#include "../common/macro/metaTags.ftl">
 <@metaTags></@metaTags>
 
-<#include "../common/macro/pubsBreadcrumb.ftl">
-<@pubsBreadcrumb "Publications"></@pubsBreadcrumb>
-
 <#macro nationalStatsStamp>
     <#list legacyPublication.informationType as type>
         <#if type == "National statistics">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
@@ -4,7 +4,6 @@
 <#include "./macro/pageIndex.ftl">
 <#include "./macro/publicationHeader.ftl">
 <#include "./macro/sections/imageSection.ftl">
-<#include "../common/macro/pubsBreadcrumb.ftl">
 <#assign formatFileSize="uk.nhs.digital.ps.directives.FileSizeFormatterDirective"?new() />
 <@hst.setBundle basename="publicationsystem.labels,publicationsystem.headers"/>
 <#-- @ftlvariable name="publication" type="uk.nhs.digital.ps.beans.Publication" -->
@@ -12,8 +11,6 @@
 <#-- Add meta tags -->
 <#include "../common/macro/metaTags.ftl">
 <@metaTags></@metaTags>
-
-<@pubsBreadcrumb "Publications"></@pubsBreadcrumb>
 
 <#macro restrictedContentOfUpcomingPublication>
     <div class="grid-wrapper grid-wrapper--full-width grid-wrapper--wide" aria-label="Document Header">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/series.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/series.ftl
@@ -7,9 +7,6 @@
 <#include "../common/macro/metaTags.ftl">
 <@metaTags></@metaTags>
 
-<#include "../common/macro/pubsBreadcrumb.ftl">
-<@pubsBreadcrumb "Publications"></@pubsBreadcrumb>
-
 <article class="article article--legacy-series">
     <#if series??>
     <div class="grid-wrapper grid-wrapper--full-width grid-wrapper--wide">

--- a/site/src/main/java/uk/nhs/digital/ps/beans/CiLanding.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/CiLanding.java
@@ -34,4 +34,10 @@ public class CiLanding extends BaseDocument {
     public String getActionLinkRelPath() {
         return getProperty("publicationsystem:actionLinkRelPath");
     }
+
+    @HippoEssentialsGenerated(internalName = "publicationsystem:urlNameOfContentFolder")
+    public String getUrlNameOfContentFolder() {
+        return getProperty("publicationsystem:urlNameOfContentFolder");
+    }
+
 }

--- a/site/src/main/java/uk/nhs/digital/ps/beans/navigation/CiBreadcrumb.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/navigation/CiBreadcrumb.java
@@ -1,0 +1,20 @@
+package uk.nhs.digital.ps.beans.navigation;
+
+import org.onehippo.forge.breadcrumb.om.Breadcrumb;
+import org.onehippo.forge.breadcrumb.om.BreadcrumbItem;
+
+import java.util.List;
+
+public class CiBreadcrumb extends Breadcrumb {
+
+    private boolean isClinicalIndicator;
+
+    public CiBreadcrumb(List<BreadcrumbItem> items, String separator, boolean isClinicalIndicator) {
+        super(items, separator);
+        this.isClinicalIndicator = isClinicalIndicator;
+    }
+
+    public boolean isClinicalIndicator() {
+        return this.isClinicalIndicator;
+    }
+}

--- a/site/src/main/java/uk/nhs/digital/ps/beans/navigation/CiBreadcrumbProvider.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/navigation/CiBreadcrumbProvider.java
@@ -1,0 +1,155 @@
+package uk.nhs.digital.ps.beans.navigation;
+
+import static org.hippoecm.hst.content.beans.query.builder.ConstraintBuilder.constraint;
+import static org.hippoecm.hst.content.beans.query.builder.ConstraintBuilder.or;
+
+import org.hippoecm.hst.container.RequestContextProvider;
+import org.hippoecm.hst.content.beans.query.HstQuery;
+import org.hippoecm.hst.content.beans.query.HstQueryResult;
+import org.hippoecm.hst.content.beans.query.builder.Constraint;
+import org.hippoecm.hst.content.beans.query.builder.HstQueryBuilder;
+import org.hippoecm.hst.content.beans.query.exceptions.QueryException;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
+import org.hippoecm.hst.core.component.HstComponentException;
+import org.hippoecm.hst.core.component.HstRequest;
+import org.hippoecm.hst.core.request.HstRequestContext;
+import org.onehippo.forge.breadcrumb.om.BreadcrumbItem;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.nhs.digital.ps.beans.*;
+
+import java.util.*;
+
+/**
+ * <p>
+ * Default Hippo Breadcrumb plugin uses menu/folder structure to generate breadcrumbs,
+ * but this doesn't fit for clinical indicator content (ciLanding, publication,
+ * series, datasets) as they have a very specific setup in the CMS.
+ * </p>
+ */
+public class CiBreadcrumbProvider  {
+
+    private static final Logger log = LoggerFactory.getLogger(CiBreadcrumbProvider.class);
+    private static final String SEPARATOR = "/";
+    private CiLanding ciLandingBean = null;
+    private boolean isClinicalIndicator = false;
+    private final HstRequestContext ctx;
+    private final HippoBean currentDocumentBean;
+
+    public CiBreadcrumbProvider(final HstRequest request) {
+        ctx = request.getRequestContext();
+        currentDocumentBean = request.getRequestContext().getContentBean();
+    }
+
+    public CiBreadcrumb getBreadcrumb() {
+
+        loadCiLandingBean();
+
+        List<BreadcrumbItem> ciBreadcrumbItems = new ArrayList<>();
+
+        if (currentDocumentBean instanceof CiLanding) {
+            isClinicalIndicator = true;
+        } else {
+            addCiLandingPageBreadcrumbItem(ciBreadcrumbItems);
+
+            // If Publication or dataset, find parent links for breadcrumb trail
+            // (note: not required for series since series documents are
+            // already top level breadcrumb)
+            if (currentDocumentBean instanceof Publication) {
+                addPublicationBreadcrumbItem(ciBreadcrumbItems);
+            } else if (currentDocumentBean instanceof Dataset) {
+                addDatasetBreadcrumbItem(ciBreadcrumbItems);
+            }
+        }
+
+        // finally, add navigation for THIS document
+        ciBreadcrumbItems.add(createBreadcrumbItem(ctx, currentDocumentBean));
+
+        log.debug("{} created {} breadcrumb items: {}", this.getClass().getName(), ciBreadcrumbItems.size(),
+            ciBreadcrumbItems.stream().map(BreadcrumbItem::getTitle).toArray());
+
+        return new CiBreadcrumb(ciBreadcrumbItems, SEPARATOR, isClinicalIndicator);
+    }
+
+    private BreadcrumbItem createBreadcrumbItem(final HstRequestContext ctx, final HippoBean bean) {
+        return new BreadcrumbItem(
+            ctx.getHstLinkCreator().create(bean, ctx),
+            ((BaseDocument) bean).getTitle());
+    }
+
+    /**
+     * <p>
+     * Query the repository to see if this document sits under one of the Clinical Indicator
+     * folders, and if so load in the CiLanding bean (which is used to create the breadcrumb).
+     * The CiLanding document has a property called urlNameOfContentFolder which links
+     * the CiLanding page to the appropriate content folder
+     * </p>
+     */
+    private void loadCiLandingBean() {
+
+        HstQueryBuilder queryBuilder = HstQueryBuilder.create(RequestContextProvider.get().getSiteContentBaseBean());
+        final HstQueryResult hstQueryResult;
+
+        Constraint[] constraints = Arrays.stream(currentDocumentBean.getPath().split("/"))
+            .map((pathSegment) -> constraint("publicationsystem:urlNameOfContentFolder").equalTo(pathSegment))
+            .toArray(Constraint[]::new);
+
+        final HstQuery query = queryBuilder
+            .ofTypes(CiLanding.class)
+            .where(or(
+                constraints
+            ))
+            .build();
+
+        try {
+            hstQueryResult = query.execute();
+        } catch (QueryException queryException) {
+            throw new HstComponentException(
+                "Exception occurred during ci folder search.", queryException);
+        }
+
+        if (hstQueryResult.getHippoBeans().hasNext()) {
+            isClinicalIndicator = true;
+            ciLandingBean = (CiLanding) hstQueryResult.getHippoBeans().nextHippoBean();
+        }
+    }
+
+    private void addCiLandingPageBreadcrumbItem(List<BreadcrumbItem> ciBreadcrumbItems) {
+        if (ciLandingBean != null) {
+            ciBreadcrumbItems.add(createBreadcrumbItem(ctx, ciLandingBean));
+        }
+    }
+
+    private void addPublicationBreadcrumbItem(List<BreadcrumbItem> ciBreadcrumbItems) {
+        // Is publication part of series?
+        HippoBean publicationParent =  ((Publication) currentDocumentBean).getParentDocument();
+        if (publicationParent != null) {
+
+            // Create Series navigation
+            Series series = (Series) publicationParent;
+            ciBreadcrumbItems.add(createBreadcrumbItem(ctx, series));
+        }
+    }
+
+    private void addDatasetBreadcrumbItem(List<BreadcrumbItem> ciBreadcrumbItems) {
+        // get Dataset's parent publication
+        HippoBean datasetParent =  ((Dataset) currentDocumentBean).getParentPublication();
+        if (datasetParent != null) {
+
+            Publication publication = (Publication) datasetParent;
+
+            // Is publication part of series?
+            HippoBean publicationParent =  publication.getParentDocument();
+            if (publicationParent != null) {
+
+                // Create Series navigation
+                Series series = (Series) publicationParent;
+                ciBreadcrumbItems.add(createBreadcrumbItem(ctx, series));
+            }
+
+            // Create Publication navigation
+            ciBreadcrumbItems.add(createBreadcrumbItem(ctx, publication));
+        }
+    }
+}

--- a/site/src/main/java/uk/nhs/digital/ps/components/CiBreadcrumbComponent.java
+++ b/site/src/main/java/uk/nhs/digital/ps/components/CiBreadcrumbComponent.java
@@ -1,0 +1,20 @@
+package uk.nhs.digital.ps.components;
+
+import org.hippoecm.hst.component.support.bean.BaseHstComponent;
+import org.hippoecm.hst.core.component.HstRequest;
+import org.hippoecm.hst.core.component.HstResponse;
+import uk.nhs.digital.ps.beans.navigation.CiBreadcrumb;
+import uk.nhs.digital.ps.beans.navigation.CiBreadcrumbProvider;
+
+public class CiBreadcrumbComponent extends BaseHstComponent {
+
+    @Override
+    public void doBeforeRender(final HstRequest request, final HstResponse response) {
+        super.doBeforeRender(request, response);
+
+        CiBreadcrumbProvider ciBreadcrumbProvider = new CiBreadcrumbProvider(request);
+        CiBreadcrumb ciBreadcrumb = ciBreadcrumbProvider.getBreadcrumb();
+
+        request.setAttribute("ciBreadcrumb", ciBreadcrumb);
+    }
+}


### PR DESCRIPTION
Added breadcrumbs for CI content (series,publication,
datasets). If the document sits under one of the
clinical indicator folders (i.e. CCG, SHMI), then a
breadcrumb back to that CI landing page is also added
to the hierarchy.

Note: 2 separate breadcrumbs had to be created, one
which uses the old styling (breadcrumb-ci-old-styling)
and one which uses the new styling (breadcrumb-ci). Once
the dataset template has been updated with the new styling,
then breadcrumb-ci-old-styling can be removed, and replaced
with the same breadcrumb that the publication/series page
uses.