### PR TITLE
[DW-557] Script to remove old migration link

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-557-remove-migration-broken-link.groovy
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-557-remove-migration-broken-link.groovy
@@ -1,0 +1,39 @@
+package org.hippoecm.frontend.plugins.cms.admin.updater
+
+import org.hippoecm.repository.util.JcrUtils
+import org.onehippo.repository.update.BaseNodeUpdateVisitor
+
+import javax.jcr.Node
+import javax.jcr.Session
+
+/**
+ * Remove one of the broken links brought over by the migration
+ */
+class RemoveMigrationBrokenLink extends BaseNodeUpdateVisitor {
+
+    Session session
+
+    void initialize(Session session) {
+        this.session = session
+    }
+
+    boolean doUpdate(Node n) {
+
+        try {
+            log.info("attempting to remove node: " + n.getPath())
+
+            JcrUtils.ensureIsCheckedOut(n)
+            n.remove()
+
+            return true
+        } catch (e) {
+            log.error("Failed to process record.", e)
+        }
+
+        return false
+    }
+
+    boolean undoUpdate(Node node) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-557-remove-migration-broken-link.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-557-remove-migration-broken-link.yaml
@@ -1,0 +1,14 @@
+---
+definitions:
+  config:
+    /hippo:configuration/hippo:update/hippo:registry/DW-557-remove-migration-broken-link:
+      hipposys:batchsize: 20
+      hipposys:description: ''
+      hipposys:dryrun: false
+      hipposys:parameters: ''
+      hipposys:query: //element(*, publicationsystem:relatedlink)[@publicationsystem:linkUrl='http://www.hscic.gov.uk/article/1165/Search-catalogue?q=title:']
+      hipposys:script:
+        resource: /configuration/update/DW-557-remove-migration-broken-link.groovy
+        type: string
+      hipposys:throttle: 200
+      jcr:primaryType: hipposys:updaterinfo


### PR DESCRIPTION
Remove instances of the following URL, which was created from
the migration:
http://www.hscic.gov.uk/article/1165/Search-catalogue?q=title: