### PR TITLE
[RPS-497] RPS-450 S3 logs fix and upload cap values

### DIFF
--- a/cms/src/main/java/uk/nhs/digital/externalstorage/s3/S3TransfersReportingTracker.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/s3/S3TransfersReportingTracker.java
@@ -185,18 +185,18 @@ public class S3TransfersReportingTracker {
     }
 
     /**
-     * Ensures synchronous access to both counts in multithreaded use;
+     * Ensures thread-safe access to both counts in a multi-threaded use;
      * be mindful of correct synchronisation of the public methods if changing.
      */
     private static class TransfersCounter {
 
         private final Logger log;
 
-        private int uploadsActiveCount = 0;
-        private int uploadsScheduledCount = 0;
+        private volatile int uploadsActiveCount = 0;
+        private volatile int uploadsScheduledCount = 0;
 
-        private int downloadsActiveCount = 0;
-        private int downloadsScheduledCount = 0;
+        private volatile int downloadsActiveCount = 0;
+        private volatile int downloadsScheduledCount = 0;
 
         private TransfersCounter(Logger log) {
             this.log = log;

--- a/repository-data/application/src/main/resources/hcm-config/configuration/modules/s3ConnectorRegistrationModule.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/modules/s3ConnectorRegistrationModule.yaml
@@ -5,8 +5,8 @@ definitions:
       /hippo:moduleconfig:
         downloadShutdownTimeoutInSecs: 30
         jcr:primaryType: hipposys:moduleconfig
-        maxConcurrentDownloadsCount: 50
-        maxConcurrentUploadsCount: 10
+        maxConcurrentDownloadsCount: 11
+        maxConcurrentUploadsCount: 5
         uploadShutdownTimeoutInSecs: 30
       hipposys:className: uk.nhs.digital.externalstorage.modules.S3ConnectorServiceRegistrationModule
       hipposys:cmsonly: true


### PR DESCRIPTION
Concurrently modified counters are now designated 'volatile' to prevent
the risk that different threads getting different values of the fields
in the shared instance.

Also, caps on the maximum numbers of concurrent downloads and uploads
via CMS have now been set to values concluded in the S3 integration
performance test.