### PR TITLE
[RPS-512] Fix breadcrumb for achived publicaton document type

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/util/TestContentUrls.java
@@ -171,6 +171,8 @@ public class TestContentUrls {
             "/data-and-information/publications/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets");
         addSiteUrl("dataset under CI folder",
             "/data-and-information/publications/clinical-indicators/ccg-outcomes-indicator-set/current/1.1-national-ccg-outcomes/ccg-dataset");
+        addSiteUrl("ccg archive publication",
+            "/data-and-information/publications/clinical-indicators/ccg-outcomes-indicator-set/archive/ccg-archive-document-1");
 
         // National Indicator Library
         addSiteUrl("nihub", "/data-and-information/national-indicator-library/nihub");

--- a/acceptance-tests/src/test/resources/features/site/ciBreadcrumb.feature
+++ b/acceptance-tests/src/test/resources/features/site/ciBreadcrumb.feature
@@ -30,6 +30,14 @@ Feature: As a user navigating to clinical indicator content, I need logical brea
             | CCG publication               |
             | CCG dataset                   |
 
+    Scenario: Archive (within CI folder) breadcrumb
+        Given I navigate to the "ccg archive publication" page
+        Then I should see the list with title "Navigation" including:
+            | Data and information          |
+            | CCG Outcomes - Indicator Set  |
+            | CCG Archive                   |
+            | CCG Archive publication       |
+
     Scenario: CI landing page (i.e. SHMI landing) breadcrumb
         Given I navigate to the "SHMI landing" page
         Then I should see the list with title "Navigation" including:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/clinical-indicators.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/clinical-indicators.yaml
@@ -2,6 +2,150 @@
 /content/documents/corporate-website/publication-system/clinical-indicators:
   /ccg-outcomes-indicator-set:
     /archive:
+      /ccg-archive-document-1:
+        /ccg-archive-document-1[1]:
+          common:FacetType: publication
+          common:searchRank: 4
+          common:searchable: true
+          hippo:availability: []
+          hippostd:state: draft
+          hippostdpubwf:createdBy: admin
+          hippostdpubwf:creationDate: 2018-05-08T15:45:10.021Z
+          hippostdpubwf:lastModificationDate: 2018-05-08T15:45:10.021Z
+          hippostdpubwf:lastModifiedBy: admin
+          hippotranslation:id: bdc8dcbc-425f-4c9b-95cf-9b034df10cbb
+          hippotranslation:locale: en
+          jcr:mixinTypes:
+          - hippotaxonomy:classifiable
+          - mix:referenceable
+          jcr:primaryType: publicationsystem:publication
+          publicationsystem:AdministrativeSources: ''
+          publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+          publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+          publicationsystem:GeographicCoverage: []
+          publicationsystem:KeyFacts: ''
+          publicationsystem:NominalDate: 2018-05-07T23:00:00Z
+          publicationsystem:PubliclyAccessible: true
+          publicationsystem:Summary: CCG Archive publication
+          publicationsystem:Title: CCG Archive publication
+        /ccg-archive-document-1[2]:
+          common:FacetType: publication
+          common:searchRank: 4
+          common:searchable: true
+          hippo:availability:
+          - preview
+          hippostd:state: unpublished
+          hippostdpubwf:createdBy: admin
+          hippostdpubwf:creationDate: 2018-05-08T15:45:10.021Z
+          hippostdpubwf:lastModificationDate: 2018-05-08T15:45:30.591Z
+          hippostdpubwf:lastModifiedBy: admin
+          hippotranslation:id: bdc8dcbc-425f-4c9b-95cf-9b034df10cbb
+          hippotranslation:locale: en
+          jcr:mixinTypes:
+          - hippotaxonomy:classifiable
+          - mix:referenceable
+          - mix:versionable
+          jcr:primaryType: publicationsystem:publication
+          publicationsystem:AdministrativeSources: ''
+          publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+          publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+          publicationsystem:GeographicCoverage: []
+          publicationsystem:KeyFacts: ''
+          publicationsystem:NominalDate: 2018-05-07T23:00:00Z
+          publicationsystem:PubliclyAccessible: true
+          publicationsystem:Summary: CCG Archive publication
+          publicationsystem:Title: CCG Archive publication
+        /ccg-archive-document-1[3]:
+          common:FacetType: publication
+          common:searchRank: 4
+          common:searchable: true
+          hippo:availability:
+          - live
+          hippostd:state: published
+          hippostdpubwf:createdBy: admin
+          hippostdpubwf:creationDate: 2018-05-08T15:45:10.021Z
+          hippostdpubwf:lastModificationDate: 2018-05-08T15:45:30.591Z
+          hippostdpubwf:lastModifiedBy: admin
+          hippostdpubwf:publicationDate: 2018-05-08T15:45:32.951Z
+          hippotranslation:id: bdc8dcbc-425f-4c9b-95cf-9b034df10cbb
+          hippotranslation:locale: en
+          jcr:mixinTypes:
+          - hippotaxonomy:classifiable
+          - mix:referenceable
+          jcr:primaryType: publicationsystem:publication
+          publicationsystem:AdministrativeSources: ''
+          publicationsystem:CoverageEnd: 0001-01-01T12:00:00Z
+          publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
+          publicationsystem:GeographicCoverage: []
+          publicationsystem:KeyFacts: ''
+          publicationsystem:NominalDate: 2018-05-07T23:00:00Z
+          publicationsystem:PubliclyAccessible: true
+          publicationsystem:Summary: CCG Archive publication
+          publicationsystem:Title: CCG Archive publication
+        hippo:name: CCG archive document 1
+        jcr:mixinTypes:
+        - hippo:named
+        - mix:referenceable
+        jcr:primaryType: hippo:handle
+      /content:
+        /content[1]:
+          common:FacetType: series
+          common:searchRank: 1
+          common:searchable: true
+          hippo:availability: []
+          hippostd:state: draft
+          hippostdpubwf:createdBy: admin
+          hippostdpubwf:creationDate: 2018-05-08T15:44:05.488Z
+          hippostdpubwf:lastModificationDate: 2018-05-08T15:44:05.488Z
+          hippostdpubwf:lastModifiedBy: admin
+          hippotranslation:id: ed227b8b-f6b4-428a-87c4-9988ef203af2
+          hippotranslation:locale: en
+          jcr:mixinTypes:
+          - mix:referenceable
+          jcr:primaryType: publicationsystem:archive
+          publicationsystem:Summary: CCG Archive
+          publicationsystem:Title: CCG Archive
+        /content[2]:
+          common:FacetType: series
+          common:searchRank: 1
+          common:searchable: true
+          hippo:availability:
+          - preview
+          hippostd:state: unpublished
+          hippostdpubwf:createdBy: admin
+          hippostdpubwf:creationDate: 2018-05-08T15:44:05.488Z
+          hippostdpubwf:lastModificationDate: 2018-05-08T15:44:37.445Z
+          hippostdpubwf:lastModifiedBy: admin
+          hippotranslation:id: ed227b8b-f6b4-428a-87c4-9988ef203af2
+          hippotranslation:locale: en
+          jcr:mixinTypes:
+          - mix:referenceable
+          - mix:versionable
+          jcr:primaryType: publicationsystem:archive
+          publicationsystem:Summary: CCG Archive
+          publicationsystem:Title: CCG Archive
+        /content[3]:
+          common:FacetType: series
+          common:searchRank: 1
+          common:searchable: true
+          hippo:availability:
+          - live
+          hippostd:state: published
+          hippostdpubwf:createdBy: admin
+          hippostdpubwf:creationDate: 2018-05-08T15:44:05.488Z
+          hippostdpubwf:lastModificationDate: 2018-05-08T15:44:37.445Z
+          hippostdpubwf:lastModifiedBy: admin
+          hippostdpubwf:publicationDate: 2018-05-08T15:44:41.088Z
+          hippotranslation:id: ed227b8b-f6b4-428a-87c4-9988ef203af2
+          hippotranslation:locale: en
+          jcr:mixinTypes:
+          - mix:referenceable
+          jcr:primaryType: publicationsystem:archive
+          publicationsystem:Summary: CCG Archive
+          publicationsystem:Title: CCG Archive
+        jcr:mixinTypes:
+        - mix:referenceable
+        jcr:primaryType: hippo:handle
       hippo:name: Archive
       hippostd:foldertype:
       - new-statistical-publications-and-clinical-indicators-folder

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/breadcrumb-ci-old-styling.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/breadcrumb-ci-old-styling.ftl
@@ -23,9 +23,9 @@
             <li class="separator">${ciBreadcrumb.separator}</li>
             <#if !item?is_last>
                 <@hst.link var="link" link=item.link/>
