### PR TITLE
[DW-366] GDPR transparency update who can access field

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-366-GdprUpdateWhoCanAccessField.groovy
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-366-GdprUpdateWhoCanAccessField.groovy
@@ -1,0 +1,76 @@
+package org.hippoecm.frontend.plugins.cms.admin.updater
+
+import org.hippoecm.repository.util.JcrUtils
+import org.onehippo.repository.update.BaseNodeUpdateVisitor
+
+import javax.jcr.Node
+import javax.jcr.NodeIterator
+
+/**
+ * Document type updated whocanaccess field from String to Rich Text.
+ * This script copies data from old field to new, and removes old field
+ */
+class GdprUpdateWhoCanAccessField extends BaseNodeUpdateVisitor {
+
+    private static final String PROPERTY_GDPR_WHOCANACCESS_OLD = "website:whocanaccess"
+    private static final String PROPERTY_GDPR_WHOCANACCESS_NEW = "website:whocanaccessinfo"
+
+    boolean doUpdate(Node node) {
+
+        // Query returns the hippo:handle node for the document
+        // (which has the 3 variants)
+        try {
+            if (node.hasNodes()) {
+                return updateFieldAndSaveDocument(node)
+            }
+        } catch (e) {
+            log.error("Failed to process record.", e)
+        }
+
+        return false
+    }
+
+    boolean updateFieldAndSaveDocument(Node parentHippoHandleNode) {
+
+        NodeIterator nodeIterator = parentHippoHandleNode.getNodes()
+        int variantsUpdated = 0
+
+        // Iterate through each variant
+        while(nodeIterator.hasNext()) {
+            Node n = nodeIterator.nextNode()
+            String path = n.getPath()
+
+            JcrUtils.ensureIsCheckedOut(n)
+            if (!n.hasProperty(PROPERTY_GDPR_WHOCANACCESS_OLD)) {
+                continue
+            }
+
+            String currentValue
+            currentValue = n.getProperty(PROPERTY_GDPR_WHOCANACCESS_OLD).getString()
+
+            log.info("attempting to update node: " + path)
+
+            // Does node already have this new property?  If so skip.
+            if (n.hasNode(PROPERTY_GDPR_WHOCANACCESS_NEW)) {
+                log.info("New property already exists. Skipping : " + path)
+                continue
+            }
+
+            // create new html whocanaccess node property and assign current value
+            def newNode = n.addNode(PROPERTY_GDPR_WHOCANACCESS_NEW, "hippostd:html")
+            newNode.setProperty("hippostd:content", "<p>" + currentValue + "</p>")
+
+            // Remove old whocanaccess property
+            n.getProperty(PROPERTY_GDPR_WHOCANACCESS_OLD).remove()
+
+            log.info("UPDATED GDPR Transparency who can access field for:" + path)
+            variantsUpdated += 1
+        }
+
+        return variantsUpdated > 0
+    }
+
+    boolean undoUpdate(Node node) {
+        throw new UnsupportedOperationException('Updater does not implement undoUpdate method')
+    }
+}

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-366-GdprUpdateWhoCanAccessField.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-366-GdprUpdateWhoCanAccessField.yaml
@@ -1,0 +1,15 @@
+---
+definitions:
+  config:
+    /hippo:configuration/hippo:update/hippo:registry/DW-366-GdprUpdateWhoCanAccessField:
+      hipposys:batchsize: 10
+      hipposys:description: ''
+      hipposys:dryrun: false
+      hipposys:loglevel: DEBUG
+      hipposys:parameters: '{}'
+      hipposys:query: /jcr:root/content/documents/corporate-website//*[@jcr:primaryType='website:gdprtransparency']//..
+      hipposys:script:
+        resource: /configuration/update/DW-366-GdprUpdateWhoCanAccessField.groovy
+        type: string
+      hipposys:throttle: 500
+      jcr:primaryType: hipposys:updaterinfo

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/website/gdprtransparency.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/website/gdprtransparency.yaml
@@ -168,14 +168,14 @@ definitions:
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
             wicket.id: ${cluster.id}.field
-          /whocanaccess:
+          /whocanaccessinfo:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
             caption: Who can access
-            field: whocanaccess
+            field: whocanaccessinfo
             hint: ''
             jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
             wicket.id: ${cluster.id}.field
           /items:
             /cluster.options:
@@ -353,13 +353,13 @@ definitions:
             - non-empty
             - required
             jcr:primaryType: hipposysedit:field
-          /whocanaccess:
+          /whocanaccessinfo:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
             hipposysedit:ordered: false
-            hipposysedit:path: website:whocanaccess
+            hipposysedit:path: website:whocanaccessinfo
             hipposysedit:primary: false
-            hipposysedit:type: String
+            hipposysedit:type: hippostd:html
             jcr:primaryType: hipposysedit:field
           /withdrawconsent:
             hipposysedit:mandatory: false
@@ -389,6 +389,9 @@ definitions:
             website:alternativeurls: []
             website:destination: ''
           /website:legallywhy:
+            hippostd:content: ''
+            jcr:primaryType: hippostd:html
+          /website:whocanaccessinfo:
             hippostd:content: ''
             jcr:primaryType: hippostd:html
           /website:withdrawconsent:
@@ -424,7 +427,6 @@ definitions:
           website:summary: ''
           website:timeretained: ''
           website:title: ''
-          website:whocanaccess: ''
         jcr:primaryType: hipposysedit:prototypeset
       jcr:mixinTypes:
       - editor:editable

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/gdpr-article.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/gdpr-article.ftl
@@ -43,7 +43,7 @@
                                     <td><@fmt.message key="labels.data-controller"/></td>
                                     <td>${document.datacontroller}</td>
                                 </tr>
-                                
+
                                 <tr>
                                     <td><@fmt.message key="labels.how-info-is-used"/></td>
                                     <td>${document.howuseinformation}</td>
@@ -54,13 +54,15 @@
                                     <td>${document.sensitivity?then("Yes", "No")}</td>
                                 </tr>
 
-                                <#if document.whocanaccess?has_content>
+                                <#if document.whocanaccessinfo?? && document.whocanaccessinfo.content?has_content>
                                 <tr>
                                     <td><@fmt.message key="labels.who-has-access"/></td>
-                                    <td>${document.whocanaccess}</td>
+                                    <td>
+                                        <@hst.html hippohtml=document.whocanaccessinfo contentRewriter=gaContentRewriter/>
+                                    </td>
                                 </tr>
                                 </#if>
-                                
+
                                 <tr>
                                     <td><@fmt.message key="labels.transferred-outside-uk"/></td>
                                     <td>${document.outsideuk}</td>
@@ -72,21 +74,21 @@
                                     <td>${document.timeretained}</td>
                                 </tr>
                                 </#if>
-                                
+
                                 <#if document.lawfulbasis?has_content>
                                 <tr>
                                     <td><@fmt.message key="labels.lawful-basis"/></td>
                                     <td>${lawfulbasis[document.lawfulbasis]}</td>
                                 </tr>
                                 </#if>
-                                
+
                                 <tr>
                                     <td><@fmt.message key="labels.your-rights"/></td>
                                     <td>
                                         <ul class="checklist checklist--condensed">
                                             <#list rights?keys as key>
                                                 <@fmt.message key="urls.${key}" var="url"/>
-                                                
+
                                                 <li class="checklist__item">
                                                     <#if document.rights?seq_contains(key)>
                                                         <img src="<@hst.webfile path="images/icon-tick.png"/>" alt="Tick" class="checklist__icon checklist__icon--small" width="24"/>
@@ -99,7 +101,7 @@
                                                     <#else>
                                                         <span class="checklist__label">${rights[key]}<span>
                                                     </#if>
-                                                </li>                                                
+                                                </li>
                                             </#list>
                                         </ul>
                                     </td>
@@ -138,7 +140,7 @@
                         </table>
                     </div>
                 </div>
-                
+
                 <#-- [FTL-BEGIN] 'Links' section -->
                 <#if document.blocks?? && document.blocks?size!=0>
                 <div class="article-section">

--- a/site/src/main/java/uk/nhs/digital/website/beans/Gdprtransparency.java
+++ b/site/src/main/java/uk/nhs/digital/website/beans/Gdprtransparency.java
@@ -79,9 +79,9 @@ public class Gdprtransparency extends BaseDocument {
         return getProperty("website:computerdecision");
     }
 
-    @HippoEssentialsGenerated(internalName = "website:whocanaccess")
-    public String getWhocanaccess() {
-        return getProperty("website:whocanaccess");
+    @HippoEssentialsGenerated(internalName = "website:whocanaccessinfo")
+    public HippoHtml getWhocanaccessinfo() {
+        return getHippoHtml("website:whocanaccessinfo");
     }
 
     @HippoEssentialsGenerated(internalName = "website:withdrawconsent")


### PR DESCRIPTION
Update GDPR Transparency document type to change the 'who can
access' field from a String field to a Rich Text field. Add groovy
script which copies values over from old field to new field.