### PR TITLE
[RPS-499] copy S3 attachments with doc

### DIFF
--- a/cms/src/main/java/uk/nhs/digital/externalstorage/ExternalStorageConstants.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/ExternalStorageConstants.java
@@ -4,9 +4,18 @@ public interface ExternalStorageConstants {
 
     String NODE_TYPE_EXTERNAL_RESOURCE = "externalstorage:resource";
 
+    /**
+     * Example: {@code 42/F961C2/dataset-attachment-text.pdf}
+     */
     String PROPERTY_EXTERNAL_STORAGE_REFERENCE = "externalstorage:reference";
-    String PROPERTY_EXTERNAL_STORAGE_SIZE = "externalstorage:size";
+
+    /**
+     * Example: {@code https://files.local.nhsd.io/42/F961C2/dataset-attachment-text.pdf}
+     */
     String PROPERTY_EXTERNAL_STORAGE_PUBLIC_URL = "externalstorage:url";
+
+    String PROPERTY_EXTERNAL_STORAGE_SIZE = "externalstorage:size";
+
     String PROPERTY_EXTERNAL_STORAGE_MIME_TYPE = "jcr:mimeType";
     String PROPERTY_EXTERNAL_STORAGE_FILE_NAME = "hippo:filename";
     String PROPERTY_EXTERNAL_STORAGE_LAST_MODIFIED = "jcr:lastModified";

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/s3/BlockingPooledS3Connector.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/s3/BlockingPooledS3Connector.java
@@ -85,6 +85,25 @@ public class BlockingPooledS3Connector implements PooledS3Connector {
         logger.reportAction("S3 file is now private: {}", s3FileReference);
     }
 
+    @Override
+    public S3ObjectMetadata copyFile(final String sourceS3FileReference, final String fileName) {
+        logger.reportAction("Copying S3 file: {}", sourceS3FileReference);
+
+        S3ObjectMetadata targetS3FileReference;
+        try {
+            targetS3FileReference = s3Connector.copyFile(sourceS3FileReference, fileName);
+        } catch (final Exception ex) {
+            logger.reportError("Failed to copy S3 file: " + sourceS3FileReference, ex);
+            throw ex;
+        }
+
+        logger.reportAction(
+            "S3 file {} has now been copied to {}", sourceS3FileReference, targetS3FileReference
+        );
+
+        return targetS3FileReference;
+    }
+
     /**
      * See {@linkplain PooledS3Connector#upload}.
      */

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/s3/S3SdkConnector.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/s3/S3SdkConnector.java
@@ -65,6 +65,21 @@ public class S3SdkConnector implements S3Connector {
     }
 
     @Override
+    public S3ObjectMetadata copyFile(final String sourceObjectPath, final String fileName) {
+        reportAction("Copying S3 resource {}", sourceObjectPath);
+
+        final String targetObjectPath = s3ObjectKeyGenerator.generateObjectKey(fileName);
+
+        s3.copyObject(bucketName, sourceObjectPath, bucketName, targetObjectPath);
+
+        final ObjectMetadata targetObjectMetadata = s3.getObjectMetadata(bucketName, targetObjectPath);
+
+        reportAction("Copied S3 resource {} to {}", sourceObjectPath, targetObjectPath);
+
+        return new S3ObjectMetadataImpl(targetObjectMetadata, bucketName, targetObjectPath);
+    }
+
+    @Override
     public S3ObjectMetadata uploadFile(InputStream fileStream, String fileName, String contentType) {
         String objectKey = s3ObjectKeyGenerator.generateObjectKey(fileName);
 

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/AbstractExternalFileTask.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/AbstractExternalFileTask.java
@@ -49,7 +49,7 @@ public abstract class AbstractExternalFileTask extends AbstractDocumentTask {
 
         Node variantNode = getVariant().getNode(getWorkflowContext().getInternalWorkflowSession());
 
-        setResourcePermission(s3Connector, findResourceNodes(variantNode));
+        processResourceNodes(s3Connector, findResourceNodes(variantNode));
 
         return null;
     }
@@ -68,7 +68,7 @@ public abstract class AbstractExternalFileTask extends AbstractDocumentTask {
         return res.getNodes();
     }
 
-    protected abstract void setResourcePermission(PooledS3Connector s3, final NodeIterator resourceNodes) throws RepositoryException, WorkflowException;
+    protected abstract void processResourceNodes(PooledS3Connector s3, final NodeIterator resourceNodes) throws RepositoryException, WorkflowException;
 
     public void logInCmsActivityStream(final String documentPath, final String message) {
         final HippoEventBus eventBus = HippoServiceRegistry.getService(HippoEventBus.class);

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFileCopy/ExternalFileCopyAction.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFileCopy/ExternalFileCopyAction.java
@@ -1,0 +1,43 @@
+package uk.nhs.digital.externalstorage.workflow.externalFileCopy;
+
+import org.apache.commons.scxml2.SCXMLExpressionException;
+import org.apache.commons.scxml2.model.ModelException;
+import org.onehippo.cms7.services.HippoServiceRegistry;
+import org.onehippo.repository.documentworkflow.action.AbstractDocumentTaskAction;
+import uk.nhs.digital.externalstorage.s3.PooledS3Connector;
+
+public class ExternalFileCopyAction extends AbstractDocumentTaskAction<ExternalFileCopyTask> {
+
+    @Override
+    protected ExternalFileCopyTask createWorkflowTask() {
+        return new ExternalFileCopyTask();
+    }
+
+    public String getNewNameExpr() {
+        return getParameter("newNameExpr");
+    }
+
+    @SuppressWarnings("unused")
+    public void setNewNameExpr(String newNameExpr) {
+        setParameter("newNameExpr", newNameExpr);
+    }
+
+    public String getDestinationExpr() {
+        return getParameter("destinationExpr");
+    }
+
+    @SuppressWarnings("unused")
+    public void setDestinationExpr(String destinationExpr) {
+        setParameter("destinationExpr", destinationExpr);
+    }
+
+    @Override
+    protected void initTask(final ExternalFileCopyTask task) throws ModelException, SCXMLExpressionException {
+        super.initTask(task);
+
+        task.setTargetFolder(eval(getDestinationExpr()));
+        task.setCopiedDocumentName(eval(getNewNameExpr()));
+
+        task.setS3Connector(HippoServiceRegistry.getService(PooledS3Connector.class));
+    }
+}

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFileCopy/ExternalFileCopyTask.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFileCopy/ExternalFileCopyTask.java
@@ -1,0 +1,69 @@
+package uk.nhs.digital.externalstorage.workflow.externalFileCopy;
+
+import static org.slf4j.LoggerFactory.getLogger;
+import static uk.nhs.digital.externalstorage.ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_FILE_NAME;
+import static uk.nhs.digital.externalstorage.ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_PUBLIC_URL;
+import static uk.nhs.digital.externalstorage.ExternalStorageConstants.PROPERTY_EXTERNAL_STORAGE_REFERENCE;
+
+import org.hippoecm.repository.HippoStdNodeType;
+import org.hippoecm.repository.api.Document;
+import org.hippoecm.repository.api.WorkflowException;
+import org.slf4j.Logger;
+import uk.nhs.digital.externalstorage.s3.PooledS3Connector;
+import uk.nhs.digital.externalstorage.s3.S3ObjectMetadata;
+import uk.nhs.digital.externalstorage.workflow.AbstractExternalFileTask;
+
+import javax.jcr.Node;
+import javax.jcr.NodeIterator;
+import javax.jcr.RepositoryException;
+
+public class ExternalFileCopyTask extends AbstractExternalFileTask {
+
+    private static final Logger log = getLogger(ExternalFileCopyTask.class);
+
+    private String copiedDocumentName;
+    private Document copiedDocumentFolder;
+
+    ExternalFileCopyTask() {
+        variantState = HippoStdNodeType.UNPUBLISHED;
+    }
+
+    void setCopiedDocumentName(String copiedDocumentName) {
+        this.copiedDocumentName = copiedDocumentName;
+    }
+
+    void setTargetFolder(final Document targetFolder) {
+        this.copiedDocumentFolder = targetFolder;
+    }
+
+    @Override
+    protected void processResourceNodes(final PooledS3Connector s3,
+                                        final NodeIterator resourceNodes
+    ) throws RepositoryException, WorkflowException {
+
+        final Node copiedDocumentFolderNode = copiedDocumentFolder.getNode(getWorkflowContext().getInternalWorkflowSession());
+        final Node copiedDocumentHandleNode = copiedDocumentFolderNode.getNode(copiedDocumentName);
+
+        // When a document gets copied, only one variant is created, regardless of whether the
+        // source document had been published or not; that variant has hippostd:state=unpublished.
+
+        for (final NodeIterator resourceNodeIterator = findResourceNodes(copiedDocumentHandleNode);
+            resourceNodeIterator.hasNext();) {
+            final Node copiedResourceNode = resourceNodeIterator.nextNode();
+
+            final String oldReference = copiedResourceNode.getProperty(PROPERTY_EXTERNAL_STORAGE_REFERENCE).getString();
+
+            final S3ObjectMetadata s3ObjectMetadata = s3.copyFile(
+                oldReference,
+                copiedResourceNode.getProperty(PROPERTY_EXTERNAL_STORAGE_FILE_NAME).getString()
+            );
+
+            s3.unpublishResource(s3ObjectMetadata.getReference());
+
+            copiedResourceNode.setProperty(PROPERTY_EXTERNAL_STORAGE_REFERENCE, s3ObjectMetadata.getReference());
+            copiedResourceNode.setProperty(PROPERTY_EXTERNAL_STORAGE_PUBLIC_URL, s3ObjectMetadata.getUrl());
+
+            log.debug("Copied external resource {} as private {}", oldReference, s3ObjectMetadata);
+        }
+    }
+}

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFilePublish/ExternalFilePublishTask.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFilePublish/ExternalFilePublishTask.java
@@ -19,7 +19,7 @@ public class ExternalFilePublishTask extends AbstractExternalFileTask {
 
     private static final String DOCUMENTS_ROOT_FOLDER = "/content/documents";
 
-    protected void setResourcePermission(final PooledS3Connector s3Connector, final NodeIterator resourceNodes) throws RepositoryException, WorkflowException {
+    protected void processResourceNodes(final PooledS3Connector s3Connector, final NodeIterator resourceNodes) throws RepositoryException, WorkflowException {
         Node variantNode = getVariant().getNode(getWorkflowContext().getInternalWorkflowSession());
 
         if (isPublication(variantNode)) {

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFileUnpublish/ExternalFileUnpublishTask.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/workflow/externalFileUnpublish/ExternalFileUnpublishTask.java
@@ -14,7 +14,7 @@ import javax.jcr.RepositoryException;
 
 public class ExternalFileUnpublishTask extends AbstractExternalFileTask {
 
-    protected void setResourcePermission(final PooledS3Connector s3Connector, final NodeIterator resourceNodes) throws RepositoryException {
+    protected void processResourceNodes(final PooledS3Connector s3Connector, final NodeIterator resourceNodes) throws RepositoryException {
         Node variantNode = getVariant().getNode(getWorkflowContext().getInternalWorkflowSession());
 
         if (isPublication(variantNode)) {

--- a/cms/src/test/java/uk/nhs/digital/externalstorage/s3/BlockingPooledS3ConnectorTest.java
+++ b/cms/src/test/java/uk/nhs/digital/externalstorage/s3/BlockingPooledS3ConnectorTest.java
@@ -51,7 +51,7 @@ public class BlockingPooledS3ConnectorTest {
     }
 
     @Test
-    public void delegatesPublishedResourceDirectlyToStandardConnector() throws Exception {
+    public void delegatesPublishResourceDirectlyToStandardConnector() throws Exception {
 
         // when
         s3proxy.publishResource(expectedObjectPath);
@@ -61,13 +61,26 @@ public class BlockingPooledS3ConnectorTest {
     }
 
     @Test
-    public void delegatesUnPublishedResourceDirectlyToStandardConnector() throws Exception {
+    public void delegatesUnPublishResourceDirectlyToStandardConnector() throws Exception {
 
         // when
         s3proxy.unpublishResource(expectedObjectPath);
 
         // then
         then(s3SdkConnector).should().unpublishResource(expectedObjectPath);
+    }
+
+    @Test
+    public void delegatesCopyResourceDirectlyToStandardConnector() throws Exception {
+
+        // given
+        final String fileName = newRandomString();
+
+        // when
+        s3proxy.copyFile(expectedObjectPath, fileName);
+
+        // then
+        then(s3SdkConnector).should().copyFile(expectedObjectPath, fileName);
     }
 
     @Test

--- a/cms/src/test/java/uk/nhs/digital/externalstorage/workflow/externalFileCopy/ExternalFileCopyTaskTest.java
+++ b/cms/src/test/java/uk/nhs/digital/externalstorage/workflow/externalFileCopy/ExternalFileCopyTaskTest.java
@@ -1,0 +1,179 @@
+package uk.nhs.digital.externalstorage.workflow.externalFileCopy;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hippoecm.repository.HippoStdNodeType.NT_FOLDER;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static uk.nhs.digital.externalstorage.ExternalStorageConstants.*;
+
+import org.apache.sling.testing.mock.jcr.MockJcr;
+import org.apache.sling.testing.mock.jcr.MockQueryResult;
+import org.hippoecm.repository.api.Document;
+import org.hippoecm.repository.api.WorkflowContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import uk.nhs.digital.externalstorage.s3.PooledS3Connector;
+import uk.nhs.digital.externalstorage.s3.S3ObjectMetadata;
+
+import java.util.UUID;
+import javax.jcr.Node;
+import javax.jcr.Repository;
+import javax.jcr.RepositoryException;
+import javax.jcr.Session;
+
+public class ExternalFileCopyTaskTest {
+
+    @Mock private WorkflowContext workflowContext;
+    @Mock private PooledS3Connector s3Connector;
+
+    private Repository repository;
+    private Session workflowSession;
+
+    private ExternalFileCopyTask externalFileCopyTask;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+
+        repository = MockJcr.newRepository();
+        workflowSession = repository.login();
+
+        externalFileCopyTask = new ExternalFileCopyTask();
+
+        given(workflowContext.getInternalWorkflowSession()).willReturn(workflowSession);
+        externalFileCopyTask.setWorkflowContext(workflowContext);
+    }
+
+    @Test
+    public void copiesS3FilesAsPrivate_onDocumentCopy() throws Exception {
+
+        // given
+
+        // node structure:
+        // /
+        // +- target-folder                            (hippostd:folder)
+        //    +- copied-document-handle                (hippo:handle)
+        //       +- copied-doc-unpublished-variant     (irrelevant:doctype)
+        //          +- copied-doc-ext-attachment       (publicationsystem:extattachment)
+        //          |  +- copied-doc-ext-resource      (externalstorage:resource)
+        //          |     - hippo:filename             = file name A
+        //          |     - externalstorage:url        = file url A
+        //          |     - externalstorage:reference  = file reference A
+        //          +- copied-doc-ext-attachment[2]    (publicationsystem:extattachment)
+        //             +- copied-doc-ext-resource      (externalstorage:resource)
+        //                - hippo:filename             = file name B
+        //                - externalstorage:url        = file url B
+        //                - externalstorage:reference  = file reference B
+
+        final String copiedDocumentName = newRandomString();
+
+        final Node targetFolderNode = workflowSession.getRootNode()
+            .addNode("target-folder", NT_FOLDER);
+        final Node copiedDocumentHandleNode = targetFolderNode
+            .addNode(copiedDocumentName, "hippo:handle");
+        final Node copiedDocUnpublishedVariant = copiedDocumentHandleNode
+            .addNode("copied-doc-unpublished-variant", "irrelevant:doctype");
+
+        externalFileCopyTask.setCopiedDocumentName(copiedDocumentName);
+        externalFileCopyTask.setTargetFolder(new Document(targetFolderNode));
+        externalFileCopyTask.setWorkflowContext(workflowContext);
+
+        // file A =============================
+
+        final String oldS3ObjectReferenceA = newRandomString();
+        final String newS3ObjectReferenceA = newRandomString();
+        final String newS3ObjectUrlA = newRandomString();
+        final String fileNameA = newRandomString();
+
+        final Node copiedDocExtResourceNodeA = newResourceNode(copiedDocUnpublishedVariant, "",
+            oldS3ObjectReferenceA,
+            newS3ObjectReferenceA,
+            newS3ObjectUrlA,
+            fileNameA
+        );
+
+        // file B =============================
+
+        final String oldS3ObjectReferenceB = newRandomString();
+        final String newS3ObjectReferenceB = newRandomString();
+        final String newS3ObjectUrlB = newRandomString();
+        final String fileNameB = newRandomString();
+
+        final Node copiedDocExtResourceNodeB = newResourceNode(copiedDocUnpublishedVariant, "[2]",
+            oldS3ObjectReferenceB, newS3ObjectReferenceB, newS3ObjectUrlB, fileNameB);
+
+        // query for resource nodes ===========
+
+        final String copiedDocumentHandleNodePath = copiedDocumentHandleNode.getPath();
+        MockJcr.addQueryResultHandler(
+            workflowSession,
+            mockQuery -> mockQuery.getStatement().matches(
+                "SELECT \\* FROM \\[externalstorage:resource].*ISDESCENDANTNODE \\(\\['" + copiedDocumentHandleNodePath + "']\\).*"
+            )
+                ? new MockQueryResult(asList(copiedDocExtResourceNodeA, copiedDocExtResourceNodeB))
+                : null
+        );
+
+        // when
+        externalFileCopyTask.processResourceNodes(s3Connector, null);
+
+        // then
+        assertS3Interactions(oldS3ObjectReferenceA, newS3ObjectReferenceA, newS3ObjectUrlA, fileNameA,
+            copiedDocExtResourceNodeA);
+
+        assertS3Interactions(oldS3ObjectReferenceB, newS3ObjectReferenceB, newS3ObjectUrlB, fileNameB,
+            copiedDocExtResourceNodeB);
+    }
+
+    private Node newResourceNode(final Node copiedDocUnpublishedVariant,
+                                 final String pathSuffix,
+                                 final String oldS3ObjectReference,
+                                 final String newS3ObjectReference,
+                                 final String newS3ObjectUrl,
+                                 final String fileName
+    ) throws RepositoryException {
+
+        final Node copiedDocExtResourceNodeA = copiedDocUnpublishedVariant
+            .addNode("copied-doc-ext-attachment" + pathSuffix, "publicationsystem:extattachment")
+            .addNode("copied-doc-ext-resource", "externalstorage:resource");
+
+        copiedDocExtResourceNodeA.setProperty(PROPERTY_EXTERNAL_STORAGE_FILE_NAME, fileName);
+        copiedDocExtResourceNodeA.setProperty(PROPERTY_EXTERNAL_STORAGE_REFERENCE, oldS3ObjectReference);
+
+        final S3ObjectMetadata s3ObjectMetadataA = mock(S3ObjectMetadata.class);
+        given(s3ObjectMetadataA.getReference()).willReturn(newS3ObjectReference);
+        given(s3ObjectMetadataA.getUrl()).willReturn(newS3ObjectUrl);
+
+        given(s3Connector.copyFile(oldS3ObjectReference, fileName)).willReturn(s3ObjectMetadataA);
+        return copiedDocExtResourceNodeA;
+    }
+
+    private void assertS3Interactions(final String oldS3ObjectReferenceA,
+                                      final String newS3ObjectReferenceA,
+                                      final String newS3ObjectUrlA,
+                                      final String fileNameA,
+                                      final Node copiedDocExtResourceNode
+    ) throws RepositoryException {
+        then(s3Connector).should().copyFile(oldS3ObjectReferenceA, fileNameA);
+        then(s3Connector).should().unpublishResource(newS3ObjectReferenceA);
+
+        assertThat("Target resource node updated with copied S3 file reference.",
+            copiedDocExtResourceNode.getProperty(PROPERTY_EXTERNAL_STORAGE_REFERENCE).getString(),
+            is(newS3ObjectReferenceA)
+        );
+
+        assertThat("Target resource node updated with copied S3 file URL.",
+            copiedDocExtResourceNode.getProperty(PROPERTY_EXTERNAL_STORAGE_PUBLIC_URL).getString(),
+            is(newS3ObjectUrlA)
+        );
+    }
+
+    private String newRandomString() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/repository-data/application/src/main/resources/hcm-config/configuration/modules/documentworkflow.scxml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/modules/documentworkflow.scxml
@@ -600,6 +600,8 @@
                 <!-- target-less transition to copy the document to the event payload provided parameters destination and name -->
                 <transition event="copy">
                     <hippo:copyDocument destinationExpr="_event.data?.destination" newNameExpr="_event.data?.name"/>
+
+                    <externalstorage:copyExternalFile destinationExpr="_event.data?.destination" newNameExpr="_event.data?.name"/>
                 </transition>
 
             </state>

--- a/repository-data/application/src/main/resources/hcm-config/configuration/modules/scxmlregistry.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/modules/scxmlregistry.yaml
@@ -2,6 +2,10 @@
 definitions:
   config:
     /hippo:configuration/hippo:modules/scxmlregistry/hippo:moduleconfig/hipposcxml:definitions/documentworkflow:
+      /copyExternalFile:
+        hipposcxml:classname: uk.nhs.digital.externalstorage.workflow.externalFileCopy.ExternalFileCopyAction
+        hipposcxml:namespace: http://digital.nhs.uk/externalstorage/scxml
+        jcr:primaryType: hipposcxml:action
       /populateSearchableFlag:
         hipposcxml:classname: uk.nhs.digital.ps.workflow.searchableFlag.SearchableFlagAction
         hipposcxml:namespace: http://digital.nhs.uk/repository/scxml

--- a/s3connector/src/main/java/uk/nhs/digital/externalstorage/s3/PooledS3Connector.java
+++ b/s3connector/src/main/java/uk/nhs/digital/externalstorage/s3/PooledS3Connector.java
@@ -25,6 +25,14 @@ public interface PooledS3Connector {
     void unpublishResource(String objectPath);
 
     /**
+     * Instantly triggers copying of given S3 file by delegating the call directly to
+     * {@linkplain uk.nhs.digital.externalstorage.s3.S3SdkConnector#copyFile} method.
+     *
+     * @return Reference of the newly created copy.
+     */
+    S3ObjectMetadata copyFile(String sourceS3FileReference, String fileName);
+
+    /**
      * <p>
      * Schedules a download from S3 as a task to be executed as soon as one of the pooled threads becomes available,
      * leaving the processing of the download input stream to the callback given as an argument. Blocks the calling

--- a/s3connector/src/main/java/uk/nhs/digital/externalstorage/s3/S3Connector.java
+++ b/s3connector/src/main/java/uk/nhs/digital/externalstorage/s3/S3Connector.java
@@ -8,6 +8,8 @@ public interface S3Connector {
 
     void unpublishResource(String objectPath);
 
+    S3ObjectMetadata copyFile(String sourceObjectPath, String fileName);
+
     S3ObjectMetadata uploadFile(InputStream fileStream, String objectPath, String contentType);
 
     /**


### PR DESCRIPTION
From now on, making a copy of a document also creates fresh copies of
the document's files hosted in S3.