### PR TITLE
[RPS-469] Added reverse date sorting for upcoming

### DIFF
--- a/acceptance-tests/src/test/resources/features/site/search.feature
+++ b/acceptance-tests/src/test/resources/features/site/search.feature
@@ -99,6 +99,17 @@ Feature: Basic search
         When I can click on the "Order by relevance" link
         Then I should see the weight search test results ordered by relevance
 
+    Scenario: Upcoming publications are ordered correctly in increasing date order
+        Given I navigate to the "search" page
+        When I click on the "Upcoming" link
+        And I click on the "National statistics" link
+        Then I should see search results starting with:
+            | 2018 - Upcoming |
+            | 2019 - Upcoming |
+            | 2020 - Upcoming |
+            | 2021 - Upcoming |
+            | 2022 - Upcoming |
+
     Scenario: Search results description is shown correctly with and without search terms
         When I navigate to the "search" page
         Then I can see the search description matching "\d+ results sorted by relevance\."

--- a/ci-cd/Makefile
+++ b/ci-cd/Makefile
@@ -204,7 +204,7 @@ check.yaml:
 
 ## Notify the slack release channel of the commits in the upcoming release
 notify.slack:
-	curl -X POST --data-urlencode "payload={\"text\": \"Release to production tomorrow at 12:05 contains the following new changes:\n\n$$(git log --format="* %s. [Author %an]" prd..rc)\"}" https://hooks.slack.com/services/${SLACK_HOOK_URL}
+	curl -X POST --data-urlencode "payload={\"text\": \"Release to production has been scheduled at 12:05 on the next working day. The following new changes (if any) will be released:\n\n$$(git log --format="* %s. [Author %an]" prd..rc)\"}" https://hooks.slack.com/services/${SLACK_HOOK_URL}
 
 ## Clean up
 clean:

--- a/cms/src/main/java/uk/nhs/digital/common/OrderedSearchDateDerivedDataFunction.java
+++ b/cms/src/main/java/uk/nhs/digital/common/OrderedSearchDateDerivedDataFunction.java
@@ -1,0 +1,52 @@
+package uk.nhs.digital.common;
+
+import static java.util.Collections.emptyMap;
+import static org.apache.commons.lang3.ArrayUtils.isEmpty;
+
+import org.apache.jackrabbit.value.LongValue;
+import org.hippoecm.repository.ext.DerivedDataFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Calendar;
+import java.util.Map;
+import javax.jcr.Value;
+
+/**
+ * Derived data function that turns the nominal publication date into a long that when
+ * sorted, will have all published documents first in descending order followed by
+ * upcoming documents in ascending date order
+ */
+public class OrderedSearchDateDerivedDataFunction extends DerivedDataFunction {
+
+    private static final long serialVersionUID = 1;
+    private static final Logger log = LoggerFactory.getLogger(OrderedSearchDateDerivedDataFunction.class);
+
+    @Override
+    public Map<String, Value[]> compute(Map<String, Value[]> parameters) {
+        try {
+            Value[] dateValues = parameters.get("date");
+            if (isEmpty(dateValues)) {
+                return emptyMap();
+            }
+
+            Value[] publiclyAccessibleValues = parameters.get("publiclyAccessible");
+
+            Calendar date = dateValues[0].getDate();
+            boolean publiclyAccessible = isEmpty(publiclyAccessibleValues) || publiclyAccessibleValues[0].getBoolean();
+
+            long orderedSearchDate = date.getTimeInMillis();
+            if (!publiclyAccessible) {
+                orderedSearchDate *= -1;
+            }
+
+            parameters.put("orderedSearchDate", new Value[]{new LongValue(orderedSearchDate)});
+
+            return parameters;
+        } catch (Exception ex) {
+            log.error("Failed to compute Ordered Search Date", ex);
+
+            return emptyMap();
+        }
+    }
+}

