### PR TITLE
[RPS-475] Improve S3 connector config mechanism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ SPLUNK_HEC ?= localhost
 SPLUNK_TOKEN ?=
 SPLUNK_URL ?=
 PROFILE_RUN ?= cargo.run
+S3_BUCKET ?= files.local.nhsd.io
+S3_REGION ?= eu-west-1
 
 export HIPPO_MAVEN_PASSWORD
 export HIPPO_MAVEN_USERNAME
@@ -51,7 +53,10 @@ run:
 		-D splunk.url=$(SPLUNK_URL) \
 		-D splunk.hec.name=$(SPLUNK_HEC) \
 		-D aws.secretKey=$(AWS_SECRET) \
-		-D aws.accessKeyId=$(AWS_KEY)
+		-D aws.accessKeyId=$(AWS_KEY) \
+		-D externalstorage.aws.bucket=$(S3_BUCKET) \
+		-D externalstorage.aws.region=$(S3_REGION)
+
 
 # we don't have to recompile it every time.
 essentials/target/essentials.war:

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/modules/S3ConnectorServiceRegistrationModuleParams.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/modules/S3ConnectorServiceRegistrationModuleParams.java
@@ -1,74 +1,131 @@
 package uk.nhs.digital.externalstorage.modules;
 
-import java.util.function.Function;
+import org.apache.commons.lang3.Validate;
 
