### PR TITLE
[DW-693] Add Lucene index export service to project

### DIFF
--- a/cms/pom.xml
+++ b/cms/pom.xml
@@ -245,6 +245,11 @@
             <artifactId>hippo-addon-targeting-bundle-collectors</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.onehippo.cms7</groupId>
+            <artifactId>hippo-addon-lucene-export</artifactId>
+        </dependency>
+
     </dependencies>
     <build>
         <finalName>cms</finalName>


### PR DESCRIPTION
This is required to enable packaged distribution uploads to
the new BloomReach Cloud