### PR TITLE
[DW-489] DW-510 Reduce GDPR searchRank and update old LinkList docs

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-489-gdpr-results-too-high-in-search-results.groovy
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-489-gdpr-results-too-high-in-search-results.groovy
@@ -1,0 +1,66 @@
+package org.hippoecm.frontend.plugins.cms.admin.updater
+
+import org.hippoecm.repository.util.JcrUtils
+import org.onehippo.repository.update.BaseNodeUpdateVisitor
+
+import javax.jcr.Node
+import javax.jcr.NodeIterator
+import javax.jcr.Session
+import javax.jcr.Value
+
+/**
+ * Update GDPR transparency documents, changing their
+ * common:searchRank from 5 to 2.
+ */
+class GdprDocumentsTooHighInSearchResults extends BaseNodeUpdateVisitor {
+
+    private static final String COMMON_SEARCHRANK_PROPERTY = "common:searchRank"
+    Session session
+
+    void initialize(Session session) {
+        this.session = session
+    }
+
+    boolean doUpdate(Node node) {
+
+        // Query returns the hippo:handle node for the document
+        // (which has the 3 variants)
+        try {
+            if (node.hasNodes()) {
+                return updateFieldAndSaveDocument(node)
+            }
+        } catch (e) {
+            log.error("Failed to process record.", e)
+        }
+
+        return false
+    }
+
+
+    boolean updateFieldAndSaveDocument(Node parentHippoHandleNode) {
+
+        NodeIterator nodeIterator = parentHippoHandleNode.getNodes()
+        int variantsUpdated = 0
+
+        // Iterate through each variant
+        while(nodeIterator.hasNext()) {
+            Node n = nodeIterator.nextNode()
+
+            log.info("attempting to update node: " + n.getPath())
+
+            JcrUtils.ensureIsCheckedOut(n)
+            if (n.hasProperty(COMMON_SEARCHRANK_PROPERTY)) {
+                n.getProperty(COMMON_SEARCHRANK_PROPERTY).remove()
+            }
+            n.setProperty(COMMON_SEARCHRANK_PROPERTY, 2l)
+
+            variantsUpdated += 1
+        }
+
+        return variantsUpdated > 0
+    }
+
+    boolean undoUpdate(Node node) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-489-gdpr-results-too-high-in-search-results.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-489-gdpr-results-too-high-in-search-results.yaml
@@ -1,0 +1,14 @@
+---
+definitions:
+  config:
+    /hippo:configuration/hippo:update/hippo:registry/DW-489-gdpr-results-too-high-in-search-results:
+      hipposys:batchsize: 10
+      hipposys:description: ''
+      hipposys:dryrun: false
+      hipposys:parameters: ''
+      hipposys:query: /jcr:root/content/documents/corporate-website//*[@jcr:primaryType='website:gdprtransparency']//..
+      hipposys:script:
+        resource: /configuration/update/DW-489-gdpr-results-too-high-in-search-results.groovy
+        type: string
+      hipposys:throttle: 200
+      jcr:primaryType: hipposys:updaterinfo

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-510-update-links-list-doc-type-search-rank.groovy
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-510-update-links-list-doc-type-search-rank.groovy
@@ -1,0 +1,65 @@
+package org.hippoecm.frontend.plugins.cms.admin.updater
+
+import org.hippoecm.repository.util.JcrUtils
+import org.onehippo.repository.update.BaseNodeUpdateVisitor
+
+import javax.jcr.Node
+import javax.jcr.NodeIterator
+import javax.jcr.Session
+
+/**
+ * Update Link Lists (componentlist) documents, setting a
+ * common:searchRank of 3.
+ */
+class UpdateLinksListDocTypeSearchRank extends BaseNodeUpdateVisitor {
+
+    private static final String COMMON_SEARCHRANK_PROPERTY = "common:searchRank"
+    Session session
+
+    void initialize(Session session) {
+        this.session = session
+    }
+
+    boolean doUpdate(Node node) {
+
+        // Query returns the hippo:handle node for the document
+        // (which has the 3 variants)
+        try {
+            if (node.hasNodes()) {
+                return updateFieldAndSaveDocument(node)
+            }
+        } catch (e) {
+            log.error("Failed to process record.", e)
+        }
+
+        return false
+    }
+
+
+    boolean updateFieldAndSaveDocument(Node parentHippoHandleNode) {
+
+        NodeIterator nodeIterator = parentHippoHandleNode.getNodes()
+        int variantsUpdated = 0
+
+        // Iterate through each variant
+        while(nodeIterator.hasNext()) {
+            Node n = nodeIterator.nextNode()
+
+            log.info("attempting to update node: " + n.getPath())
+
+            JcrUtils.ensureIsCheckedOut(n)
+            if (n.hasProperty(COMMON_SEARCHRANK_PROPERTY)) {
+                n.getProperty(COMMON_SEARCHRANK_PROPERTY).remove()
+            }
+            n.setProperty(COMMON_SEARCHRANK_PROPERTY, 3l)
+
+            variantsUpdated += 1
+        }
+
+        return variantsUpdated > 0
+    }
+
+    boolean undoUpdate(Node node) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-510-update-links-list-doc-type-search-rank.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-510-update-links-list-doc-type-search-rank.yaml
@@ -1,0 +1,14 @@
+---
+definitions:
+  config:
+    /hippo:configuration/hippo:update/hippo:registry/DW-510-update-links-list-doc-type-search-rank:
+      hipposys:batchsize: 10
+      hipposys:description: ''
+      hipposys:dryrun: false
+      hipposys:parameters: ''
+      hipposys:query: /jcr:root/content/documents/corporate-website//*[@jcr:primaryType='website:componentlist']//..
+      hipposys:script:
+        resource: /configuration/update/DW-510-update-links-list-doc-type-search-rank.groovy
+        type: string
+      hipposys:throttle: 200
+      jcr:primaryType: hipposys:updaterinfo


### PR DESCRIPTION
Add groovy script to reduce common:searchRank property of
GDPR transparency documents from 5 to 2 as these were incorrectly
set on mass import. The GDPR transparency document type is already
correctly set to 2.

DW-510 script to update old Links List doc types to include
search rank property