-public class S3ConnectorServiceRegistrationModuleParams<T> {
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
 
-    // AWS PARAMS
+public class S3ConnectorServiceRegistrationModuleParams {
 
-    static final S3ConnectorServiceRegistrationModuleParams<String> AWS_BUCKET = init(
-        "externalstorage.aws.bucket", "s3Bucket", stringValue -> stringValue, ""
-    );
-    static final S3ConnectorServiceRegistrationModuleParams<String> AWS_REGION = init(
-        "externalstorage.aws.region","s3Region", stringValue -> stringValue, ""
-    );
-    static final S3ConnectorServiceRegistrationModuleParams<String> AWS_S3_ENDPOINT = init(
-        "externalstorage.aws.s3.endpoint", "s3Endpoint", stringValue -> stringValue, ""
-    );
+    // SYSTEM PROPERTY KEYS
+    private static final String KEY_AWS_BUCKET = "externalstorage.aws.bucket";
+    private static final String KEY_AWS_REGION = "externalstorage.aws.region";
+    private static final String KEY_AWS_S3_ENDPOINT = "externalstorage.aws.s3.endpoint";
+    // JCR PROPERTIES KEYS
+    private static final String KEY_DOWNLOAD_MAX_CONC_COUNT = "maxConcurrentDownloadsCount";
+    private static final String KEY_DOWNLOAD_SHUTDOWN_TIMEOUT_IN_SECS = "downloadShutdownTimeoutInSecs";
+    private static final String KEY_UPLOAD_MAX_CONC_COUNT = "maxConcurrentUploadsCount";
+    private static final String KEY_UPLOAD_SHUTDOWN_TIMEOUT_IN_SECS = "uploadShutdownTimeoutInSecs";
 
-    // DOWNLOAD PARAMS
+    private String s3Bucket;
+    private String s3Region;
+    private String s3Endpoint;
+    private int downloadsMaxConcurrentCount;
+    private int downloadsShutdownTimeoutInSecs;
+    private int uploadsMaxConcurrentCount;
+    private int uploadsShutdownTimeoutInSecs;
 
-    static final S3ConnectorServiceRegistrationModuleParams<Integer> DOWNLOAD_MAX_CONC_COUNT = init(
-        "externalstorage.download.maxConcurrentDownloads", "maxConcurrentDownloadsCount", Integer::valueOf, 0
-    );
-    static final S3ConnectorServiceRegistrationModuleParams<Long> DOWNLOAD_SHUTDOWN_TIMEOUT_IN_SECS = init(
-        "externalstorage.download.shutdown.timeoutInSecs", "downloadShutdownTimeoutInSecs", Long::valueOf, 0L
-    );
 
-    // UPLOAD PARAMS
-
-    static final S3ConnectorServiceRegistrationModuleParams<Integer> UPLOAD_MAX_CONC_COUNT = init(
-        "externalstorage.upload.maxConcurrentUploads", "maxConcurrentUploadsCount", Integer::valueOf, 0
-    );
-    static final S3ConnectorServiceRegistrationModuleParams<Long> UPLOAD_SHUTDOWN_TIMEOUT_IN_SECS = init(
-        "externalstorage.upload.shutdown.timeoutInSecs", "uploadShutdownTimeoutInSecs", Long::valueOf, 0L
-    );
-
-    private final String systemPropertyKey;
-    private final String jcrModulePropertyKey;
-    private final Function<String, T> fromStringConverter;
-    private final T defaultValue;
-
-    private S3ConnectorServiceRegistrationModuleParams(final String systemPropertyKey,
-                                                       final String jcrModulePropertyKey,
-                                                       final Function<String, T> fromStringConverter,
-                                                       final T defaultValue
+    private S3ConnectorServiceRegistrationModuleParams(final String s3Bucket,
+                                                       final String s3Region,
+                                                       final String s3Endpoint,
+                                                       final int downloadsMaxConcurrentCount,
+                                                       final int downloadsShutdownTimeoutInSecs,
+                                                       final int uploadsMaxConcurrentCount,
+                                                       final int uploadsShutdownTimeoutInSecs
     ) {
-        this.systemPropertyKey = systemPropertyKey;
-        this.jcrModulePropertyKey = jcrModulePropertyKey;
-        this.fromStringConverter = fromStringConverter;
-        this.defaultValue = defaultValue;
+        this.s3Bucket = s3Bucket;
+        this.s3Region = s3Region;
+        this.s3Endpoint = s3Endpoint;
+        this.downloadsMaxConcurrentCount = downloadsMaxConcurrentCount;
+        this.downloadsShutdownTimeoutInSecs = downloadsShutdownTimeoutInSecs;
+        this.uploadsMaxConcurrentCount = uploadsMaxConcurrentCount;
+        this.uploadsShutdownTimeoutInSecs = uploadsShutdownTimeoutInSecs;
     }
 
-    public String getSystemPropertyKey() {
-        return systemPropertyKey;
-    }
+    static S3ConnectorServiceRegistrationModuleParams extractParameters(final Node moduleConfigNode) {
+        return new S3ConnectorServiceRegistrationModuleParams(
 
-    public String getJcrModulePropertyKey() {
-        return jcrModulePropertyKey;
-    }
+            // System properties set via command line
+            System.getProperty(KEY_AWS_BUCKET, ""),
+            System.getProperty(KEY_AWS_REGION, ""),
+            System.getProperty(KEY_AWS_S3_ENDPOINT, ""),
 
-    public T fromString(final String stringValue) {
-        return stringValue == null ? defaultValue : fromStringConverter.apply(stringValue);
-    }
-
-    private static <T> S3ConnectorServiceRegistrationModuleParams<T> init(final String systemPropertyKey,
-                                                                          final String jcrModulePropertyKey,
-                                                                          final Function<String, T> fromStringConverter,
-                                                                          final T defaultValue
-    ) {
-        return new S3ConnectorServiceRegistrationModuleParams<>(
-            systemPropertyKey, jcrModulePropertyKey, fromStringConverter, defaultValue
+            // JCR properties set by YAML config
+            // (hippo:configuration/hippo:modules/s3ConnectorRegistrationModule/hippo:moduleconfig)
+            getIntJcrPropertyValue(moduleConfigNode, KEY_DOWNLOAD_MAX_CONC_COUNT),
+            getIntJcrPropertyValue(moduleConfigNode, KEY_DOWNLOAD_SHUTDOWN_TIMEOUT_IN_SECS),
+            getIntJcrPropertyValue(moduleConfigNode, KEY_UPLOAD_MAX_CONC_COUNT),
+            getIntJcrPropertyValue(moduleConfigNode, KEY_UPLOAD_SHUTDOWN_TIMEOUT_IN_SECS)
         );
+    }
+
+    private static int getIntJcrPropertyValue(Node moduleConfigNode, String jcrPropertyKey) {
+        try {
+            return moduleConfigNode.getProperty(jcrPropertyKey).getDecimal().intValue();
+        } catch (RepositoryException repositoryException) {
+            throw new RuntimeException(repositoryException);
+        }
+    }
+
+    public void validate() {
+
+        try {
+            Validate.notBlank(s3Bucket, "Required argument is missing: " + KEY_AWS_BUCKET);
+            Validate.notBlank(s3Region, "Required argument is missing: " + KEY_AWS_REGION);
+            // s3Endpoint is optional
+
+            Validate.inclusiveBetween(1L, Integer.MAX_VALUE, downloadsMaxConcurrentCount,
+                "Required argument is missing or out of range: " + KEY_DOWNLOAD_MAX_CONC_COUNT);
+            Validate.inclusiveBetween(1L, Integer.MAX_VALUE, downloadsShutdownTimeoutInSecs,
+                "Required argument is missing or out of range: " + KEY_DOWNLOAD_SHUTDOWN_TIMEOUT_IN_SECS);
+            Validate.inclusiveBetween(1L, Integer.MAX_VALUE, uploadsMaxConcurrentCount,
+                "Required argument is missing or out of range: " + KEY_UPLOAD_MAX_CONC_COUNT);
+            Validate.inclusiveBetween(1L, Integer.MAX_VALUE, uploadsShutdownTimeoutInSecs,
+                "Required argument is missing or out of range: " + KEY_UPLOAD_SHUTDOWN_TIMEOUT_IN_SECS);
+        } catch (Exception validationException) {
+            throw new IllegalArgumentException("Failed to configure " + getClass().getSimpleName(), validationException);
+        }
+    }
+
+    String getS3Bucket() {
+        return s3Bucket;
+    }
+
+    String getS3Region() {
+        return s3Region;
+    }
+
+    String getS3Endpoint() {
+        return s3Endpoint;
+    }
+
+    int getDownloadsMaxConcurrentCount() {
+        return downloadsMaxConcurrentCount;
+    }
+
+    int getDownloadsShutdownTimeoutInSecs() {
+        return downloadsShutdownTimeoutInSecs;
+    }
+
+    int getUploadsMaxConcurrentCount() {
+        return uploadsMaxConcurrentCount;
+    }
+
+    int getUploadsShutdownTimeoutInSecs() {
+        return uploadsShutdownTimeoutInSecs;
+    }
+
+    @Override
+    public String toString() {
+        return "S3ConnectorServiceRegistrationModuleParams{"
+            + "s3Bucket='" + s3Bucket + '\''
+            + ", s3Region='" + s3Region + '\''
+            + ", s3Endpoint='" + s3Endpoint + '\''
+            + ", downloadsMaxConcurrentCount=" + downloadsMaxConcurrentCount
+            + ", downloadsShutdownTimeoutInSecs=" + downloadsShutdownTimeoutInSecs
+            + ", uploadsMaxConcurrentCount=" + uploadsMaxConcurrentCount
+            + ", uploadsShutdownTimeoutInSecs=" + uploadsShutdownTimeoutInSecs
+            + '}';
     }
 }

--- a/repository-data/application/src/main/resources/hcm-config/configuration/modules/s3ConnectorRegistrationModule.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/modules/s3ConnectorRegistrationModule.yaml
@@ -7,9 +7,6 @@ definitions:
         jcr:primaryType: hipposys:moduleconfig
         maxConcurrentDownloadsCount: 50
         maxConcurrentUploadsCount: 10
-        s3Bucket: files.digital.nhs.uk
-        s3Endpoint: ''
-        s3Region: eu-west-2
         uploadShutdownTimeoutInSecs: 30
       hipposys:className: uk.nhs.digital.externalstorage.modules.S3ConnectorServiceRegistrationModule
       hipposys:cmsonly: true

--- a/repository-data/development/src/main/resources/hcm-config/configuration/modules/s3ConnectorRegistrationModule.yaml
+++ b/repository-data/development/src/main/resources/hcm-config/configuration/modules/s3ConnectorRegistrationModule.yaml
@@ -1,7 +1,0 @@
----
-definitions:
-  config:
-    /hippo:configuration/hippo:modules/s3ConnectorRegistrationModule:
-      /hippo:moduleconfig:
-        s3Bucket: files.local.nhsd.io
-        s3Region: eu-west-1


### PR DESCRIPTION
S3 Connector config updated to make it clearer which settings are
set by system properties and which are set via JCR.

The following are now set as system properties only, since the
likelyhood of wanting to change these on the fly (via JCR) is very
unlikely, and potentially risky:
external.aws.bucket
external.aws.region
external.aws.s3.endpoint

The following are set via JCR. These values can be modified
on the fly in the console, but because they are part of
the bootstrapped config, any updated values are not persisted
opon a new release. To update the values permanently, update
the values in s3ConnectorRegistrationModule.yaml:
maxConcurrentDownloadsCount
downloadShutdownTimeoutInSecs
maxConcurrentUploadsCount
uploadShutdownTimeoutInSecs