### PR TITLE
[DW-490] Add Links list to search results and other UI updates

### DIFF
--- a/cms/src/main/java/uk/nhs/digital/repository/schedulers/ConditionalFormDataCleanupJob.java
+++ b/cms/src/main/java/uk/nhs/digital/repository/schedulers/ConditionalFormDataCleanupJob.java
@@ -30,7 +30,7 @@ public class ConditionalFormDataCleanupJob implements RepositoryJob {
 
     @Override
     public void execute(final RepositoryJobExecutionContext context) throws RepositoryException {
-        log.info("Running form data cleanup job");
+        log.warn("Running form data cleanup job");
         final Session session = context.createSystemSession();
         try {
             long minutesToLive = Long.parseLong(context.getAttribute(CONFIG_MINUTES_TO_LIVE));
@@ -81,6 +81,9 @@ public class ConditionalFormDataCleanupJob implements RepositoryJob {
                         });
                         //fetching the eforms_process_done
                         FormField formField = emp.get("eforms_process_done");
+                        if (formField == null) {
+                            continue outer;
+                        }
                         List<String> valueList = formField.getValueList();
                         if (valueList.isEmpty() || valueList.stream().allMatch(t -> t.toLowerCase().equals("false"))) {
                             //in case the valueList is empty or the one of the values is false, something went wrong with the one of the form data behavior
@@ -92,7 +95,7 @@ public class ConditionalFormDataCleanupJob implements RepositoryJob {
                     }
                 }
 
-                log.debug("Removing form data item at {}", node.getPath());
+                log.warn("Form data cleanup item: {}", node.getPath());
                 remove(node, 2);
                 if (count++ % batchSize == 0) {
                     session.save();

--- a/conf/query/lucene/indexing_configuration.xml
+++ b/conf/query/lucene/indexing_configuration.xml
@@ -130,6 +130,15 @@ https://wiki.apache.org/jackrabbit/IndexingConfiguration
         <property isRegexp="true" nodeScopeIndex="false">.*:.*</property>
     </index-rule>
 
+    <index-rule nodeType="website:componentlist">
+        <property>website:title</property>
+        <property>website:summary</property>
+        <property>website:shortsummary</property>
+        <property>website:seosummary</property>
+        <property>website:body</property>
+        <property isRegexp="true" nodeScopeIndex="false">.*:.*</property>
+    </index-rule>
+
     <!-- hippo aggregates -->
     <aggregates>
         <nodetype>hippostd:html</nodetype>

--- a/repository-data/application/src/main/resources/hcm-config/configuration/modules/scheduler.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/modules/scheduler.yaml
@@ -8,7 +8,7 @@ definitions:
       - /formdata/permanent/
       hipposched:repositoryJobClass: uk.nhs.digital.repository.schedulers.ConditionalFormDataCleanupJob
     /hippo:configuration/hippo:modules/scheduler/hippo:moduleconfig/system/FormDataCleanup/hipposched:triggers/bi-hourly:
-      hipposched:cronExpression: 0 30 0/2 * * ?
+      hipposched:cronExpression: 0 0/30 * * * ?
       hipposched:enabled: true
       hipposched:nextFireTime: 2018-07-03T12:30:00Z
       jcr:mixinTypes:

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/website/componentlist.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/website/componentlist.yaml
@@ -211,6 +211,7 @@ definitions:
             jcr:primaryType: website:friendlyurls
             website:alternativeurls: []
             website:destination: ''
+          common:searchRank: 3
           common:searchable: true
           hippostd:holder: holder
           hippostd:state: draft

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/alphabeticalGroupOfGDPRDocuments.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/alphabeticalGroupOfGDPRDocuments.ftl
@@ -12,7 +12,7 @@
     <#if gdprDocumentGroups[letter]??>
     <#assign matchesFound++ />
 
-    <div class="article-section article-section--letter-group" id="section-${letter}">
+    <div class="article-section article-section--letter-group" id="${slugify(letter)}">
         <div class="grid-row sticky sticky--top">
             <div class="column column--reset">
                 <div class="article-header article-header--tertiary">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/hubBox.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/hubBox.ftl
@@ -34,8 +34,8 @@
                 <#list options.types as type>
                     <li class="tag">${type}</li>
                 </#list>
-                </#if>
                 </ul>
+                </#if>
             </div>
         </article>
     </#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/hubPageComponents.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/hubPageComponents.ftl
@@ -10,7 +10,7 @@
 <div class="article-section article-section--hub-component">
     <div class="grid-row">
         <div class="column column--two-thirds column--left">
-            <div class="rich-text-content">
+            <div class="rich-text-content" id="${slugify(component.title)}">
                 <@hst.html hippohtml=component.component contentRewriter=gaContentRewriter/>
             </div>
 

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/results.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/results.ftl
@@ -31,6 +31,8 @@
                 <@publishedwork item=document />
             <#elseif document.class.name == "uk.nhs.digital.website.beans.Publishedworkchapter">
                 <@publishedworkchapter item=document />
+            <#elseif document.class.name == "uk.nhs.digital.website.beans.ComponentList">
+                <@componentlist item=document />
             </#if>
         </#list>
     </div>
@@ -54,7 +56,7 @@
         </#if>
 
         <div>
-            <h3 class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.publication"/></h3>
+            <span class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.publication"/></span>
         </div>
 
         <a class="cta__title cta__button" href="<@hst.link hippobean=item.selfLinkBean/>" title="${item.title}" data-uipath="ps.search-results.result.title">
@@ -86,7 +88,7 @@
 <#macro legacypublication item>
     <div class="cta cta--detailed" data-uipath="ps.search-results.result">
         <div>
-            <h3 class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.publication"/></h3>
+            <span class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.publication"/></span>
         </div>
         <a class="cta__title cta__button" href="<@hst.link hippobean=item.selfLinkBean/>" title="${item.title}" data-uipath="ps.search-results.result.title">
             ${item.title}
@@ -98,7 +100,7 @@
 <#macro series item>
     <div class="cta cta--detailed" data-uipath="ps.search-results.result">
         <div>
-            <h3 class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.series"/></h3>
+            <span class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.series"/></span>
         </div>
         <a class="cta__title cta__button" href="<@hst.link hippobean=item.selfLinkBean/>" title="${item.title}" data-uipath="ps.search-results.result.title">
             ${item.title}
@@ -119,7 +121,7 @@
 <#macro archive item>
     <div class="cta cta--detailed" data-uipath="ps.search-results.result">
         <div>
-            <h3 class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.archive"/></h3>
+            <span class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.archive"/></span>
         </div>
         <a class="cta__title cta__button" href="<@hst.link hippobean=item.selfLinkBean/>" title="${item.title}" data-uipath="ps.search-results.result.title">
             ${item.title}
@@ -131,7 +133,7 @@
 <#macro dataset item>
     <div class="cta cta--detailed" data-uipath="ps.search-results.result">
         <div>
-            <h3 class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.dataset"/></h3>
+            <span class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.dataset"/></span>
         </div>
         <a class="cta__title cta__button" href="<@hst.link hippobean=item.selfLinkBean/>" title="${item.title}" data-uipath="ps.search-results.result.title">
             ${item.title}
@@ -144,7 +146,7 @@
 <#macro indicator item>
     <div class="cta cta--detailed" data-uipath="ps.search-results.result">
         <div>
-            <h3 class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.indicator"/></h3>
+            <span class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.indicator"/></span>
         </div>
         <a class="cta__title cta__button" href="<@hst.link hippobean=item.selfLinkBean/>" title="${item.title}" data-uipath="ps.search-results.result.title">
                 ${item.title}
@@ -176,7 +178,7 @@
 <#macro service item>
     <div class="cta cta--detailed" data-uipath="ps.search-results.result">
         <div>
-            <h3 class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.service"/></h3>
+            <span class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.service"/></span>
         </div>
         <a class="cta__title cta__button" href="<@hst.link hippobean=item/>" title="${item.title}" data-uipath="ps.search-results.result.title">
             ${item.title}
@@ -197,7 +199,7 @@
 <#macro event item>
     <div class="cta cta--detailed" data-uipath="ps.search-results.result">
         <div>
-            <h3 class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.event"/></h3>
+            <span class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.event"/></span>
         </div>
         <a class="cta__title cta__button" href="<@hst.link hippobean=item/>" title="${item.title}" data-uipath="ps.search-results.result.title">
             ${item.title}
@@ -226,7 +228,7 @@
 <#macro news item>
     <div class="cta cta--detailed" data-uipath="ps.search-results.result">
         <div>
-            <h3 class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.news"/></h3>
+            <span class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.news"/></span>
         </div>
         <a class="cta__title cta__button" href="<@hst.link hippobean=item/>" title="${item.title}" data-uipath="ps.search-results.result.title">
             ${item.title}
@@ -249,7 +251,7 @@
 <#macro gdpr item>
     <div class="cta cta--detailed" data-uipath="ps.search-results.result">
         <div>
-            <h3 class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.gdpr"/></h3>
+            <span class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.gdpr"/></span>
         </div>
         <a class="cta__title cta__button" href="<@hst.link hippobean=item/>" title="${item.title}" data-uipath="ps.search-results.result.title">
             ${item.title}
@@ -261,7 +263,7 @@
 <#macro publishedwork item>
 <div class="cta cta--detailed" data-uipath="ps.search-results.result">
     <div>
-        <h3 class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.publishedwork"/></h3>
+        <span class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.publishedwork"/></span>
     </div>
     <a class="cta__title cta__button" href="<@hst.link hippobean=item/>" title="${item.title}" data-uipath="ps.search-results.result.title">
         ${item.title}
@@ -274,11 +276,23 @@
 <#macro publishedworkchapter item>
 <div class="cta cta--detailed" data-uipath="ps.search-results.result">
     <div>
-        <h3 class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.publishedworkchapter"/></h3>
+        <span class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.publishedworkchapter"/></span>
     </div>
     <a class="cta__title cta__button" href="<@hst.link hippobean=item/>" title="${item.title}" data-uipath="ps.search-results.result.title">
         ${item.title}
     </a>
     <p class="cta__text" data-uipath="ps.search-results.result.summary"><@truncate text=item.shortsummary size="300"/></p>
+</div>
+</#macro>
+
+<#macro componentlist item>
+
+<div class="cta cta--detailed" data-uipath="ps.search-results.result">
+    <div class="cta cta--detailed" data-uipath="ps.search-results.result">
+        <a class="cta__title cta__button" href="<@hst.link hippobean=item/>" title="${item.title}" data-uipath="ps.search-results.result.title">
+            ${item.title}
+        </a>
+        <p class="cta__text" data-uipath="ps.search-results.result.summary"><@truncate text=item.shortsummary size="300"/></p>
+    </div>
 </div>
 </#macro>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/site-footer.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/site-footer.ftl
@@ -71,7 +71,7 @@
                                     <ul class="list list--inline list--reset">
                                         <li>
                                             <a href="https://www.linkedin.com/company/nhs-digital" onClick="${getOnClickMethodCall('Footer', 'https://www.linkedin.com/company/nhs-digital')}" onKeyUp="return vjsu.onKeyUp(event)">
-                                                <img src="<@hst.webfile  path="images/icon-linkedin.png"/>" alt="Linkedin logo" class="image-icon" /><span>LinkedIn</span>
+                                                <img src="<@hst.webfile  path="images/icon-linkedin.png"/>" alt="LinkedIn logo" class="image-icon" /><span>LinkedIn</span>
                                             </a>
                                         </li>
                                         <li>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/macro/publicationHeader.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/macro/publicationHeader.ftl
@@ -95,7 +95,7 @@
     </div>
 
     <#if !restricted && publication.pageIndex?has_content>
-        <div class="grid-wrapper grid-row" data-uipath="ps.publication.pages">
+        <div class="grid-wrapper grid-row grid-wrapper--article" data-uipath="ps.publication.pages">
             <#assign chunks=publication.pageIndex?chunk((publication.pageIndex?size/2)?ceiling)/>
 
             <div class="column column--one-half column--left">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/publicationsystem/publication.ftl
@@ -48,7 +48,7 @@
 <#macro fullContentOfPubliclyAvailablePublication>
     <@publicationHeader publication=publication/>
 
-    <div class="grid-wrapper grid-wrapper--article <#if publication.pages?has_content>article-section</#if>" aria-label="Document Content">
+    <div class="grid-wrapper grid-wrapper--article aria-label="Document Content">
         <div class="grid-row">
             <#if index?has_content && index?size gt 1>
             <div class="column column--one-third page-block page-block--sidebar article-section-nav-outer-wrapper">

--- a/site/src/main/java/uk/nhs/digital/common/components/SearchComponent.java
+++ b/site/src/main/java/uk/nhs/digital/common/components/SearchComponent.java
@@ -369,6 +369,15 @@ public class SearchComponent extends CommonComponent {
     }
 
     /**
+     * Adding the Link List (ComponentList) document type
+     */
+    private void addComponentList(HstQueryBuilder query) {
+        query.ofTypes(
+            ComponentList.class
+        );
+    }
+
+    /**
      * Adding all the document types supported by the SearchComponent
      */
     private void addAllTypes(HstQueryBuilder query) {
@@ -380,6 +389,7 @@ public class SearchComponent extends CommonComponent {
         addGdprTypes(query);
         addPublishedWork(query);
         addPublishedWorkChapter(query);
+        addComponentList(query);
     }
 
 }


### PR DESCRIPTION
Add ComponentList doc type to search results, and other fixes which
include:

DW-491 Fix spelling of LinkedIn on image Alt text in footer
DW-453 Anchor links not working on certain pages
DW-495 Remove H3 Doctype indicators in search
DW-496 Closing unopened ul tag
DW-416 UI - A-Z navigation broken on GDPR summary page
DW-504 Fix sticky nav on publications with pages
DW-302 Fix forms cleanup job