-                <li><a href="${link}" class="breadcrumb__link">${item.title}</a></li>
+                <li><a href="${link}" class="breadcrumb__link" title="${item.title}">${item.title}</a></li>
             <#else>
-                <li><span class="breadcrumb__link breadcrumb__link--secondary">${item.title}</span></li>
+                <li><span class="breadcrumb__link breadcrumb__link--secondary" title="${item.title}">${item.title}</span></li>
             </#if>
         </#list>
     </ul>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/breadcrumb-ci.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/breadcrumb-ci.ftl
@@ -11,7 +11,7 @@
                     <ul class="breadcrumb" title="Navigation">
 
                         <li class="breadcrumb__crumb">
-                            <a href="<@hst.link siteMapItemRefId='root'/>" class="breadcrumb__link">NHS Digital</a>
+                            <a href="<@hst.link siteMapItemRefId='root'/>" class="breadcrumb__link" title="NHS Digital">NHS Digital</a>
                         </li>
 
                         <#if ciBreadcrumb.clinicalIndicator>
@@ -23,7 +23,7 @@
                         </#if>
 
                         <#list ciBreadcrumb.items as item>
-                            <li class="breadcrumb__crumb">
+                            <li class="breadcrumb__crumb" title="${item.title}">
                                 <img src="<@hst.webfile  path="images/icon-arrow.png"/>" alt="" class="breadcrumb__sep"/>
                                 <#if !item?is_last>
                                     <@hst.link var="link" link=item.link/>

--- a/site/src/main/java/uk/nhs/digital/ps/beans/navigation/CiBreadcrumbProvider.java
+++ b/site/src/main/java/uk/nhs/digital/ps/beans/navigation/CiBreadcrumbProvider.java
@@ -10,6 +10,7 @@ import org.hippoecm.hst.content.beans.query.builder.Constraint;
 import org.hippoecm.hst.content.beans.query.builder.HstQueryBuilder;
 import org.hippoecm.hst.content.beans.query.exceptions.QueryException;
 import org.hippoecm.hst.content.beans.standard.HippoBean;
+import org.hippoecm.hst.content.beans.standard.HippoFolder;
 import org.hippoecm.hst.core.component.HstComponentException;
 import org.hippoecm.hst.core.component.HstRequest;
 import org.hippoecm.hst.core.request.HstRequestContext;
@@ -43,6 +44,10 @@ public class CiBreadcrumbProvider  {
     }
 
     public CiBreadcrumb getBreadcrumb() {
+
+        if (currentDocumentBean == null || currentDocumentBean instanceof HippoFolder) {
+            return null;
+        }
 
         loadCiLandingBean();
 
@@ -122,13 +127,13 @@ public class CiBreadcrumbProvider  {
     }
 
     private void addPublicationBreadcrumbItem(List<BreadcrumbItem> ciBreadcrumbItems) {
-        // Is publication part of series?
+        // Is publication part of archive/series?
         HippoBean publicationParent =  ((Publication) currentDocumentBean).getParentDocument();
         if (publicationParent != null) {
 
-            // Create Series navigation
-            Series series = (Series) publicationParent;
-            ciBreadcrumbItems.add(createBreadcrumbItem(ctx, series));
+            // Create Archive/Series navigation
+            BaseDocument seriesOrArchiveDocument = (BaseDocument) publicationParent;
+            ciBreadcrumbItems.add(createBreadcrumbItem(ctx, seriesOrArchiveDocument));
         }
     }
 
@@ -139,13 +144,13 @@ public class CiBreadcrumbProvider  {
 
             Publication publication = (Publication) datasetParent;
 
-            // Is publication part of series?
+            // Is publication part of archive/series?
             HippoBean publicationParent =  publication.getParentDocument();
             if (publicationParent != null) {
 
-                // Create Series navigation
-                Series series = (Series) publicationParent;
-                ciBreadcrumbItems.add(createBreadcrumbItem(ctx, series));
+                // Create Archive/Series navigation
+                BaseDocument seriesOrArchiveDocument = (BaseDocument) publicationParent;
+                ciBreadcrumbItems.add(createBreadcrumbItem(ctx, seriesOrArchiveDocument));
             }
 
             // Create Publication navigation


### PR DESCRIPTION
Also adds some logic which will reduce the noise in Splunk logs,in
particular from the Page Not found template which uses base-layout
(which references the breadcrumb-ci-old-styling template)