### PR TITLE
[DW-737] Adds download styling to more doctypes

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/event-article.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/event-article.ftl
@@ -1,12 +1,18 @@
 <#ftl output_format="HTML">
+
 <#-- @ftlvariable name="document" type="uk.nhs.digital.website.beans.Event" -->
+<#-- @ftlvariable name="event" type="uk.nhs.digital.website.beans.Interval" -->
+
 <#include "../include/imports.ftl">
-<#-- Add meta tags -->
 <#include "macro/metaTags.ftl">
-<@metaTags></@metaTags>
+<#include "../common/macro/fileMetaAppendix.ftl">
+<#include "../common/macro/fileIcon.ftl">
 
 <@hst.setBundle basename="site.website.labels"/>
 <@fmt.message key="child-pages-section.title" var="childPagesSectionTitle"/>
+
+
+<@metaTags></@metaTags>
 
 <#macro schemaMeta title startTimeData = '' endTimeData = ''>
     <#-- [BEGIN] Schema microdata -->
@@ -91,7 +97,7 @@
                                             </dl>
                                         </div>
 
-                                        <@schemaMeta "${document.title}" event.startdatetime.time event.enddatetime.time />
+                                        <@schemaMeta "${document.title}" event.startdatetime.time?date event.enddatetime.time?date_if_unknown />
                                     </#if>
                                 </div>
                             </#list>
@@ -137,17 +143,16 @@
                         <#if event.enddatetime.time?date gt .now?date>
                             <#assign hasFutureEvent = true>
                         </#if>
+                        <#if document.booking?has_content>
+                            <#if hasFutureEvent>
+                                ${event.startdatetime.time?date}
+                                <div class="article-section">
+                                    <#assign onClickMethodCall = getOnClickMethodCall(document.class.name, document.booking) />
+                                    <a class="button" href="${document.booking}" onClick="${onClickMethodCall}" onKeyUp="return vjsu.onKeyUp(event)">Book Now</a>
+                                </div>
+                            </#if>
+                        </#if>
                     </#list>
-                </#if>
-
-                <#if document.booking?has_content>
-                    <#if hasFutureEvent>
-                        ${event.startdatetime.time}
-                        <div class="article-section">
-                            <#assign onClickMethodCall = getOnClickMethodCall(document.class.name, document.booking) />
-                            <a class="button" href="${document.booking}" onClick="${onClickMethodCall}" onKeyUp="return vjsu.onKeyUp(event)">Book Now</a>
-                        </div>
-                    </#if>
                 </#if>
 
                 <#if document.summaryimage?? && document.summaryimage.original??>
@@ -174,13 +179,26 @@
                 <#if document.extAttachments?has_content>
                     <div class="article-section" id="resources">
                         <h2>Resources</h2>
-                        <ul class="list">
+                        <ul class="list list--reset">
                             <#list document.extAttachments as attachment>
                                 <li class="attachment" itemprop="hasPart" itemscope itemtype="http://schema.org/MediaObject">
                                     <@externalstorageLink attachment.resource; url>
-                                        <a title="${attachment.text}" href="${url}" onClick="logGoogleAnalyticsEvent('Download attachment','Publication','${attachment.resource.filename}');" onKeyUp="return vjsu.onKeyUp(event)" itemprop="contentUrl"><span itemprop="name">${attachment.text}</span></a>;
+                                        <a title="${attachment.text}"
+                                           href="${url}"
+                                           class="block-link"
+                                           onClick="logGoogleAnalyticsEvent('Download attachment','Publication','${attachment.resource.filename}');"
+                                           onKeyUp="return vjsu.onKeyUp(event)"
+                                           itemprop="contentUrl">
+                                            <div class="block-link__header">
+                                                <@fileIcon attachment.resource.mimeType></@fileIcon>
+                                            </div>
+                                            <div class="block-link__body">
+                                                <span class="block-link__title" itemprop="name">${attachment.text}</span>
+                                                <@fileMetaAppendix attachment.resource.length, attachment.resource.mimeType></@fileMetaAppendix>
+                                            </div>
+
+                                        </a>
                                     </@externalstorageLink>
-                                    <span class="fileSize">[size: <span itemprop="contentSize"><@formatFileSize bytesCount=attachment.resource.length/></span>]</span>
                                 </li>
                             </#list>
                         </ul>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/list-article/unordered-list-article.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/list-article/unordered-list-article.ftl
@@ -6,6 +6,7 @@
 <#include "../macro/fileMetaAppendix.ftl">
 <#include "../macro/typeSpan.ftl">
 <#include "../macro/component/lastModified.ftl">
+<#include "../macro/fileIcon.ftl">
 
 <article class="article article--list">
     <div class="grid-wrapper grid-wrapper--article">
@@ -39,9 +40,9 @@
                 <div class="article-section article-section--list">
                     <div class="grid-row">
                         <div class="column column--two-thirds column--reset">
-                            <div class="list list--reset cta-list cta-list--sections">
+                            <ul class="list list--reset cta-list cta-list--sections">
                                 <#list document.blocks as block>
-                                <div class="cta">  
+                                <li class="cta">
                                     <#if block.linkType??>
                                         <@typeSpan block.linkType />
                                         
@@ -53,12 +54,23 @@
                                             <h2 class="cta__title"><a href="${block.link}" onClick="${onClickMethodCall}" onKeyUp="return vjsu.onKeyUp(event)">${block.title}</a></h2>
                                             <p class="cta__text">${block.shortsummary}</p>
                                         <#elseif block.linkType == "asset">
-                                            <h2 class="cta__title"><a href="<@hst.link hippobean=block.link />" onClick="${onClickMethodCall}" onKeyUp="return vjsu.onKeyUp(event)">${block.title}</a><@fileMetaAppendix block.link.asset.getLength()></@fileMetaAppendix></h2>
+                                            <a href="<@hst.link hippobean=block.link />"
+                                               class="block-link"
+                                               onClick="${onClickMethodCall}"
+                                               onKeyUp="return vjsu.onKeyUp(event)">
+                                                <div class="block-link__header">
+                                                    <@fileIcon block.link.asset.mimeType></@fileIcon>
+                                                </div>
+                                                <div class="block-link__body">
+                                                    <span class="block-link__title">${block.title}</span>
+                                                    <@fileMetaAppendix block.link.asset.getLength()></@fileMetaAppendix>
+                                                </div>
+                                            </a>
                                         </#if>
                                     </#if>
-                                </div>
+                                </li>
                                 </#list>
-                            </div>
+                            </ul>
                         </div>
                     </div>
                 </div>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/childPageGrid.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/childPageGrid.ftl
@@ -2,6 +2,7 @@
 <#include "../../include/imports.ftl">
 <#include "fileMetaAppendix.ftl">
 <#include "typeSpan.ftl">
+<#include "fileIcon.ftl">
 
 <#macro childPageGrid childPages>
 <#if childPages?has_content>
@@ -20,7 +21,18 @@
                     <#if childPage.linkType == "external">
                         <h2 class="cta__title"><a href="${childPage.link}" onClick="${onClickMethodCall}" onKeyUp="return vjsu.onKeyUp(event)">${childPage.title}</a></h2>
                     <#elseif childPage.linkType == "asset">
-                        <h2 class="cta__title"><a href="<@hst.link hippobean=childPage.link />" onClick="${onClickMethodCall}" onKeyUp="return vjsu.onKeyUp(event)">${childPage.title}</a><@fileMetaAppendix childPage.link.asset.getLength()></@fileMetaAppendix></h2>
+                        <a href="<@hst.link hippobean=childPage.link />"
+                           class="block-link"
+                           onClick="${onClickMethodCall}"
+                           onKeyUp="return vjsu.onKeyUp(event)">
+                            <div class="block-link__header">
+                                <@fileIcon childPage.link.asset.mimeType></@fileIcon>
+                            </div>
+                            <div class="block-link__body">
+                                <span class="block-link__title">${childPage.title}</span>
+                                <@fileMetaAppendix childPage.link.asset.getLength()></@fileMetaAppendix>
+                            </div>
+                        </a>
                     </#if>
                 <#elseif hst.isBeanType(childPage, 'org.hippoecm.hst.content.beans.standard.HippoBean')>
                     <@typeSpan "internal" />

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/furtherInformationSection.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/furtherInformationSection.ftl
@@ -1,7 +1,9 @@
 <#ftl output_format="HTML">
 <#include "fileMetaAppendix.ftl">
 <#include "typeSpan.ftl">
+<#include "fileIcon.ftl">
 <@hst.setBundle basename="rb.generic.headers"/>
+<#-- @ftlvariable name="childPages" type="java.util.List<uk.nhs.digital.common.components.DocumentChildComponent>" -->
 
 <#macro furtherInformationSection childPages>
     <#-- BEGIN optional 'Further information section' -->
@@ -11,31 +13,54 @@
         <ol class="list list--reset cta-list">
             <#list childPages as childPage>
                 <li>
-                    <article class="cta cta--hf">
-                        <#if childPage.linkType??>
-                            <#assign onClickMethodCall = getOnClickMethodCall(document.class.name, childPage.link) />
+                    <#-- If external link -->
+                    <#if childPage.linkType??>
 
-                            <@typeSpan childPage.linkType />
+                        <#assign onClickMethodCall = getOnClickMethodCall(document.class.name, childPage.link) />
+                        <@typeSpan childPage.linkType />
 
-                            <#if childPage.linkType == "external">
+                        <#if childPage.linkType == "external">
+                            <article class="cta cta--hf">
                                 <h2 class="cta__title"><a href="${childPage.link}" onClick="${onClickMethodCall}" onKeyUp="return vjsu.onKeyUp(event)">${childPage.title}</a></h2>
-                            <#elseif childPage.linkType == "asset">
-                                <h2 class="cta__title">
-                                    <a href="<@hst.link hippobean=childPage.link />" onClick="${onClickMethodCall}" onKeyUp="return vjsu.onKeyUp(event)">${childPage.title}</a><@fileMetaAppendix childPage.link.asset.getLength(), childPage.link.asset.mimeType></@fileMetaAppendix>
-                                </h2>
+                                <#if childPage.shortsummary?? && childPage.shortsummary?has_content>
+                                    <p class="cta__text">${childPage.shortsummary}</p>
+                                </#if>
+                            </article>
+                        </#if>
+
+                    <#-- If internal link -->
+                    <#elseif hst.isBeanType(childPage, 'org.hippoecm.hst.content.beans.standard.HippoBean')>
+                        <article class="cta cta--hf">
+                        <@typeSpan "internal" />
+                        <h2 class="cta__title"><a href="<@hst.link var=link hippobean=childPage />">${childPage.title}</a></h2>
+                            <#if childPage.shortsummary?? && childPage.shortsummary?has_content>
+                                <p class="cta__text">${childPage.shortsummary}</p>
                             </#if>
-                        <#elseif hst.isBeanType(childPage, 'org.hippoecm.hst.content.beans.standard.HippoBean')>
-                            <@typeSpan "internal" />
-
-                            <h2 class="cta__title"><a href="<@hst.link var=link hippobean=childPage />">${childPage.title}</a></h2>
-                        </#if>
-
-                        <#if childPage.shortsummary?? && childPage.shortsummary?has_content>
-                            <p class="cta__text">${childPage.shortsummary}</p>
-                        </#if>
-                    </article>
+                        </article>
+                    </#if>
                 </li>
             </#list>
+        </ol>
+
+        <ol class="list list--reset">
+        <#list childPages as childPage>
+            <li>
+                <#if childPage.linkType??>
+                    <#-- If asset link -->
+                    <#if childPage.linkType == "asset">
+                        <a href="<@hst.link hippobean=childPage.link />" class="block-link" onClick="${onClickMethodCall}" onKeyUp="return vjsu.onKeyUp(event)">
+                            <div class="block-link__header">
+                                <@fileIcon childPage.link.asset.mimeType></@fileIcon>
+                            </div>
+                            <div class="block-link__body">
+                                <span class="block-link__title">${childPage.title}</span>
+                                <@fileMetaAppendix childPage.link.asset.getLength(), childPage.link.asset.mimeType></@fileMetaAppendix>
+                            </div>
+                        </a>
+                    </#if>
+                </#if>
+            </li>
+        </#list>
         </ol>
     </div>
     </#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/published-work-article.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/published-work-article.ftl
@@ -7,6 +7,8 @@
 <#include "../common/macro/component/lastModified.ftl">
 <#include "macro/sectionNav.ftl">
 <#include "macro/metaTags.ftl">
+<#include "../common/macro/fileMetaAppendix.ftl">
+<#include "../common/macro/fileIcon.ftl">
 
 <#-- Add meta tags -->
 <@metaTags></@metaTags>
@@ -234,20 +236,32 @@
                 <#if hasResources>
                     <div class="article-section" id="resources">
                         <h2><@fmt.message key="labels.resources"/></h2>
-                        <ul class="list">
+                        <ul class="list list--reset">
                             <#list document.resources as attachment>
                                 <li class="attachment" itemprop="hasPart" itemscope itemtype="http://schema.org/MediaObject">
                                     <@externalstorageLink attachment.resource; url>
-                                        <a title="${attachment.text}" href="${url}" onClick="logGoogleAnalyticsEvent('Download attachment','Publication','${attachment.resource.filename}');" onKeyUp="return vjsu.onKeyUp(event)" itemprop="contentUrl"><span itemprop="name">${attachment.text}</span></a>;
+                                        <a title="${attachment.text}"
+                                           href="${url}"
+                                           class="block-link"
+                                           onClick="logGoogleAnalyticsEvent('Download attachment','Publication','${attachment.resource.filename}');"
+                                           onKeyUp="return vjsu.onKeyUp(event)"
+                                           itemprop="contentUrl">
+                                            <div class="block-link__header">
+                                                <@fileIcon attachment.resource.mimeType></@fileIcon>
+                                            </div>
+                                            <div class="block-link__body">
+                                                <span class="block-link__title" itemprop="name">${attachment.text}</span>
+                                                <@fileMetaAppendix attachment.resource.length, attachment.resource.mimeType></@fileMetaAppendix>
+                                            </div>
+                                        </a>
                                     </@externalstorageLink>
-                                    <span class="fileSize">[size: <span itemprop="contentSize"><@formatFileSize bytesCount=attachment.resource.length/></span>]</span>
                                 </li>
                             </#list>
                         </ul>
                     </div>
                 </#if>
-                <div class="article-section muted no-border no-top-padding no-top-margin">
-                    <@lastModified document.lastModified false></@lastModified>
+                <div class="article-section muted">
+                    <p><@lastModified document.lastModified false></@lastModified></p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
@GeoffHayward @ngta1 

Can you take a look at this one? The block link style has been applied to the remaining templates and styling amended. In terms of the story I am done. I think there needs to be a tidy up ticket as a follow up to this one. At the moment the block links are all output in lists. Each item is counted as part of the list even when it sits outside of the specific list.