### PR TITLE
[RPS-491] S3 use environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ PROFILE_RUN ?= cargo.run
 S3_BUCKET ?= files.local.nhsd.io
 S3_REGION ?= eu-west-1
 
+export AWS_ACCESS_KEY_ID=$(AWS_KEY)
+export AWS_SECRET_ACCESS_KEY=$(AWS_SECRET)
 export HIPPO_MAVEN_PASSWORD
 export HIPPO_MAVEN_USERNAME
 export HOME
@@ -52,8 +54,6 @@ run:
 		-D splunk.token=$(SPLUNK_TOKEN) \
 		-D splunk.url=$(SPLUNK_URL) \
 		-D splunk.hec.name=$(SPLUNK_HEC) \
-		-D aws.secretKey=$(AWS_SECRET) \
-		-D aws.accessKeyId=$(AWS_KEY) \
 		-D externalstorage.aws.bucket=$(S3_BUCKET) \
 		-D externalstorage.aws.region=$(S3_REGION)
 

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/modules/S3ConnectorServiceRegistrationModule.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/modules/S3ConnectorServiceRegistrationModule.java
@@ -4,7 +4,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 import static uk.nhs.digital.externalstorage.modules.S3ConnectorServiceRegistrationModuleParams.*;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
@@ -153,7 +153,7 @@ public class S3ConnectorServiceRegistrationModule extends AbstractReconfigurable
     }
 
     private AmazonS3 getAmazonS3Client() {
-        AWSCredentialsProvider provider = new SystemPropertiesCredentialsProvider();
+        AWSCredentialsProvider provider = new EnvironmentVariableCredentialsProvider();
         AmazonS3ClientBuilder s3Builder = AmazonS3ClientBuilder.standard()
             .withCredentials(provider)
             .withRegion(Regions.fromName(params.getS3Region()));

--- a/pom.xml
+++ b/pom.xml
@@ -83,10 +83,6 @@
         In production, start with a setting of "10" and adjust as necessary. -->
         <splunk.batch.size.count>1</splunk.batch.size.count>
 
-        <!-- AWS S3 access -->
-        <aws.accessKeyId></aws.accessKeyId>
-        <aws.secretKey></aws.secretKey>
-
         <externalstorage.aws.bucket></externalstorage.aws.bucket>
         <externalstorage.aws.region></externalstorage.aws.region>
         <externalstorage.aws.s3.endpoint></externalstorage.aws.s3.endpoint>
@@ -625,9 +621,6 @@
                                     <splunk.token>${splunk.token}</splunk.token>
                                     <splunk.url>${splunk.url}</splunk.url>
                                     <splunk.batch.size.count>${splunk.batch.size.count}</splunk.batch.size.count>
-
-                                    <aws.accessKeyId>${aws.accessKeyId}</aws.accessKeyId>
-                                    <aws.secretKey>${aws.secretKey}</aws.secretKey>
 
                                     <externalstorage.aws.bucket>${externalstorage.aws.bucket}</externalstorage.aws.bucket>
                                     <externalstorage.aws.region>${externalstorage.aws.region}</externalstorage.aws.region>


### PR DESCRIPTION
Instead of System variables, use Environment variables for
S3 AWS accessKeyId and secretKey which prevents the credentials
being visible in the catalina logs, and on the Admin System
Properties CMS screen.