--- a/cms/src/test/java/uk/nhs/digital/common/OrderedSearchDateDerivedDataFunctionTest.java
+++ b/cms/src/test/java/uk/nhs/digital/common/OrderedSearchDateDerivedDataFunctionTest.java
@@ -1,0 +1,155 @@
+package uk.nhs.digital.common;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import org.apache.commons.lang3.tuple.MutablePair;
+import org.apache.jackrabbit.value.BooleanValue;
+import org.apache.jackrabbit.value.DateValue;
+import org.apache.jackrabbit.value.LongValue;
+import org.junit.Test;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.stream.Collectors;
+import javax.jcr.RepositoryException;
+import javax.jcr.Value;
+
+public class OrderedSearchDateDerivedDataFunctionTest {
+
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("dd-MM-yyyy");
+    private static final String ORDERED_SEARCH_DATE = "orderedSearchDate";
+
+    private OrderedSearchDateDerivedDataFunction function = new OrderedSearchDateDerivedDataFunction();
+
+    @Test
+    public void upcomingDateConvertedToNegativeMillis() throws Exception {
+        // given
+        Map<String, Value[]> map = generateInputMap("20-03-2020", false);
+
+        // when
+        Map<String, Value[]> result = function.compute(map);
+
+        // then
+        long expectedValue = -parseDate("20-03-2020").getTimeInMillis();
+        assertThat("Computed value is negative date millis", result, hasEntry(ORDERED_SEARCH_DATE, new Value[]{new LongValue(expectedValue)}));
+    }
+
+    @Test
+    public void publishedDateConvertedToPositiveMillis() throws Exception {
+        // given
+        Map<String, Value[]> map = generateInputMap("10-08-2010", true);
+
+        // when
+        Map<String, Value[]> result = function.compute(map);
+
+        // then
+        long expectedValue = parseDate("10-08-2010").getTimeInMillis();
+        assertThat("Computed value is positive date millis", result, hasEntry(ORDERED_SEARCH_DATE, new Value[]{new LongValue(expectedValue)}));
+    }
+
+    @Test
+    public void documentWithoutAccessibleFlagConvertedToPositiveMillis() throws Exception {
+        // given
+        Map<String, Value[]> map = generateInputMap("18-11-2013", null);
+
+        // when
+        Map<String, Value[]> result = function.compute(map);
+
+        // then
+        long expectedValue = parseDate("18-11-2013").getTimeInMillis();
+        assertThat("Computed value is positive date millis", result, hasEntry(ORDERED_SEARCH_DATE, new Value[]{new LongValue(expectedValue)}));
+    }
+
+    @Test
+    public void documentWithoutDateDoesNotGetComputedValue() throws Exception {
+        // given
+        Map<String, Value[]> inputMap = generateInputMap(null, true);
+
+        // then
+        assertNull(function.compute(inputMap).get(ORDERED_SEARCH_DATE));
+
+        // given
+        inputMap = generateInputMap(null, false);
+
+        // then
+        assertNull(function.compute(inputMap).get(ORDERED_SEARCH_DATE));
+
+        // given
+        inputMap = generateInputMap(null, null);
+
+        // then
+        assertNull(function.compute(inputMap).get(ORDERED_SEARCH_DATE));
+    }
+
+    @Test
+    public void datesSortedByComputedValueAreOrderedAsExpected() throws Exception {
+        // given
+        Map<String, Map<String, Value[]>> dateToInput = new HashMap<>();
+        addInput(dateToInput, "25-02-2020", null);
+        addInput(dateToInput, "09-03-2020", true);
+        addInput(dateToInput, "10-03-2020", false);
+        addInput(dateToInput, "11-03-2020", true);
+        addInput(dateToInput, "12-03-2020", false);
+        addInput(dateToInput, "15-03-2020", null);
+        addInput(dateToInput, "20-05-2023", true);
+        addInput(dateToInput, "21-06-2023", false);
+
+        // when
+        List<String> sortedDates = dateToInput.entrySet().stream()
+            .map(entry -> new MutablePair<>(entry.getKey(), computeValue(entry.getValue())))
+            .sorted(Map.Entry.comparingByValue())
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toList());
+
+        // We sort from highest to lowest so need to reverse
+        Collections.reverse(sortedDates);
+
+        // then
+        assertThat("The order should be published first in descending order followed by upcoming in ascending date order",
+            sortedDates, contains(
+                "20-05-2023",
+                "15-03-2020",
+                "11-03-2020",
+                "09-03-2020",
+                "25-02-2020",
+                "10-03-2020",
+                "12-03-2020",
+                "21-06-2023"
+            ));
+    }
+
+    private Map<String, Value[]> addInput(Map<String, Map<String, Value[]>> map, String date, Boolean publiclyAccessible) throws ParseException {
+        return map.put(date, generateInputMap(date, publiclyAccessible));
+    }
+
+    private long computeValue(Map<String, Value[]> input) {
+        try {
+            return function.compute(input).get(ORDERED_SEARCH_DATE)[0].getLong();
+        } catch (RepositoryException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private Map<String, Value[]> generateInputMap(String dateStr, Boolean publiclyAccessible) throws ParseException {
+        Map<String, Value[]> map = new HashMap<>();
+
+        if (dateStr != null) {
+            map.put("date", new Value[]{new DateValue(parseDate(dateStr))});
+        }
+
+        if (publiclyAccessible != null) {
+            map.put("publiclyAccessible", new Value[]{new BooleanValue(publiclyAccessible)});
+        }
+        return map;
+    }
+
+    private Calendar parseDate(String dateStr) throws ParseException {
+        Calendar date = Calendar.getInstance();
+        date.setTime(DATE_FORMAT.parse(dateStr));
+        return date;
+    }
+}

--- a/repository-data/application/src/main/resources/hcm-config/configuration/derivatives/ordered-search-date.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/derivatives/ordered-search-date.yaml
@@ -1,0 +1,21 @@
+---
+definitions:
+  config:
+    /hippo:configuration/hippo:derivatives/ordered-search-date:
+      /hipposys:accessed:
+        /date:
+          hipposys:relPath: publicationsystem:NominalDate
+          jcr:primaryType: hipposys:relativepropertyreference
+        /publiclyAccessible:
+          hipposys:relPath: publicationsystem:PubliclyAccessible
+          jcr:primaryType: hipposys:relativepropertyreference
+        jcr:primaryType: hipposys:propertyreferences
+      /hipposys:derived:
+        /orderedSearchDate:
+          hipposys:relPath: common:orderedSearchDate
+          jcr:primaryType: hipposys:relativepropertyreference
+        jcr:primaryType: hipposys:propertyreferences
+      hipposys:classname: uk.nhs.digital.common.OrderedSearchDateDerivedDataFunction
+      hipposys:nodetype: publicationsystem:basedocument
+      hipposys:serialver: 1
+      jcr:primaryType: hipposys:deriveddefinition

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/Migration20180522OrderedSearchDate.groovy
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/Migration20180522OrderedSearchDate.groovy
@@ -1,0 +1,22 @@
+package org.hippoecm.frontend.plugins.cms.admin.updater
+
+import org.onehippo.repository.update.BaseNodeUpdateVisitor
+
+import javax.jcr.Node
+
+class Migration20180522OrderedSearchDate extends BaseNodeUpdateVisitor {
+
+    boolean doUpdate(Node node) {
+        log.debug "Updating node ${node.path}"
+
+        // We just need to do something on this node to cause it to get saved to
+        // trigger the derived data function to set the calculated value
+        node.setProperty("common:orderedSearchDate", 0l)
+
+        return true
+    }
+
+    boolean undoUpdate(Node node) {
+        throw new UnsupportedOperationException('Updater does not implement undoUpdate method')
+    }
+}

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/Migration20180522OrderedSearchDate.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/Migration20180522OrderedSearchDate.yaml
@@ -1,0 +1,15 @@
+---
+definitions:
+  config:
+    /hippo:configuration/hippo:update/hippo:registry/Migration-20180522-OrderedSearchDate:
+      hipposys:batchsize: 10
+      hipposys:description: ''
+      hipposys:dryrun: false
+      hipposys:loglevel: DEBUG
+      hipposys:parameters: ''
+      hipposys:query: /jcr:root/content/documents/corporate-website//*[@publicationsystem:NominalDate]
+      hipposys:script:
+        resource: /configuration/update/Migration20180522OrderedSearchDate.groovy
+        type: string
+      hipposys:throttle: 100
+      jcr:primaryType: hipposys:updaterinfo

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/another-upcoming-publication.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/another-upcoming-publication.yaml
@@ -13,6 +13,7 @@
       - Falls
       - Infectious diseases
       - Workforce
+      common:orderedSearchDate: -1496275200000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -55,6 +56,7 @@
       - Falls
       - Infectious diseases
       - Workforce
+      common:orderedSearchDate: -1496275200000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -99,6 +101,7 @@
       - Falls
       - Infectious diseases
       - Workforce
+      common:orderedSearchDate: -1496275200000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/attachment-test.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/attachment-test.yaml
@@ -39,6 +39,7 @@
         jcr:primaryType: publicationsystem:extattachment
         publicationsystem:displayName: ''
       common:FacetType: dataset
+      common:orderedSearchDate: 1524697200000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -99,6 +100,7 @@
         jcr:primaryType: publicationsystem:extattachment
         publicationsystem:displayName: ''
       common:FacetType: dataset
+      common:orderedSearchDate: 1524697200000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -160,6 +162,7 @@
         jcr:primaryType: publicationsystem:extattachment
         publicationsystem:displayName: ''
       common:FacetType: dataset
+      common:orderedSearchDate: 1524697200000
       common:searchRank: 3
       common:searchable: true
       hippo:availability: []
@@ -225,6 +228,7 @@
         jcr:primaryType: publicationsystem:extattachment
         publicationsystem:displayName: ''
       common:FacetType: dataset
+      common:orderedSearchDate: 1524697200000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -285,6 +289,7 @@
         jcr:primaryType: publicationsystem:extattachment
         publicationsystem:displayName: ''
       common:FacetType: dataset
+      common:orderedSearchDate: 1524697200000
       common:searchRank: 3
       common:searchable: true
       hippo:availability: []
@@ -351,6 +356,7 @@
         jcr:primaryType: publicationsystem:extattachment
         publicationsystem:displayName: ''
       common:FacetType: dataset
+      common:orderedSearchDate: 1524697200000
       common:searchRank: 3
       common:searchable: true
       hippo:availability: []
@@ -410,6 +416,7 @@
         jcr:primaryType: publicationsystem:extattachment
         publicationsystem:displayName: ''
       common:FacetType: dataset
+      common:orderedSearchDate: 1524697200000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/attachment-test/content.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/attachment-test/content.yaml
@@ -38,6 +38,7 @@
       jcr:primaryType: publicationsystem:extattachment
       publicationsystem:displayName: ''
     common:FacetType: publication
+    common:orderedSearchDate: 1513123200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability: []
@@ -100,6 +101,7 @@
       jcr:primaryType: publicationsystem:extattachment
       publicationsystem:displayName: ''
     common:FacetType: publication
+    common:orderedSearchDate: 1513123200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:
@@ -164,6 +166,7 @@
       jcr:primaryType: publicationsystem:extattachment
       publicationsystem:displayName: ''
     common:FacetType: publication
+    common:orderedSearchDate: 1513123200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/attachment-test/dataset.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/attachment-test/dataset.yaml
@@ -39,6 +39,7 @@
       jcr:primaryType: publicationsystem:extattachment
       publicationsystem:displayName: ''
     common:FacetType: dataset
+    common:orderedSearchDate: 1513123200000
     common:searchRank: 3
     common:searchable: true
     hippo:availability: []
@@ -99,6 +100,7 @@
       jcr:primaryType: publicationsystem:extattachment
       publicationsystem:displayName: ''
     common:FacetType: dataset
+    common:orderedSearchDate: 1513123200000
     common:searchRank: 3
     common:searchable: true
     hippo:availability:
@@ -161,6 +163,7 @@
       jcr:primaryType: publicationsystem:extattachment
       publicationsystem:displayName: ''
     common:FacetType: dataset
+    common:orderedSearchDate: 1513123200000
     common:searchRank: 3
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/coveragedates-test.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/coveragedates-test.yaml
@@ -2,6 +2,7 @@
 /content/documents/corporate-website/publication-system/acceptance-tests/coveragedates-test:
   /coverage-test:
     /coverage-test[1]:
+      common:orderedSearchDate: 1517184000000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -25,6 +26,7 @@
       publicationsystem:Summary: Coverage dates Document
       publicationsystem:Title: Coverage dates Document
     /coverage-test[2]:
+      common:orderedSearchDate: 1517184000000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -50,6 +52,7 @@
       publicationsystem:Summary: Coverage dates Document
       publicationsystem:Title: Coverage dates Document
     /coverage-test[3]:
+      common:orderedSearchDate: 1517184000000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/dataset-without-publication.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/dataset-without-publication.yaml
@@ -3,6 +3,7 @@
   /dataset-without-publication:
     /dataset-without-publication[1]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1517529600000
       common:searchRank: 3
       common:searchable: true
       hippo:availability: []
@@ -25,6 +26,7 @@
       publicationsystem:Title: Dataset without publication
     /dataset-without-publication[2]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1517529600000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -49,6 +51,7 @@
       publicationsystem:Title: Dataset without publication
     /dataset-without-publication[3]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1517529600000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/facets-test.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/facets-test.yaml
@@ -4,6 +4,7 @@
     /content:
       /content[1]:
         common:FacetType: publication
+        common:orderedSearchDate: 1514764800000
         common:searchRank: 4
         common:searchable: true
         hippo:availability: []
@@ -36,6 +37,7 @@
         publicationsystem:Title: Facets Other Publication
       /content[2]:
         common:FacetType: publication
+        common:orderedSearchDate: 1514764800000
         common:searchRank: 4
         common:searchable: true
         hippo:availability:
@@ -70,6 +72,7 @@
         publicationsystem:Title: Facets Other Publication
       /content[3]:
         common:FacetType: publication
+        common:orderedSearchDate: 1514764800000
         common:searchRank: 4
         common:searchable: true
         hippo:availability:
@@ -128,6 +131,7 @@
         common:SearchableTags:
         - Falls
         - Social care
+        common:orderedSearchDate: 1512086400000
         common:searchRank: 4
         common:searchable: true
         hippo:availability: []
@@ -171,6 +175,7 @@
         common:SearchableTags:
         - Falls
         - Social care
+        common:orderedSearchDate: 1512086400000
         common:searchRank: 4
         common:searchable: true
         hippo:availability:
@@ -216,6 +221,7 @@
         common:SearchableTags:
         - Falls
         - Social care
+        common:orderedSearchDate: 1512086400000
         common:searchRank: 4
         common:searchable: true
         hippo:availability:
@@ -265,6 +271,7 @@
         common:SearchableTags:
         - Bowel cancer
         - Social care
+        common:orderedSearchDate: 1516147200000
         common:searchRank: 3
         common:searchable: true
         hippo:availability: []
@@ -303,6 +310,7 @@
         common:SearchableTags:
         - Bowel cancer
         - Social care
+        common:orderedSearchDate: 1516147200000
         common:searchRank: 3
         common:searchable: true
         hippo:availability:
@@ -343,6 +351,7 @@
         common:SearchableTags:
         - Bowel cancer
         - Social care
+        common:orderedSearchDate: 1516147200000
         common:searchRank: 3
         common:searchable: true
         hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/geographic-coverage-test.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/geographic-coverage-test.yaml
@@ -2,6 +2,7 @@
 /content/documents/corporate-website/publication-system/acceptance-tests/geographiccoverage-test:
   /british-isles:
     /british-isles[1]:
+      common:orderedSearchDate: 1517184000000
       common:searchable: true
       hippo:availability: []
       hippostd:state: draft
@@ -30,6 +31,7 @@
       publicationsystem:Summary: British Isles test Document
       publicationsystem:Title: British Isles test Document
     /british-isles[2]:
+      common:orderedSearchDate: 1517184000000
       common:searchable: true
       hippo:availability:
       - preview
@@ -60,6 +62,7 @@
       publicationsystem:Summary: British Isles test Document
       publicationsystem:Title: British Isles test Document
     /british-isles[3]:
+      common:orderedSearchDate: 1517184000000
       common:searchable: true
       hippo:availability:
       - live
@@ -96,6 +99,7 @@
     jcr:primaryType: hippo:handle
   /great-britain:
     /great-britain[1]:
+      common:orderedSearchDate: 1517184000000
       common:searchable: true
       hippo:availability: []
       hippostd:state: draft
@@ -122,6 +126,7 @@
       publicationsystem:Summary: Great Britain test Document
       publicationsystem:Title: Great Britain test Document
     /great-britain[2]:
+      common:orderedSearchDate: 1517184000000
       common:searchable: true
       hippo:availability:
       - preview
@@ -150,6 +155,7 @@
       publicationsystem:Summary: Great Britain test Document
       publicationsystem:Title: Great Britain test Document
     /great-britain[3]:
+      common:orderedSearchDate: 1517184000000
       common:searchable: true
       hippo:availability:
       - live
@@ -184,6 +190,7 @@
     jcr:primaryType: hippo:handle
   /other-combination:
     /other-combination[1]:
+      common:orderedSearchDate: 1517184000000
       common:searchable: true
       hippo:availability: []
       hippostd:state: draft
@@ -210,6 +217,7 @@
       publicationsystem:Summary: Other combination test Document
       publicationsystem:Title: Other combination test Document
     /other-combination[2]:
+      common:orderedSearchDate: 1517184000000
       common:searchable: true
       hippo:availability:
       - preview
@@ -238,6 +246,7 @@
       publicationsystem:Summary: Other combination test Document
       publicationsystem:Title: Other combination test Document
     /other-combination[3]:
+      common:orderedSearchDate: 1517184000000
       common:searchable: true
       hippo:availability:
       - live
@@ -272,6 +281,7 @@
     jcr:primaryType: hippo:handle
   /united-kingdom:
     /united-kingdom[1]:
+      common:orderedSearchDate: 1517184000000
       common:searchable: true
       hippo:availability: []
       hippostd:state: draft
@@ -299,6 +309,7 @@
       publicationsystem:Summary: United Kingdom test Document
       publicationsystem:Title: United Kingdom test Document
     /united-kingdom[2]:
+      common:orderedSearchDate: 1517184000000
       common:searchable: true
       hippo:availability:
       - preview
@@ -328,6 +339,7 @@
       publicationsystem:Summary: United Kingdom test Document
       publicationsystem:Title: United Kingdom test Document
     /united-kingdom[3]:
+      common:orderedSearchDate: 1517184000000
       common:searchable: true
       hippo:availability:
       - live

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/indicator-documents.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/indicator-documents.yaml
@@ -17,6 +17,7 @@
       - NHS Outcomes Framework
       - Summary Hospital-level Mortality Indicator (SHMI)
       - Clinical Commissioning Groups Outcomes Framework
+      common:orderedSearchDate: 1517184000000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -61,6 +62,7 @@
       - NHS Outcomes Framework
       - Summary Hospital-level Mortality Indicator (SHMI)
       - Clinical Commissioning Groups Outcomes Framework
+      common:orderedSearchDate: 1517184000000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -107,6 +109,7 @@
       - NHS Outcomes Framework
       - Summary Hospital-level Mortality Indicator (SHMI)
       - Clinical Commissioning Groups Outcomes Framework
+      common:orderedSearchDate: 1517184000000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/legacy-publication.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/legacy-publication.yaml
@@ -106,6 +106,7 @@
             <p>Nulla non urna id arcu ullamcorper malesuada. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Sed sodales fermentum nisi. Fusce dignissim orci sit amet imperdiet dapibus. Cras sed arcu nec lorem malesuada gravida.</p>
           jcr:primaryType: hippostd:html
         common:FacetType: publication
+        common:orderedSearchDate: 1518566400000
         common:searchRank: 4
         common:searchable: true
         hippo:availability: []
@@ -188,6 +189,7 @@
             <p>Nulla non urna id arcu ullamcorper malesuada. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Sed sodales fermentum nisi. Fusce dignissim orci sit amet imperdiet dapibus. Cras sed arcu nec lorem malesuada gravida.</p>
           jcr:primaryType: hippostd:html
         common:FacetType: publication
+        common:orderedSearchDate: 1518566400000
         common:searchRank: 4
         common:searchable: true
         hippo:availability:
@@ -272,6 +274,7 @@
             <p>Nulla non urna id arcu ullamcorper malesuada. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Sed sodales fermentum nisi. Fusce dignissim orci sit amet imperdiet dapibus. Cras sed arcu nec lorem malesuada gravida.</p>
           jcr:primaryType: hippostd:html
         common:FacetType: publication
+        common:orderedSearchDate: 1518566400000
         common:searchRank: 4
         common:searchable: true
         hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-rich/content.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-rich/content.yaml
@@ -2,6 +2,7 @@
 /content/documents/corporate-website/publication-system/acceptance-tests/publication-rich/content:
   /content[1]:
     common:FacetType: publication
+    common:orderedSearchDate: 1476057600000
     common:searchRank: 4
     common:searchable: true
     hippo:availability: []
@@ -69,6 +70,7 @@
     publicationsystem:Title: publication with rich content
   /content[2]:
     common:FacetType: publication
+    common:orderedSearchDate: 1476057600000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:
@@ -138,6 +140,7 @@
     publicationsystem:Title: publication with rich content
   /content[3]:
     common:FacetType: publication
+    common:orderedSearchDate: 1476057600000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/content.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/content.yaml
@@ -32,6 +32,7 @@
     - people,-patients-and-geography
     common:SearchableTags:
     - People, patients and geography
+    common:orderedSearchDate: 1602374400000
     common:searchRank: 4
     common:searchable: true
     hippo:availability: []
@@ -118,6 +119,7 @@
     - people,-patients-and-geography
     common:SearchableTags:
     - People, patients and geography
+    common:orderedSearchDate: 1602374400000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:
@@ -206,6 +208,7 @@
     - people,-patients-and-geography
     common:SearchableTags:
     - People, patients and geography
+    common:orderedSearchDate: 1602374400000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/datasets-subfolder/publication-with-datasets-dataset.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/datasets-subfolder/publication-with-datasets-dataset.yaml
@@ -28,6 +28,7 @@
     - conditions
     common:SearchableTags:
     - Conditions
+    common:orderedSearchDate: 1507593600000
     common:searchRank: 3
     common:searchable: true
     hippo:availability:
@@ -95,6 +96,7 @@
     - conditions
     common:SearchableTags:
     - Conditions
+    common:orderedSearchDate: 1507593600000
     common:searchRank: 3
     common:searchable: true
     hippo:availability: []
@@ -161,6 +163,7 @@
     - conditions
     common:SearchableTags:
     - Conditions
+    common:orderedSearchDate: 1507593600000
     common:searchRank: 3
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/etiam-placerat-arcu-dataset.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/etiam-placerat-arcu-dataset.yaml
@@ -2,6 +2,7 @@
 ? /content/documents/corporate-website/publication-system/acceptance-tests/publication-with-datasets/etiam-placerat-arcu-dataset
 : /etiam-placerat-arcu-dataset[1]:
     common:FacetType: dataset
+    common:orderedSearchDate: 1507593600000
     common:searchRank: 3
     common:searchable: true
     hippo:availability: []
@@ -31,6 +32,7 @@
     publicationsystem:Title: Etiam Placerat Arcu Dataset
   /etiam-placerat-arcu-dataset[2]:
     common:FacetType: dataset
+    common:orderedSearchDate: 1507593600000
     common:searchRank: 3
     common:searchable: true
     hippo:availability:
@@ -62,6 +64,7 @@
     publicationsystem:Title: Etiam Placerat Arcu Dataset
   /etiam-placerat-arcu-dataset[3]:
     common:FacetType: dataset
+    common:orderedSearchDate: 1507593600000
     common:searchRank: 3
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/search-fields-test.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/search-fields-test.yaml
@@ -11,6 +11,7 @@
       common:SearchableTags:
       - Circulatory system diseases
       - Major accidents
+      common:orderedSearchDate: 1531353600000
       common:searchRank: 3
       common:searchable: true
       hippo:availability: []
@@ -48,6 +49,7 @@
       common:SearchableTags:
       - Circulatory system diseases
       - Major accidents
+      common:orderedSearchDate: 1531353600000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -87,6 +89,7 @@
       common:SearchableTags:
       - Circulatory system diseases
       - Major accidents
+      common:orderedSearchDate: 1531353600000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -124,6 +127,7 @@
   /publication-fields-test:
     /publication-fields-test[1]:
       common:FacetType: publication
+      common:orderedSearchDate: 1515369600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -154,6 +158,7 @@
       publicationsystem:Title: Publication fields titleTestApricots
     /publication-fields-test[2]:
       common:FacetType: publication
+      common:orderedSearchDate: 1515369600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -186,6 +191,7 @@
       publicationsystem:Title: Publication fields titleTestApricots
     /publication-fields-test[3]:
       common:FacetType: publication
+      common:orderedSearchDate: 1515369600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/search-weights.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/search-weights.yaml
@@ -125,6 +125,7 @@
   /content:
     /content[1]:
       common:FacetType: publication
+      common:orderedSearchDate: 1515369600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -149,6 +150,7 @@
       publicationsystem:Title: Search Weights Publication
     /content[2]:
       common:FacetType: publication
+      common:orderedSearchDate: 1515369600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -175,6 +177,7 @@
       publicationsystem:Title: Search Weights Publication
     /content[3]:
       common:FacetType: publication
+      common:orderedSearchDate: 1515369600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -205,6 +208,7 @@
   /dataset-summary:
     /dataset-summary[1]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1520726400000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -228,6 +232,7 @@
       publicationsystem:Title: Search Test Dataset Summary Mar 18
     /dataset-summary[2]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1520726400000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -252,6 +257,7 @@
       publicationsystem:Title: Search Test Dataset Summary Mar 18
     /dataset-summary[3]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1520726400000
       common:searchRank: 3
       common:searchable: true
       hippo:availability: []
@@ -280,6 +286,7 @@
   /dataset-title:
     /dataset-title[1]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1515369600000
       common:searchRank: 3
       common:searchable: true
       hippo:availability: []
@@ -302,6 +309,7 @@
       publicationsystem:Title: "Search Test Dataset Title Jan 18\r\nWeightSearchTerm"
     /dataset-title[2]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1515369600000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -326,6 +334,7 @@
       publicationsystem:Title: "Search Test Dataset Title Jan 18\r\nWeightSearchTerm"
     /dataset-title[3]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1515369600000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -356,6 +365,7 @@
   /publication-key-facts:
     /publication-key-facts[1]:
       common:FacetType: publication
+      common:orderedSearchDate: 1518480000000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -381,6 +391,7 @@
       publicationsystem:Title: Search Test Publication Key Facts Feb 18
     /publication-key-facts[2]:
       common:FacetType: publication
+      common:orderedSearchDate: 1518480000000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -405,6 +416,7 @@
       publicationsystem:Title: Search Test Publication Key Facts Feb 18
     /publication-key-facts[3]:
       common:FacetType: publication
+      common:orderedSearchDate: 1518480000000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -437,6 +449,7 @@
   /publication-summary:
     /publication-summary[1]:
       common:FacetType: publication
+      common:orderedSearchDate: 1523401200000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -462,6 +475,7 @@
       publicationsystem:Title: Search Test Publication Summary Apr 18
     /publication-summary[2]:
       common:FacetType: publication
+      common:orderedSearchDate: 1523401200000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -486,6 +500,7 @@
       publicationsystem:Title: Search Test Publication Summary Apr 18
     /publication-summary[3]:
       common:FacetType: publication
+      common:orderedSearchDate: 1523401200000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -518,6 +533,7 @@
   /publication-title:
     /publication-title[1]:
       common:FacetType: publication
+      common:orderedSearchDate: 1514678400000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -542,6 +558,7 @@
       publicationsystem:Title: "Search Test Publication Title Dec 17\r\nWeightSearchTerm"
     /publication-title[2]:
       common:FacetType: publication
+      common:orderedSearchDate: 1514678400000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -568,6 +585,7 @@
       publicationsystem:Title: "Search Test Publication Title Dec 17\r\nWeightSearchTerm"
     /publication-title[3]:
       common:FacetType: publication
+      common:orderedSearchDate: 1514678400000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/sectioned-publication.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/sectioned-publication.yaml
@@ -16,6 +16,9 @@
       /publicationsystem:KeyFactImages[1]:
         /publicationsystem:image:
           hippo:filename: robot.jpeg
+          hippo:text:
+            resource: /content/documents/corporate-website/publication-system/acceptance-tests/sectioned-publication/content/content[1]/KeyFactImages[1]/image/text.jpg
+            type: binary
           jcr:data:
             resource: /content/documents/corporate-website/publication-system/acceptance-tests/sectioned-publication/content/content[1]/KeyFactImages[1]/image/data.jpg
             type: binary
@@ -45,6 +48,7 @@
         publicationsystem:caption: ''
         publicationsystem:link: ''
       common:FacetType: publication
+      common:orderedSearchDate: 1523318400000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -109,6 +113,7 @@
         publicationsystem:caption: ''
         publicationsystem:link: ''
       common:FacetType: publication
+      common:orderedSearchDate: 1523318400000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -175,6 +180,7 @@
         publicationsystem:caption: ''
         publicationsystem:link: ''
       common:FacetType: publication
+      common:orderedSearchDate: 1523318400000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -751,6 +757,7 @@
   /dataset:
     /dataset[1]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1523318400000
       common:searchRank: 3
       common:searchable: true
       hippo:availability: []
@@ -773,6 +780,7 @@
       publicationsystem:Title: Dataset
     /dataset[2]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1523318400000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -797,6 +805,7 @@
       publicationsystem:Title: Dataset
     /dataset[3]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1523318400000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/content.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/content.yaml
@@ -2,6 +2,7 @@
 ? /content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/content
 : /content[1]:
     common:FacetType: publication
+    common:orderedSearchDate: 1507593600000
     common:searchRank: 4
     common:searchable: true
     hippo:availability: []
@@ -41,6 +42,7 @@
     publicationsystem:Title: series publication with datasets
   /content[2]:
     common:FacetType: publication
+    common:orderedSearchDate: 1507593600000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:
@@ -82,6 +84,7 @@
     publicationsystem:Title: series publication with datasets
   /content[3]:
     common:FacetType: publication
+    common:orderedSearchDate: 1507593600000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/series-publication-with-datasets-dataset.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/series-publication-with-datasets-dataset.yaml
@@ -2,6 +2,7 @@
 ? /content/documents/corporate-website/publication-system/acceptance-tests/series-with-publication-with-datasets/series-publication-with-datasets/series-publication-with-datasets-dataset
 : /series-publication-with-datasets-dataset[1]:
     common:FacetType: dataset
+    common:orderedSearchDate: 1507593600000
     common:searchRank: 3
     common:searchable: true
     hippo:availability:
@@ -49,6 +50,7 @@
     publicationsystem:Title: series-publication-with-datasets Dataset
   /series-publication-with-datasets-dataset[2]:
     common:FacetType: dataset
+    common:orderedSearchDate: 1507593600000
     common:searchRank: 3
     common:searchable: true
     hippo:availability: []
@@ -95,6 +97,7 @@
     publicationsystem:Title: series-publication-with-datasets Dataset
   /series-publication-with-datasets-dataset[3]:
     common:FacetType: dataset
+    common:orderedSearchDate: 1507593600000
     common:searchRank: 3
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/series-without-latest.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/series-without-latest.yaml
@@ -3,6 +3,7 @@
   /2017:
     /2017[1]:
       common:FacetType: publication
+      common:orderedSearchDate: 1487721600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -27,6 +28,7 @@
       publicationsystem:Title: Publication 2017
     /2017[2]:
       common:FacetType: publication
+      common:orderedSearchDate: 1487721600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -53,6 +55,7 @@
       publicationsystem:Title: Publication 2017
     /2017[3]:
       common:FacetType: publication
+      common:orderedSearchDate: 1487721600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -83,6 +86,7 @@
   /2018:
     /2018[1]:
       common:FacetType: publication
+      common:orderedSearchDate: 1519257600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -107,6 +111,7 @@
       publicationsystem:Title: A publication 2018
     /2018[2]:
       common:FacetType: publication
+      common:orderedSearchDate: 1519257600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -133,6 +138,7 @@
       publicationsystem:Title: A publication 2018
     /2018[3]:
       common:FacetType: publication
+      common:orderedSearchDate: 1519257600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -163,6 +169,7 @@
   /2019:
     /2019[1]:
       common:FacetType: publication
+      common:orderedSearchDate: 1550793600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -187,6 +194,7 @@
       publicationsystem:Title: Latest 2019
     /2019[2]:
       common:FacetType: publication
+      common:orderedSearchDate: 1550793600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -213,6 +221,7 @@
       publicationsystem:Title: Latest 2019
     /2019[3]:
       common:FacetType: publication
+      common:orderedSearchDate: 1550793600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -243,13 +252,14 @@
   /2020-upcoming:
     /2020-upcoming[1]:
       common:FacetType: publication
+      common:orderedSearchDate: -1577836800000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
       hippostd:state: draft
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2018-05-04T15:02:02.672Z
-      hippostdpubwf:lastModificationDate: 2018-05-04T15:02:02.673Z
+      hippostdpubwf:lastModificationDate: 2018-05-22T15:48:54.490Z
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: d2d8c97d-a309-4941-a2e1-4c7207bfa4bf
       hippotranslation:locale: en
@@ -262,12 +272,13 @@
       publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
       publicationsystem:GeographicCoverage: []
       publicationsystem:KeyFacts: ''
-      publicationsystem:NominalDate: 2018-05-03T23:00:00Z
+      publicationsystem:NominalDate: 2020-01-01T00:00:00Z
       publicationsystem:PubliclyAccessible: false
       publicationsystem:Summary: 2020 Upcoming
       publicationsystem:Title: 2020 Upcoming
     /2020-upcoming[2]:
       common:FacetType: publication
+      common:orderedSearchDate: -1577836800000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -275,7 +286,7 @@
       hippostd:state: unpublished
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2018-05-04T15:02:02.672Z
-      hippostdpubwf:lastModificationDate: 2018-05-04T15:02:37.837Z
+      hippostdpubwf:lastModificationDate: 2018-05-22T15:49:08.100Z
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: d2d8c97d-a309-4941-a2e1-4c7207bfa4bf
       hippotranslation:locale: en
@@ -289,12 +300,13 @@
       publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
       publicationsystem:GeographicCoverage: []
       publicationsystem:KeyFacts: ''
-      publicationsystem:NominalDate: 2018-05-03T23:00:00Z
+      publicationsystem:NominalDate: 2020-01-01T00:00:00Z
       publicationsystem:PubliclyAccessible: false
       publicationsystem:Summary: 2020 Upcoming
       publicationsystem:Title: 2020 Upcoming
     /2020-upcoming[3]:
       common:FacetType: publication
+      common:orderedSearchDate: -1577836800000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -302,9 +314,9 @@
       hippostd:state: published
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2018-05-04T15:02:02.672Z
-      hippostdpubwf:lastModificationDate: 2018-05-04T15:02:37.837Z
+      hippostdpubwf:lastModificationDate: 2018-05-22T15:49:08.100Z
       hippostdpubwf:lastModifiedBy: admin
-      hippostdpubwf:publicationDate: 2018-05-04T15:03:05.109Z
+      hippostdpubwf:publicationDate: 2018-05-22T15:49:13.332Z
       hippotranslation:id: d2d8c97d-a309-4941-a2e1-4c7207bfa4bf
       hippotranslation:locale: en
       jcr:mixinTypes:
@@ -316,7 +328,7 @@
       publicationsystem:CoverageStart: 0001-01-01T12:00:00Z
       publicationsystem:GeographicCoverage: []
       publicationsystem:KeyFacts: ''
-      publicationsystem:NominalDate: 2018-05-03T23:00:00Z
+      publicationsystem:NominalDate: 2020-01-01T00:00:00Z
       publicationsystem:PubliclyAccessible: false
       publicationsystem:Summary: 2020 Upcoming
       publicationsystem:Title: 2020 Upcoming

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/taxonomy-tests.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/taxonomy-tests.yaml
@@ -10,6 +10,7 @@
       - SynonymTest Test
       - Other Synonym
       - SynonymSearchTerm
+      common:orderedSearchDate: 1519084800000
       common:searchRank: 3
       common:searchable: true
       hippo:availability: []
@@ -41,6 +42,7 @@
       - SynonymTest Test
       - Other Synonym
       - SynonymSearchTerm
+      common:orderedSearchDate: 1519084800000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -74,6 +76,7 @@
       - SynonymTest Test
       - Other Synonym
       - SynonymSearchTerm
+      common:orderedSearchDate: 1519084800000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -111,6 +114,7 @@
       - acceptance-tests
       common:SearchableTags:
       - TaxonomySearchTerm test
+      common:orderedSearchDate: 1519084800000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -142,6 +146,7 @@
       - acceptance-tests
       common:SearchableTags:
       - TaxonomySearchTerm test
+      common:orderedSearchDate: 1519084800000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -175,6 +180,7 @@
       - acceptance-tests
       common:SearchableTags:
       - TaxonomySearchTerm test
+      common:orderedSearchDate: 1519084800000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/upcoming-publication/content.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/upcoming-publication/content.yaml
@@ -2,6 +2,7 @@
 /content/documents/corporate-website/publication-system/acceptance-tests/upcoming-publication/content:
   /content[1]:
     common:FacetType: publication
+    common:orderedSearchDate: -1507593600000
     common:searchRank: 4
     common:searchable: true
     hippo:availability: []
@@ -43,6 +44,7 @@
     publicationsystem:Title: Upcoming Publication
   /content[2]:
     common:FacetType: publication
+    common:orderedSearchDate: -1507593600000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:
@@ -86,6 +88,7 @@
     publicationsystem:Title: Upcoming Publication
   /content[3]:
     common:FacetType: publication
+    common:orderedSearchDate: -1507593600000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/upcoming-publication/upcoming-dataset.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/upcoming-publication/upcoming-dataset.yaml
@@ -2,6 +2,7 @@
 /content/documents/corporate-website/publication-system/acceptance-tests/upcoming-publication/upcoming-dataset:
   /upcoming-dataset[1]:
     common:FacetType: dataset
+    common:orderedSearchDate: 1507593600000
     common:searchRank: 3
     common:searchable: false
     hippo:availability: []
@@ -31,6 +32,7 @@
     publicationsystem:Title: Upcoming Dataset
   /upcoming-dataset[2]:
     common:FacetType: dataset
+    common:orderedSearchDate: 1507593600000
     common:searchRank: 3
     common:searchable: false
     hippo:availability:
@@ -62,6 +64,7 @@
     publicationsystem:Title: Upcoming Dataset
   /upcoming-dataset[3]:
     common:FacetType: dataset
+    common:orderedSearchDate: 1507593600000
     common:searchRank: 3
     common:searchable: false
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/valid-archive.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/acceptance-tests/valid-archive.yaml
@@ -3,6 +3,7 @@
   /2002:
     /2002[1]:
       common:FacetType: publication
+      common:orderedSearchDate: 1012521600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -27,6 +28,7 @@
       publicationsystem:Title: Lorem Ipsum Dolor 2002
     /2002[2]:
       common:FacetType: publication
+      common:orderedSearchDate: 1012521600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -53,6 +55,7 @@
       publicationsystem:Title: Lorem Ipsum Dolor 2002
     /2002[3]:
       common:FacetType: publication
+      common:orderedSearchDate: 1012521600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -85,6 +88,7 @@
   /2003:
     /2003[1]:
       common:FacetType: publication
+      common:orderedSearchDate: 1044057600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -109,6 +113,7 @@
       publicationsystem:Title: Lorem Ipsum Dolor 2003
     /2003[2]:
       common:FacetType: publication
+      common:orderedSearchDate: 1044057600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -135,6 +140,7 @@
       publicationsystem:Title: Lorem Ipsum Dolor 2003
     /2003[3]:
       common:FacetType: publication
+      common:orderedSearchDate: 1044057600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -167,6 +173,7 @@
   /2004:
     /2004[1]:
       common:FacetType: publication
+      common:orderedSearchDate: 1075593600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -191,6 +198,7 @@
       publicationsystem:Title: Lorem Ipsum Dolor 2004
     /2004[2]:
       common:FacetType: publication
+      common:orderedSearchDate: 1075593600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -217,6 +225,7 @@
       publicationsystem:Title: Lorem Ipsum Dolor 2004
     /2004[3]:
       common:FacetType: publication
+      common:orderedSearchDate: 1075593600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/bare-minimum-publication.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/bare-minimum-publication.yaml
@@ -3,6 +3,7 @@
   /bare-minimum-dataset:
     /bare-minimum-dataset[1]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1515369600000
       common:searchRank: 3
       common:searchable: true
       hippo:availability: []
@@ -25,6 +26,7 @@
       publicationsystem:Title: Bare Minimum Dataset
     /bare-minimum-dataset[2]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1515369600000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -49,6 +51,7 @@
       publicationsystem:Title: Bare Minimum Dataset
     /bare-minimum-dataset[3]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1515369600000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -79,6 +82,7 @@
   /content:
     /content[1]:
       common:FacetType: publication
+      common:orderedSearchDate: 1515369600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -103,6 +107,7 @@
       publicationsystem:Title: Bare Minimum Publication
     /content[2]:
       common:FacetType: publication
+      common:orderedSearchDate: 1515369600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -129,6 +134,7 @@
       publicationsystem:Title: Bare Minimum Publication
     /content[3]:
       common:FacetType: publication
+      common:orderedSearchDate: 1515369600000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/clinical-indicators.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/clinical-indicators.yaml
@@ -5,6 +5,7 @@
       /ccg-archive-document-1:
         /ccg-archive-document-1[1]:
           common:FacetType: publication
+          common:orderedSearchDate: 1525734000000
           common:searchRank: 4
           common:searchable: true
           hippo:availability: []
@@ -30,6 +31,7 @@
           publicationsystem:Title: CCG Archive publication
         /ccg-archive-document-1[2]:
           common:FacetType: publication
+          common:orderedSearchDate: 1525734000000
           common:searchRank: 4
           common:searchable: true
           hippo:availability:
@@ -57,6 +59,7 @@
           publicationsystem:Title: CCG Archive publication
         /ccg-archive-document-1[3]:
           common:FacetType: publication
+          common:orderedSearchDate: 1525734000000
           common:searchRank: 4
           common:searchable: true
           hippo:availability:
@@ -162,6 +165,7 @@
         /ccg-dataset:
           /ccg-dataset[1]:
             common:FacetType: dataset
+            common:orderedSearchDate: 1522710000000
             common:searchRank: 3
             common:searchable: true
             hippo:availability: []
@@ -185,6 +189,7 @@
             publicationsystem:Title: CCG dataset
           /ccg-dataset[2]:
             common:FacetType: dataset
+            common:orderedSearchDate: 1522710000000
             common:searchRank: 3
             common:searchable: true
             hippo:availability:
@@ -210,6 +215,7 @@
             publicationsystem:Title: CCG dataset
           /ccg-dataset[3]:
             common:FacetType: dataset
+            common:orderedSearchDate: 1522710000000
             common:searchRank: 3
             common:searchable: true
             hippo:availability:
@@ -241,6 +247,7 @@
         /content:
           /content[1]:
             common:FacetType: publication
+            common:orderedSearchDate: 1524178800000
             common:searchRank: 4
             common:searchable: true
             hippo:availability: []
@@ -268,6 +275,7 @@
             publicationsystem:Title: CCG publication
           /content[2]:
             common:FacetType: publication
+            common:orderedSearchDate: 1524178800000
             common:searchRank: 4
             common:searchable: true
             hippo:availability:
@@ -297,6 +305,7 @@
             publicationsystem:Title: CCG publication
           /content[3]:
             common:FacetType: publication
+            common:orderedSearchDate: 1524178800000
             common:searchRank: 4
             common:searchable: true
             hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/fusce-viverra-dolor.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/fusce-viverra-dolor.yaml
@@ -8,6 +8,7 @@
     - accidents-and-injuries
     common:SearchableTags:
     - Falls
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability: []
@@ -49,6 +50,7 @@
     - accidents-and-injuries
     common:SearchableTags:
     - Falls
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:
@@ -92,6 +94,7 @@
     - accidents-and-injuries
     common:SearchableTags:
     - Falls
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/lorem-ipsum.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/lorem-ipsum.yaml
@@ -7,6 +7,7 @@
     - conditions
     common:SearchableTags:
     - Infectious diseases
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability: []
@@ -45,6 +46,7 @@
     - conditions
     common:SearchableTags:
     - Infectious diseases
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:
@@ -85,6 +87,7 @@
     - conditions
     common:SearchableTags:
     - Infectious diseases
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-tempor-euismod-vehicula.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-tempor-euismod-vehicula.yaml
@@ -6,6 +6,7 @@
     - workforce
     common:SearchableTags:
     - Workforce
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability: []
@@ -45,6 +46,7 @@
     - workforce
     common:SearchableTags:
     - Workforce
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:
@@ -86,6 +88,7 @@
     - workforce
     common:SearchableTags:
     - Workforce
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-vitae-nunc-ac-lacus-malesuada-tempus.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/morbi-vitae-nunc-ac-lacus-malesuada-tempus.yaml
@@ -9,6 +9,7 @@
     common:SearchableTags:
     - Infectious diseases
     - Workforce
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability: []
@@ -52,6 +53,7 @@
     common:SearchableTags:
     - Infectious diseases
     - Workforce
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:
@@ -97,6 +99,7 @@
     common:SearchableTags:
     - Infectious diseases
     - Workforce
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/nullam-vel-ligula-dapibus.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/nullam-vel-ligula-dapibus.yaml
@@ -12,6 +12,7 @@
     - Falls
     - Infectious diseases
     - Workforce
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability: []
@@ -58,6 +59,7 @@
     - Falls
     - Infectious diseases
     - Workforce
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:
@@ -106,6 +108,7 @@
     - Falls
     - Infectious diseases
     - Workforce
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/nunc-tempus-ante-nec.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/nunc-tempus-ante-nec.yaml
@@ -10,6 +10,7 @@
     common:SearchableTags:
     - Falls
     - Circulatory system diseases
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability: []
@@ -56,6 +57,7 @@
     common:SearchableTags:
     - Falls
     - Circulatory system diseases
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:
@@ -104,6 +106,7 @@
     common:SearchableTags:
     - Falls
     - Circulatory system diseases
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-elementum-justo-eu-tortor.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-elementum-justo-eu-tortor.yaml
@@ -10,6 +10,7 @@
     common:SearchableTags:
     - Falls
     - Workforce
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability: []
@@ -52,6 +53,7 @@
     common:SearchableTags:
     - Falls
     - Workforce
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:
@@ -96,6 +98,7 @@
     common:SearchableTags:
     - Falls
     - Workforce
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-nec-justo.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/lorem-ipsum-content/proin-nec-justo.yaml
@@ -9,6 +9,7 @@
     common:SearchableTags:
     - Circulatory system diseases
     - Workforce
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability: []
@@ -57,6 +58,7 @@
     - Falls
     - Infectious diseases
     - Workforce
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:
@@ -108,6 +110,7 @@
     - Falls
     - Infectious diseases
     - Workforce
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/loremimsumdolor.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/loremimsumdolor.yaml
@@ -12,6 +12,7 @@
     - Falls
     - Infectious diseases
     - Workforce
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability: []
@@ -52,6 +53,7 @@
     - Falls
     - Infectious diseases
     - Workforce
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:
@@ -94,6 +96,7 @@
     - Falls
     - Infectious diseases
     - Workforce
+    common:orderedSearchDate: 1496275200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/search-test-1.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/search-test-1.yaml
@@ -9,6 +9,7 @@
     common:SearchableTags:
     - Circulatory system diseases
     - Dental health
+    common:orderedSearchDate: 1604707200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability: []
@@ -47,6 +48,7 @@
     common:SearchableTags:
     - Circulatory system diseases
     - Dental health
+    common:orderedSearchDate: 1604707200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:
@@ -87,6 +89,7 @@
     common:SearchableTags:
     - Circulatory system diseases
     - Dental health
+    common:orderedSearchDate: 1604707200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/search-test-2.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/search-test-2.yaml
@@ -9,6 +9,7 @@
     common:SearchableTags:
     - Circulatory system diseases
     - Dental health
+    common:orderedSearchDate: 1604707200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:
@@ -48,6 +49,7 @@
     common:SearchableTags:
     - Circulatory system diseases
     - Dental health
+    common:orderedSearchDate: 1604707200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability: []
@@ -86,6 +88,7 @@
     common:SearchableTags:
     - Circulatory system diseases
     - Dental health
+    common:orderedSearchDate: 1604707200000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/search-test-3.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/search-test-3.yaml
@@ -9,6 +9,7 @@
     common:SearchableTags:
     - Circulatory system diseases
     - Dental health
+    common:orderedSearchDate: 1604793600000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:
@@ -48,6 +49,7 @@
     common:SearchableTags:
     - Circulatory system diseases
     - Dental health
+    common:orderedSearchDate: 1604793600000
     common:searchRank: 4
     common:searchable: true
     hippo:availability: []
@@ -86,6 +88,7 @@
     common:SearchableTags:
     - Circulatory system diseases
     - Dental health
+    common:orderedSearchDate: 1604793600000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/search-test-4.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/search-test-loremipsumdolor/search-test-4.yaml
@@ -9,6 +9,7 @@
     common:SearchableTags:
     - Circulatory system diseases
     - Dental health
+    common:orderedSearchDate: 1604793600000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:
@@ -49,6 +50,7 @@
     common:SearchableTags:
     - Circulatory system diseases
     - Dental health
+    common:orderedSearchDate: 1604793600000
     common:searchRank: 4
     common:searchable: true
     hippo:availability: []
@@ -88,6 +90,7 @@
     common:SearchableTags:
     - Circulatory system diseases
     - Dental health
+    common:orderedSearchDate: 1604793600000
     common:searchRank: 4
     common:searchable: true
     hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/valid-publication-series.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/publication-system/valid-publication-series.yaml
@@ -9,6 +9,7 @@
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
       common:FacetType: publication
+      common:orderedSearchDate: 1357776000000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -41,6 +42,7 @@
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
       common:FacetType: publication
+      common:orderedSearchDate: 1357776000000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -75,6 +77,7 @@
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
       common:FacetType: publication
+      common:orderedSearchDate: 1357776000000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -113,6 +116,7 @@
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
       common:FacetType: publication
+      common:orderedSearchDate: 1389312000000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -145,6 +149,7 @@
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
       common:FacetType: publication
+      common:orderedSearchDate: 1389312000000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -179,6 +184,7 @@
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
       common:FacetType: publication
+      common:orderedSearchDate: 1389312000000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -217,6 +223,7 @@
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
       common:FacetType: publication
+      common:orderedSearchDate: 1420848000000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -249,6 +256,7 @@
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
       common:FacetType: publication
+      common:orderedSearchDate: 1420848000000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -283,6 +291,7 @@
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
       common:FacetType: publication
+      common:orderedSearchDate: 1420848000000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -321,6 +330,7 @@
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
       common:FacetType: publication
+      common:orderedSearchDate: 1452384000000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -353,6 +363,7 @@
         publicationsystem:link_text: ''
         publicationsystem:link_url: ''
       common:FacetType: publication
+      common:orderedSearchDate: 1452384000000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -385,6 +396,7 @@
   /2018---upcoming:
     /2018---upcoming[1]:
       common:FacetType: publication
+      common:orderedSearchDate: -1525388400000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -412,6 +424,7 @@
       publicationsystem:Title: 2018 - Upcoming
     /2018---upcoming[2]:
       common:FacetType: publication
+      common:orderedSearchDate: -1525388400000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -441,6 +454,7 @@
       publicationsystem:Title: 2018 - Upcoming
     /2018---upcoming[3]:
       common:FacetType: publication
+      common:orderedSearchDate: -1525388400000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -476,6 +490,7 @@
   /2019---upcoming:
     /2019---upcoming[1]:
       common:FacetType: publication
+      common:orderedSearchDate: -1548892800000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -504,6 +519,7 @@
       publicationsystem:Title: 2019 - Upcoming
     /2019---upcoming[2]:
       common:FacetType: publication
+      common:orderedSearchDate: -1548892800000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -531,6 +547,7 @@
       publicationsystem:Title: 2019 - Upcoming
     /2019---upcoming[3]:
       common:FacetType: publication
+      common:orderedSearchDate: -1548892800000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -566,6 +583,7 @@
   /2020---upcoming:
     /2020---upcoming[1]:
       common:FacetType: publication
+      common:orderedSearchDate: -1577836800000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -594,6 +612,7 @@
       publicationsystem:Title: 2020 - Upcoming
     /2020---upcoming[2]:
       common:FacetType: publication
+      common:orderedSearchDate: -1577836800000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -621,6 +640,7 @@
       publicationsystem:Title: 2020 - Upcoming
     /2020---upcoming[3]:
       common:FacetType: publication
+      common:orderedSearchDate: -1577836800000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -656,6 +676,7 @@
   /2021---upcoming:
     /2021---upcoming[1]:
       common:FacetType: publication
+      common:orderedSearchDate: -1609459200000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -684,6 +705,7 @@
       publicationsystem:Title: 2021 - Upcoming
     /2021---upcoming[2]:
       common:FacetType: publication
+      common:orderedSearchDate: -1609459200000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -711,6 +733,7 @@
       publicationsystem:Title: 2021 - Upcoming
     /2021---upcoming[3]:
       common:FacetType: publication
+      common:orderedSearchDate: -1609459200000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -746,6 +769,7 @@
   /2022---upcoming:
     /2022---upcoming[1]:
       common:FacetType: publication
+      common:orderedSearchDate: -1640995200000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -774,6 +798,7 @@
       publicationsystem:Title: 2022 - Upcoming
     /2022---upcoming[2]:
       common:FacetType: publication
+      common:orderedSearchDate: -1640995200000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -801,6 +826,7 @@
       publicationsystem:Title: 2022 - Upcoming
     /2022---upcoming[3]:
       common:FacetType: publication
+      common:orderedSearchDate: -1640995200000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/ordered-publication.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/ordered-publication.yaml
@@ -3,6 +3,7 @@
   /1.1:
     /1.1[1]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1518998400000
       common:searchRank: 3
       common:searchable: true
       hippo:availability: []
@@ -25,6 +26,7 @@
       publicationsystem:Title: 1.1 Dataset
     /1.1[2]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1518998400000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -49,6 +51,7 @@
       publicationsystem:Title: 1.1 Dataset
     /1.1[3]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1518998400000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -77,6 +80,7 @@
   /1.9:
     /1.9[1]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1518998400000
       common:searchRank: 3
       common:searchable: true
       hippo:availability: []
@@ -99,6 +103,7 @@
       publicationsystem:Title: 1.9 Dataset
     /1.9[2]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1518998400000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -123,6 +128,7 @@
       publicationsystem:Title: 1.9 Dataset
     /1.9[3]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1518998400000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -151,6 +157,7 @@
   /1.10:
     /1.10[1]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1518998400000
       common:searchRank: 3
       common:searchable: true
       hippo:availability: []
@@ -173,6 +180,7 @@
       publicationsystem:Title: 1.10 Dataset
     /1.10[2]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1518998400000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -197,6 +205,7 @@
       publicationsystem:Title: 1.10 Dataset
     /1.10[3]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1518998400000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -225,6 +234,7 @@
   /2.0:
     /2.0[1]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1518998400000
       common:searchRank: 3
       common:searchable: true
       hippo:availability: []
@@ -247,6 +257,7 @@
       publicationsystem:Title: 2.0 Dataset
     /2.0[2]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1518998400000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -271,6 +282,7 @@
       publicationsystem:Title: 2.0 Dataset
     /2.0[3]:
       common:FacetType: dataset
+      common:orderedSearchDate: 1518998400000
       common:searchRank: 3
       common:searchable: true
       hippo:availability:
@@ -299,6 +311,7 @@
   /content:
     /content[1]:
       common:FacetType: publication
+      common:orderedSearchDate: 1518998400000
       common:searchRank: 4
       common:searchable: true
       hippo:availability: []
@@ -323,6 +336,7 @@
       publicationsystem:Title: Ordered Publication
     /content[2]:
       common:FacetType: publication
+      common:orderedSearchDate: 1518998400000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:
@@ -349,6 +363,7 @@
       publicationsystem:Title: Ordered Publication
     /content[3]:
       common:FacetType: publication
+      common:orderedSearchDate: 1518998400000
       common:searchRank: 4
       common:searchable: true
       hippo:availability:

--- a/site/src/main/java/uk/nhs/digital/common/components/SearchComponent.java
+++ b/site/src/main/java/uk/nhs/digital/common/components/SearchComponent.java
@@ -60,6 +60,7 @@ public class SearchComponent extends CommonComponent {
     private static final String FOLDER_NIL = "national-indicator-library";
 
     private static final String PROPERTY_SEARCH_RANK = "common:searchRank";
+    private static final String PROPERTY_ORDERED_SEARCH_DATE = "common:orderedSearchDate";
 
     private static final int PAGEABLE_SIZE = 5;
 
@@ -196,7 +197,7 @@ public class SearchComponent extends CommonComponent {
         switch (sortParam) {
             case SORT_DATE:
                 queryBuilder.orderByDescending(
-                    "publicationsystem:NominalDate",
+                    PROPERTY_ORDERED_SEARCH_DATE,
                     "nationalindicatorlibrary:assuranceDate",
                     PROPERTY_SEARCH_RANK,
                     HippoStdPubWfNodeType.HIPPOSTDPUBWF_LAST_MODIFIED_DATE);
@@ -205,7 +206,7 @@ public class SearchComponent extends CommonComponent {
                 // This is what we want for data and info - when we have tabs this will need to be made specific
                 queryBuilder.orderByDescending(
                     PROPERTY_SEARCH_RANK,
-                    "publicationsystem:NominalDate",
+                    PROPERTY_ORDERED_SEARCH_DATE,
                     "nationalindicatorlibrary:assuranceDate",
                     HippoStdPubWfNodeType.HIPPOSTDPUBWF_LAST_MODIFIED_DATE);
                 break;
@@ -248,7 +249,7 @@ public class SearchComponent extends CommonComponent {
                 scopeBeans.add(request.getRequestContext().getSiteContentBaseBean());
         }
 
-        return scopeBeans.toArray(new HippoBean[scopeBeans.size()]);
+        return scopeBeans.toArray(new HippoBean[0]);
     }
 
     private String getSortOption(HstRequest request) {


### PR DESCRIPTION
Upcoming publications will be return below any published ones
in search results and the date order will be reverse so you
see the next to be published first.

This is achived with a derived data field that is used for
the sorting.