### PR TITLE
[RPS-451] Changed the s3 rollback script

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/Migration20180502RevertExternalAttachmentsToEmbedded.groovy
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/Migration20180502RevertExternalAttachmentsToEmbedded.groovy
@@ -1,9 +1,12 @@
 package org.hippoecm.frontend.plugins.cms.admin.updater
 
+import org.hippoecm.repository.HippoStdNodeType
 import org.hippoecm.repository.util.JcrUtils
 import org.onehippo.repository.update.BaseNodeUpdateVisitor
 
 import javax.jcr.Node
+import javax.jcr.nodetype.ConstraintViolationException
+
 /**
  * Revert the nodes from external attachments to embedded ones for if anything goes wrong with
  * activating the S3 integration
@@ -15,6 +18,7 @@ class Migration20180502RevertExternalAttachmentsToEmbedded extends BaseNodeUpdat
 
     private static final String NODE_TYPE_OLD_ATTACHMENT = "publicationsystem:attachment"
     private static final String NODE_TYPE_EXTERNAL_ATTACHMENT = "publicationsystem:extattachment"
+    private static final String CONSTRAINT_ERROR_MESSAGE = "no matching property definition found for {http://digital.nhs.uk/jcr/externalstorage/nt/1.0}reference"
 
     boolean doUpdate(Node attachmentNode) {
         try {
@@ -29,7 +33,21 @@ class Migration20180502RevertExternalAttachmentsToEmbedded extends BaseNodeUpdat
 
             Node resourceNode = attachmentNode.getNode(NODE_NAME_RESOURCE)
             JcrUtils.ensureIsCheckedOut(resourceNode)
-            resourceNode.setPrimaryType(NODE_TYPE_OLD_RESOURCE)
+
+            // Because the old resource node type doesn't have the relaxed mixin type,
+            // we get an exception here because we have got properties on this node
+            // which are not allowed. To get around this, we suppress the exception and
+            // add the relaxed mixin afterwards manually
+            try {
+                resourceNode.setPrimaryType(NODE_TYPE_OLD_RESOURCE)
+            } catch (ConstraintViolationException cve) {
+                if (cve.getMessage().equals(CONSTRAINT_ERROR_MESSAGE)) {
+                    log.info("Suppressing Constraint error and adding relaxed mixin")
+                    resourceNode.addMixin(HippoStdNodeType.NT_RELAXED)
+                } else {
+                    throw cve
+                }
+            }
 
             return true
         } catch (e) {

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/Migration20180502RevertExternalAttachmentsToEmbedded.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/Migration20180502RevertExternalAttachmentsToEmbedded.yaml
@@ -1,7 +1,7 @@
 ---
 definitions:
   config:
-    /hippo:configuration/hippo:update/hippo:registry/Migration-20180502-RevertExternalAttachmentsToEmbedded.groovy:
+    /hippo:configuration/hippo:update/hippo:registry/Migration-20180502-RevertExternalAttachmentsToEmbedded:
       hipposys:batchsize: 10
       hipposys:description: ''
       hipposys:dryrun: false

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem.cnd
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem.cnd
@@ -48,7 +48,7 @@
 [publicationsystem:relatedlink] > hippo:compound, hippostd:relaxed
   orderable
 
-[publicationsystem:resource] > hippo:derived, hippo:resource, hippostd:relaxed
+[publicationsystem:resource] > hippo:derived, hippo:resource
 
 [publicationsystem:series] > hippostd:relaxed, hippotranslation:translated, publicationsystem:basedocument
   orderable


### PR DESCRIPTION
You can't add mixin types to already defined node definitions as you get
errors when deploying to onDemand. I have updated the rollback
script to add the required mixin if the error occurs instead
of in the node definition.