### PR TITLE
[DW-643] A to Z glossary list doc type

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/SitePage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/SitePage.java
@@ -40,6 +40,7 @@ public class SitePage extends AbstractSitePage {
         pagesElements.add(new DatasetPageElements());
         pagesElements.add(new IndicatorPageElements());
         pagesElements.add(new GeneralPageElements());
+        pagesElements.add(new ContentBlockElements());
         pagesElements.add(new ServicePageElements());
         pagesElements.add(new HubPageElements());
         pagesElements.add(new PublishedWorkPageElements());

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/website/ContentBlockElements.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/website/ContentBlockElements.java
@@ -1,0 +1,68 @@
+package uk.nhs.digital.ps.test.acceptance.pages.site.website;
+
+import static uk.nhs.digital.ps.test.acceptance.pages.site.website.ContentBlockElements.FieldKeys.EMPHASIS_CONENT;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.website.ContentBlockElements.FieldKeys.EMPHASIS_HEADING;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.website.ContentBlockElements.FieldKeys.SECTION_CONTENT;
+import static uk.nhs.digital.ps.test.acceptance.pages.site.website.ContentBlockElements.FieldKeys.SECTION_TITLE;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import uk.nhs.digital.ps.test.acceptance.pages.PageHelper;
+import uk.nhs.digital.ps.test.acceptance.pages.site.PageElements;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ContentBlockElements implements PageElements {
+
+    private static final Map<String, By> pageElements = new HashMap<String, By>() {
+        {
+            put(SECTION_TITLE,
+                By.xpath("//*[" + getDataUiPathXpath("section.title") + "]"));
+            put(SECTION_CONTENT,
+                By.xpath("//*[" + getDataUiPathXpath("section.content") + "]"));
+            put(EMPHASIS_HEADING,
+                By.xpath("//*[" + getDataUiPathXpath("emphasis.heading") + "]"));
+            put(EMPHASIS_CONENT,
+                By.xpath("//*[" + getDataUiPathXpath("emphasis.content") + "]"));
+
+        }
+    };
+
+    public static By getFieldSelector(final String fieldSelectorKey) {
+        return pageElements.get(fieldSelectorKey);
+    }
+
+    private static String getDataUiPathXpath(String fieldName) {
+        return "@data-uipath='website.contentblock." + fieldName + "'";
+    }
+
+    @Override
+    public boolean contains(String elementName) {
+        return pageElements.containsKey(elementName);
+    }
+
+    @Override
+    public WebElement getElementByName(String elementName, PageHelper helper) {
+        return getElementByName(elementName, 0, helper);
+    }
+
+    public WebElement getElementByName(String elementName, int nth, PageHelper helper) {
+        List<WebElement> elements = helper.findOptionalElements(pageElements.get(elementName));
+
+        if (elements.size() == 0) {
+            return null;
+        }
+
+        return elements.get(nth);
+    }
+
+    interface FieldKeys {
+
+        String SECTION_TITLE = "Section Title";
+        String SECTION_CONTENT = "Section Content";
+        String EMPHASIS_HEADING = "Emphasis Box Heading";
+        String EMPHASIS_CONENT = "Emphasis Box Content";
+    }
+}

--- a/acceptance-tests/src/test/resources/features/site/contentBlocks.feature
+++ b/acceptance-tests/src/test/resources/features/site/contentBlocks.feature
@@ -1,0 +1,9 @@
+Feature: Ensure content block sections display required fields.
+
+    Scenario: Check 'Section' and 'Emphasis box' content blocks
+        Given I navigate to the "General test document" page
+        Then I should see:
+            | Section Title             | Section One                           |
+            | Section Content           | General Section One lorem content ... |
+            | Emphasis Box Heading      | Important note heading                |
+            | Emphasis Box Content      | Some important note in the content ...|

--- a/repository-data/application/src/main/resources/hcm-config/configuration/frontend/settings.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/frontend/settings.yaml
@@ -1,0 +1,5 @@
+---
+definitions:
+  config:
+    /hippo:configuration/hippo:frontend/settings:
+      send.usage.statistics.to.hippo: false

--- a/repository-data/application/src/main/resources/hcm-config/configuration/queries/templates/new-digital-website-document.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/queries/templates/new-digital-website-document.yaml
@@ -29,4 +29,4 @@ definitions:
         or @jcr:primaryType='website:hub' or @jcr:primaryType='website:news' or @jcr:primaryType='website:service'
         or @jcr:primaryType='website:publishedwork' or @jcr:primaryType='website:publishedworkchapter'
         or @jcr:primaryType='website:generalnonsearch' or @jcr:primaryType='website:roadmap'
-        or @jcr:primaryType='website:roadmapitem']
+        or @jcr:primaryType='website:roadmapitem' or @jcr:primaryType='website:glossarylist']

--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/templates.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/templates.yaml
@@ -68,6 +68,11 @@ definitions:
           jcr:name: Text
           jcr:primaryType: hipposys:resourcebundle
         jcr:primaryType: hipposys:resourcebundles
+      /website:assetlink:
+        /en:
+          jcr:name: Related file
+          jcr:primaryType: hipposys:resourcebundle
+        jcr:primaryType: hipposys:resourcebundles
       /website:bannerdocument:
         /en:
           jcr:name: Banner
@@ -88,6 +93,21 @@ definitions:
           jcr:name: Emphasis Box
           jcr:primaryType: hipposys:resourcebundle
         jcr:primaryType: hipposys:resourcebundles
+      /website:externallinkbase:
+        /en:
+          jcr:name: External link
+          jcr:primaryType: hipposys:resourcebundle
+        jcr:primaryType: hipposys:resourcebundles
+      /website:galleryitem:
+        /en:
+          jcr:name: Gallery Item
+          jcr:primaryType: hipposys:resourcebundle
+        jcr:primaryType: hipposys:resourcebundles
+      /website:gallerysection:
+        /en:
+          jcr:name: Gallery Section
+          jcr:primaryType: hipposys:resourcebundle
+        jcr:primaryType: hipposys:resourcebundles
       /website:general:
         /en:
           jcr:name: General
@@ -98,9 +118,29 @@ definitions:
           jcr:name: General non searchable
           jcr:primaryType: hipposys:resourcebundle
         jcr:primaryType: hipposys:resourcebundles
+      /website:glossaryitem:
+        /en:
+          jcr:name: Glossary item
+          jcr:primaryType: hipposys:resourcebundle
+        jcr:primaryType: hipposys:resourcebundles
+      /website:glossarylist:
+        /en:
+          jcr:name: Glossary list
+          jcr:primaryType: hipposys:resourcebundle
+        jcr:primaryType: hipposys:resourcebundles
       /website:hub:
         /en:
           jcr:name: Hub
+          jcr:primaryType: hipposys:resourcebundle
+        jcr:primaryType: hipposys:resourcebundles
+      /website:iconlist:
+        /en:
+          jcr:name: Icon list
+          jcr:primaryType: hipposys:resourcebundle
+        jcr:primaryType: hipposys:resourcebundles
+      /website:iconlistitem:
+        /en:
+          jcr:name: Icon list item
           jcr:primaryType: hipposys:resourcebundle
         jcr:primaryType: hipposys:resourcebundles
       /website:publishedwork:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/pages/glossarylist.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/pages/glossarylist.yaml
@@ -1,0 +1,10 @@
+---
+definitions:
+  config:
+    /hst:hst/hst:configurations/common/hst:pages/glossarylist:
+      /main:
+        hst:componentclassname: uk.nhs.digital.common.components.DocumentChildComponent
+        hst:template: glossary-list
+        jcr:primaryType: hst:component
+      hst:referencecomponent: hst:abstractpages/apppage
+      jcr:primaryType: hst:component

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
@@ -19,6 +19,7 @@ definitions:
           - website:generalnonsearch
           - website:roadmap
           - website:roadmapitem
+          - website:glossarylist
           hst:componentconfigurationmappingvalues:
           - hst:pages/service
           - hst:pages/general
@@ -33,6 +34,7 @@ definitions:
           - hst:pages/general
           - hst:pages/roadmap
           - hst:pages/roadmapitem
+          - hst:pages/glossarylist
           hst:relativecontentpath: ${parent}/content
           jcr:primaryType: hst:sitemapitem
         hst:componentconfigurationid: hst:pages/404
@@ -50,6 +52,7 @@ definitions:
         - website:generalnonsearch
         - website:roadmap
         - website:roadmapitem
+        - website:glossarylist
         hst:componentconfigurationmappingvalues:
         - hst:pages/service
         - hst:pages/general
@@ -64,6 +67,7 @@ definitions:
         - hst:pages/general
         - hst:pages/roadmap
         - hst:pages/roadmapitem
+        - hst:pages/glossarylist
         hst:relativecontentpath: ${1}
         jcr:primaryType: hst:sitemapitem
       /about:

--- a/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/hst/configurations/common/templates.yaml
@@ -68,6 +68,9 @@ definitions:
       /general-article:
         hst:renderpath: webfile:/freemarker/common/general-article.ftl
         jcr:primaryType: hst:template
+      /glossary-list:
+        hst:renderpath: webfile:/freemarker/common/glossary-list.ftl
+        jcr:primaryType: hst:template
       /homeland:
         hst:renderpath: webfile:/freemarker/common/homeland.ftl
         jcr:primaryType: hst:template

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publicationPage.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/publicationsystem/publicationPage.yaml
@@ -31,7 +31,7 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
             caption: Body
-            compoundList: publicationsystem:imageSection,publicationsystem:chartSection,publicationsystem:mapSection,publicationsystem:textSection,publicationsystem:relatedlink
+            compoundList: publicationsystem:imageSection,publicationsystem:chartSection,publicationsystem:mapSection,publicationsystem:textSection,publicationsystem:relatedlink,website:iconlist,website:gallerysection
             contentPickerType: links
             field: body
             hint: ''

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/website.cnd
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/website.cnd
@@ -34,7 +34,16 @@
 [website:externallink] > hippo:compound, hippostd:relaxed
   orderable
 
+[website:externallinkbase] > hippo:compound, hippostd:relaxed
+  orderable
+
 [website:friendlyurls] > hippo:compound, hippostd:relaxed
+  orderable
+
+[website:galleryitem] > hippo:compound, hippostd:relaxed
+  orderable
+
+[website:gallerysection] > hippo:compound, hippostd:relaxed
   orderable
 
 [website:gdprsummary] > hippostd:relaxed, hippotranslation:translated, website:basedocument
@@ -49,7 +58,19 @@
 [website:generalnonsearch] > hippostd:relaxed, hippotranslation:translated, website:basedocument
   orderable
 
+[website:glossaryitem] > hippo:compound, hippostd:relaxed
+  orderable
+
+[website:glossarylist] > hippostd:relaxed, hippotaxonomy:classifiable, hippotranslation:translated, website:basedocument
+  orderable
+
 [website:hub] > hippostd:relaxed, hippotranslation:translated, website:basedocument
+  orderable
+
+[website:iconlist] > hippo:compound, hippostd:relaxed
+  orderable
+
+[website:iconlistitem] > hippo:compound, hippostd:relaxed
   orderable
 
 [website:internallink] > hippo:compound, hippostd:relaxed

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/website/assetlink.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/website/assetlink.yaml
@@ -36,6 +36,7 @@ definitions:
               last.visited.nodetypes: []
               nodetypes:
               - hippogallery:exampleAssetSet
+              - hippogallery:imageset
             caption: Asset Link
             field: link
             hint: ''

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/website/externallinkbase.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/website/externallinkbase.yaml
@@ -1,7 +1,7 @@
 ---
 definitions:
   config:
-    /hippo:namespaces/website/externallink:
+    /hippo:namespaces/website/externallinkbase:
       /editor:templates:
         /_default_:
           jcr:primaryType: frontend:plugincluster
@@ -19,23 +19,6 @@ definitions:
             item: ${cluster.id}.field
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
-          /title:
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-            caption: Title
-            field: title
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.field
-          /shortsummary:
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-            caption: Summary
-            field: shortsummary
-            hint: ''
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.field
           /link:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
@@ -60,28 +43,6 @@ definitions:
             - required
             - valid-url
             jcr:primaryType: hipposysedit:field
-          /shortsummary:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: website:shortsummary
-            hipposysedit:primary: false
-            hipposysedit:type: Text
-            hipposysedit:validators:
-            - non-empty
-            - required
-            jcr:primaryType: hipposysedit:field
-          /title:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: website:title
-            hipposysedit:primary: false
-            hipposysedit:type: String
-            hipposysedit:validators:
-            - non-empty
-            - required
-            jcr:primaryType: hipposysedit:field
           hipposysedit:node: true
           hipposysedit:supertype:
           - hippo:compound
@@ -96,10 +57,8 @@ definitions:
         jcr:primaryType: hippo:handle
       /hipposysedit:prototypes:
         /hipposysedit:prototype:
-          jcr:primaryType: website:externallink
+          jcr:primaryType: website:externallinkbase
           website:link: ''
-          website:shortsummary: ''
-          website:title: ''
         jcr:primaryType: hipposysedit:prototypeset
       jcr:mixinTypes:
       - editor:editable

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/website/galleryitem.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/website/galleryitem.yaml
@@ -1,7 +1,7 @@
 ---
 definitions:
   config:
-    /hippo:namespaces/website/emphasisBox:
+    /hippo:namespaces/website/galleryitem:
       /editor:templates:
         /_default_:
           jcr:primaryType: frontend:plugincluster
@@ -33,88 +33,63 @@ definitions:
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
             wicket.id: ${cluster.id}.right
-          /emphasisType:
+          /title:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-              selectable.options: Warning,Important,Emphasis,Note
-            caption: Type
-            field: emphasisType
-            hint: ''
+            caption: Title
+            field: title
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.css:
-            - emphasis-type
-            wicket.id: ${cluster.id}.right.item
-          /heading:
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-            caption: Heading
-            field: heading
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.css:
-            - heading
-            wicket.id: ${cluster.id}.left.item
-          /body:
-            /cluster.options:
-              ckeditor.config.appended.json: '{toolbarGroups: [{ name: ''document''}],
-                extraPlugins: ''balloonpanel,a11ychecker'', allowedContent: ''h2 h3
-                h4 em strong ul div thead tbody td tr th caption ol li sub sup img
-                a[*](*);p{text-align};table[class,id,dir]{*};iframe[id,class,style,title,height,name,src,width,allowfullscreen,sandbox,srcdoc]{*}'',
-                disallowedContent: ''iframe[frameborder]'', mathJaxLib: ''https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS_HTML''}}'
-              ckeditor.config.overlayed.json: '{linkShowAdvancedTab: true, extraPlugins:
-                ''wordcount,mathjax''}'
-              jcr:primaryType: frontend:pluginconfig
-            caption: Body
-            field: body
-            hint: ''
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
-            wicket.css:
-            - body
             wicket.id: ${cluster.id}.left.item
           /image:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-            caption: Icon image
+            caption: Image
             field: image
-            hint: SVG format only
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
-            wicket.css:
-            - image
             wicket.id: ${cluster.id}.right.item
+          /imagewarning:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+              maxlength: '20'
+            caption: Image warning
+            field: imagewarning
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.right.item
+          /description:
+            /cluster.options:
+              ckeditor.config.appended.json: '{toolbar: [{ name: ''summarytoolbar'',  items:
+                [''Link'',''PickInternalLink'',''Source''] }] }'
+              jcr:primaryType: frontend:pluginconfig
+            caption: Description
+            field: description
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.left.item
+          /relatedfiles:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Related files
+            compoundList: website:assetlink
+            contentPickerType: links
+            field: relatedfiles
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.onehippo.forge.contentblocks.ContentBlocksFieldPlugin
+            wicket.id: ${cluster.id}.left.item
         jcr:primaryType: editor:templateset
       /hipposysedit:nodetype:
         /hipposysedit:nodetype:
-          /body:
+          /description:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
             hipposysedit:ordered: false
-            hipposysedit:path: website:body
+            hipposysedit:path: website:description
             hipposysedit:primary: false
             hipposysedit:type: hippostd:html
-            hipposysedit:validators:
-            - required
-            jcr:primaryType: hipposysedit:field
-          /emphasisType:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: website:emphasisType
-            hipposysedit:primary: false
-            hipposysedit:type: StaticDropdown
-            hipposysedit:validators:
-            - non-empty
-            - required
-            jcr:primaryType: hipposysedit:field
-          /heading:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: website:heading
-            hipposysedit:primary: false
-            hipposysedit:type: String
             jcr:primaryType: hipposysedit:field
           /image:
             hipposysedit:mandatory: false
@@ -123,6 +98,33 @@ definitions:
             hipposysedit:path: website:image
             hipposysedit:primary: false
             hipposysedit:type: hippogallerypicker:imagelink
+            hipposysedit:validators:
+            - required
+            jcr:primaryType: hipposysedit:field
+          /imagewarning:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: website:imagewarning
+            hipposysedit:primary: false
+            hipposysedit:type: String
+            jcr:primaryType: hipposysedit:field
+          /relatedfiles:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: true
+            hipposysedit:ordered: false
+            hipposysedit:path: website:relatedfiles
+            hipposysedit:type: hippo:compound
+            hipposysedit:validators:
+            - contentblocks-validator
+            jcr:primaryType: hipposysedit:field
+          /title:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: website:title
+            hipposysedit:primary: false
+            hipposysedit:type: String
             jcr:primaryType: hipposysedit:field
           hipposysedit:node: true
           hipposysedit:supertype:
@@ -138,7 +140,7 @@ definitions:
         jcr:primaryType: hippo:handle
       /hipposysedit:prototypes:
         /hipposysedit:prototype:
-          /website:body:
+          /website:description:
             hippostd:content: ''
             jcr:primaryType: hippostd:html
           /website:image:
@@ -147,9 +149,9 @@ definitions:
             hippo:modes: []
             hippo:values: []
             jcr:primaryType: hippogallerypicker:imagelink
-          jcr:primaryType: website:emphasisBox
-          website:emphasisType: Emphasis
-          website:heading: ''
+          jcr:primaryType: website:galleryitem
+          website:imagewarning: ''
+          website:title: ''
         jcr:primaryType: hipposysedit:prototypeset
       jcr:mixinTypes:
       - editor:editable

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/website/gallerysection.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/website/gallerysection.yaml
@@ -1,7 +1,7 @@
 ---
 definitions:
   config:
-    /hippo:namespaces/website/externallink:
+    /hippo:namespaces/website/gallerysection:
       /editor:templates:
         /_default_:
           jcr:primaryType: frontend:plugincluster
@@ -19,68 +19,78 @@ definitions:
             item: ${cluster.id}.field
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
-          /title:
+          /heading:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-            caption: Title
-            field: title
+            caption: Heading
+            field: heading
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
-          /shortsummary:
+          /headinglevel:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-            caption: Summary
-            field: shortsummary
-            hint: ''
+              selectable.options: Main heading,Sub heading
+            caption: Heading level
+            field: headinglevel
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
-          /link:
+          /description:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-            caption: External Link
-            field: link
+            caption: Description
+            field: description
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /galleryitems:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Gallery Items
+            compoundList: website:galleryitem
+            contentPickerType: links
+            field: galleryitems
             hint: ''
             jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            plugin.class: org.onehippo.forge.contentblocks.ContentBlocksFieldPlugin
             wicket.id: ${cluster.id}.field
         jcr:primaryType: editor:templateset
       /hipposysedit:nodetype:
         /hipposysedit:nodetype:
-          /link:
+          /description:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
             hipposysedit:ordered: false
-            hipposysedit:path: website:link
+            hipposysedit:path: website:description
+            hipposysedit:primary: false
+            hipposysedit:type: hippostd:html
+            jcr:primaryType: hipposysedit:field
+          /galleryitems:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: true
+            hipposysedit:ordered: false
+            hipposysedit:path: website:galleryitems
+            hipposysedit:primary: false
+            hipposysedit:type: hippo:compound
+            hipposysedit:validators:
+            - contentblocks-validator
+            jcr:primaryType: hipposysedit:field
+          /heading:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: website:heading
             hipposysedit:primary: false
             hipposysedit:type: String
-            hipposysedit:validators:
-            - non-empty
-            - required
-            - valid-url
             jcr:primaryType: hipposysedit:field
-          /shortsummary:
+          /headinglevel:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
             hipposysedit:ordered: false
-            hipposysedit:path: website:shortsummary
+            hipposysedit:path: website:headinglevel
             hipposysedit:primary: false
-            hipposysedit:type: Text
-            hipposysedit:validators:
-            - non-empty
-            - required
-            jcr:primaryType: hipposysedit:field
-          /title:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: website:title
-            hipposysedit:primary: false
-            hipposysedit:type: String
-            hipposysedit:validators:
-            - non-empty
-            - required
+            hipposysedit:type: StaticDropdown
             jcr:primaryType: hipposysedit:field
           hipposysedit:node: true
           hipposysedit:supertype:
@@ -96,10 +106,24 @@ definitions:
         jcr:primaryType: hippo:handle
       /hipposysedit:prototypes:
         /hipposysedit:prototype:
-          jcr:primaryType: website:externallink
-          website:link: ''
-          website:shortsummary: ''
-          website:title: ''
+          /website:description:
+            hippostd:content: ''
+            jcr:primaryType: hippostd:html
+          /website:galleryitems:
+            /website:description:
+              hippostd:content: ''
+              jcr:primaryType: hippostd:html
+            /website:image:
+              hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+              hippo:facets: []
+              hippo:modes: []
+              hippo:values: []
+              jcr:primaryType: hippogallerypicker:imagelink
+            jcr:primaryType: website:galleryitem
+            website:imagewarning: ''
+            website:title: ''
+          jcr:primaryType: website:gallerysection
+          website:heading: ''
         jcr:primaryType: hipposysedit:prototypeset
       jcr:mixinTypes:
       - editor:editable

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/website/general.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/website/general.yaml
@@ -62,7 +62,7 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
             caption: Sections
-            compoundList: website:section,publicationsystem:chartSection,publicationsystem:mapSection,website:emphasisBox
+            compoundList: website:section,publicationsystem:chartSection,publicationsystem:mapSection,website:emphasisBox,website:iconlist,website:gallerysection
             contentPickerType: links
             field: sections
             hint: ''
@@ -148,6 +148,15 @@ definitions:
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
+          /pageicon:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Page icon (optional)
+            field: pageicon
+            hint: Only to be used under web team guidance
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.field
         jcr:primaryType: editor:templateset
       /hipposysedit:nodetype:
         /hipposysedit:nodetype:
@@ -200,6 +209,14 @@ definitions:
             hipposysedit:path: website:metadata
             hipposysedit:primary: false
             hipposysedit:type: String
+            jcr:primaryType: hipposysedit:field
+          /pageicon:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: website:pageicon
+            hipposysedit:primary: false
+            hipposysedit:type: hippogallerypicker:imagelink
             jcr:primaryType: hipposysedit:field
           /sections:
             hipposysedit:multiple: true
@@ -275,6 +292,12 @@ definitions:
             jcr:primaryType: website:friendlyurls
             website:alternativeurls: []
             website:destination: ''
+          /website:pageicon:
+            hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+            hippo:facets: []
+            hippo:modes: []
+            hippo:values: []
+            jcr:primaryType: hippogallerypicker:imagelink
           /website:summary:
             hippostd:content: ''
             jcr:primaryType: hippostd:html

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/website/glossaryitem.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/website/glossaryitem.yaml
@@ -1,7 +1,7 @@
 ---
 definitions:
   config:
-    /hippo:namespaces/website/externallink:
+    /hippo:namespaces/website/glossaryitem:
       /editor:templates:
         /_default_:
           jcr:primaryType: frontend:plugincluster
@@ -19,68 +19,63 @@ definitions:
             item: ${cluster.id}.field
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
-          /title:
+          /heading:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-            caption: Title
-            field: title
+            caption: Heading
+            field: heading
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
-          /shortsummary:
+          /definition:
             /cluster.options:
+              ckeditor.config.appended.json: '{toolbar: [{ name: ''summarytoolbar'',
+                items: [''Link'',''PickInternalLink'',''Source''] }] }'
+              ckeditor.config.overlayed.json: '{linkShowAdvancedTab: true, extraPlugins:''wordcount''}'
               jcr:primaryType: frontend:pluginconfig
-            caption: Summary
-            field: shortsummary
+            caption: Definition
+            field: definition
             hint: ''
             jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
             wicket.id: ${cluster.id}.field
-          /link:
+          /items:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-            caption: External Link
-            field: link
+            caption: Link
+            compoundList: website:externallinkbase,website:internallink
+            contentPickerType: links
+            field: items
             hint: ''
             jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            plugin.class: org.onehippo.forge.contentblocks.ContentBlocksFieldPlugin
             wicket.id: ${cluster.id}.field
         jcr:primaryType: editor:templateset
       /hipposysedit:nodetype:
         /hipposysedit:nodetype:
-          /link:
+          /definition:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
             hipposysedit:ordered: false
-            hipposysedit:path: website:link
+            hipposysedit:path: website:definition
+            hipposysedit:primary: false
+            hipposysedit:type: hippostd:html
+            jcr:primaryType: hipposysedit:field
+          /heading:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: website:heading
             hipposysedit:primary: false
             hipposysedit:type: String
-            hipposysedit:validators:
-            - non-empty
-            - required
-            - valid-url
             jcr:primaryType: hipposysedit:field
-          /shortsummary:
-            hipposysedit:mandatory: false
+          /items:
             hipposysedit:multiple: false
             hipposysedit:ordered: false
-            hipposysedit:path: website:shortsummary
-            hipposysedit:primary: false
-            hipposysedit:type: Text
+            hipposysedit:path: website:items
+            hipposysedit:type: hippo:compound
             hipposysedit:validators:
-            - non-empty
-            - required
-            jcr:primaryType: hipposysedit:field
-          /title:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: website:title
-            hipposysedit:primary: false
-            hipposysedit:type: String
-            hipposysedit:validators:
-            - non-empty
-            - required
+            - contentblocks-validator
             jcr:primaryType: hipposysedit:field
           hipposysedit:node: true
           hipposysedit:supertype:
@@ -88,18 +83,19 @@ definitions:
           - hippostd:relaxed
           hipposysedit:uri: http://digital.nhs.uk/jcr/website/nt/1.0
           jcr:mixinTypes:
-          - hipposysedit:remodel
           - mix:referenceable
+          - hipposysedit:remodel
           jcr:primaryType: hipposysedit:nodetype
         jcr:mixinTypes:
         - mix:referenceable
         jcr:primaryType: hippo:handle
       /hipposysedit:prototypes:
         /hipposysedit:prototype:
-          jcr:primaryType: website:externallink
-          website:link: ''
-          website:shortsummary: ''
-          website:title: ''
+          /website:definition:
+            hippostd:content: ''
+            jcr:primaryType: hippostd:html
+          jcr:primaryType: website:glossaryitem
+          website:heading: ''
         jcr:primaryType: hipposysedit:prototypeset
       jcr:mixinTypes:
       - editor:editable

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/website/glossarylist.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/website/glossarylist.yaml
@@ -1,7 +1,7 @@
 ---
 definitions:
   config:
-    /hippo:namespaces/website/publishedworkchapter:
+    /hippo:namespaces/website/glossarylist:
       /editor:templates:
         /_default_:
           jcr:primaryType: frontend:plugincluster
@@ -22,8 +22,10 @@ definitions:
           /title:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
+              maxlength: '120'
             caption: Title
             field: title
+            hint: ''
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
@@ -58,18 +60,26 @@ definitions:
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
-          /sections:
+          /indexpage:
+            /cluster.options:
+              falseLabel: 'No'
+              jcr:primaryType: frontend:pluginconfig
+              trueLabel: 'Yes'
+            caption: Index this page as a reference glossary
+            field: indexpage
+            hint: Select 'yes' if this is a list of defined glossary terms which people
+              might look up
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /glossaryitems:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-            caption: Sections
-            compoundList: website:section,publicationsystem:chartSection,publicationsystem:mapSection,website:emphasisBox,website:iconlist,website:gallerysection
-            contentPickerType: links
-            field: sections
-            hint: ''
+            caption: Glossary Items
+            field: glossaryitems
             jcr:primaryType: frontend:plugin
-            plugin.class: org.onehippo.forge.contentblocks.ContentBlocksFieldPlugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
             wicket.id: ${cluster.id}.field
-            wicket.skin: skin/content-blocks.css
           /classifiable:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
@@ -79,34 +89,24 @@ definitions:
             mixin: hippotaxonomy:classifiable
             plugin.class: org.hippoecm.frontend.editor.plugins.mixin.MixinLoaderPlugin
             wicket.id: ${cluster.id}.field
-          /friendlyurls:
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-            caption: Friendly URLs
-            field: friendlyurls
-            hint: ''
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
-            wicket.id: ${cluster.id}.field
         jcr:primaryType: editor:templateset
       /hipposysedit:nodetype:
         /hipposysedit:nodetype:
-          /friendlyurls:
+          /glossaryitems:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: true
+            hipposysedit:ordered: false
+            hipposysedit:path: website:glossaryitems
+            hipposysedit:primary: false
+            hipposysedit:type: website:glossaryitem
+            jcr:primaryType: hipposysedit:field
+          /indexpage:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
             hipposysedit:ordered: false
-            hipposysedit:path: website:friendlyurls
+            hipposysedit:path: website:indexpage
             hipposysedit:primary: false
-            hipposysedit:type: website:friendlyurls
-            jcr:primaryType: hipposysedit:field
-          /sections:
-            hipposysedit:multiple: true
-            hipposysedit:ordered: true
-            hipposysedit:path: website:sections
-            hipposysedit:primary: false
-            hipposysedit:type: hippo:compound
-            hipposysedit:validators:
-            - contentblocks-validator
+            hipposysedit:type: selection:BooleanRadioGroup
             jcr:primaryType: hipposysedit:field
           /seosummary:
             hipposysedit:mandatory: false
@@ -151,22 +151,18 @@ definitions:
           - hippotaxonomy:classifiable
           hipposysedit:uri: http://digital.nhs.uk/jcr/website/nt/1.0
           jcr:mixinTypes:
-          - mix:referenceable
           - hipposysedit:remodel
+          - mix:referenceable
           jcr:primaryType: hipposysedit:nodetype
         jcr:mixinTypes:
         - mix:referenceable
         jcr:primaryType: hippo:handle
       /hipposysedit:prototypes:
         /hipposysedit:prototype:
-          /website:friendlyurls:
-            jcr:primaryType: website:friendlyurls
-            website:alternativeurls: []
-            website:destination: ''
           /website:summary:
             hippostd:content: ''
             jcr:primaryType: hippostd:html
-          common:searchRank: 5
+          common:searchRank: 3
           common:searchable: true
           hippostd:holder: holder
           hippostd:state: draft
@@ -178,7 +174,8 @@ definitions:
           hippotranslation:locale: document-type-locale
           jcr:mixinTypes:
           - mix:referenceable
-          jcr:primaryType: website:publishedworkchapter
+          jcr:primaryType: website:glossarylist
+          website:indexpage: false
           website:seosummary: ''
           website:shortsummary: ''
           website:title: ''

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/website/iconlist.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/website/iconlist.yaml
@@ -1,7 +1,7 @@
 ---
 definitions:
   config:
-    /hippo:namespaces/website/externallink:
+    /hippo:namespaces/website/iconlist:
       /editor:templates:
         /_default_:
           jcr:primaryType: frontend:plugincluster
@@ -24,52 +24,31 @@ definitions:
               jcr:primaryType: frontend:pluginconfig
             caption: Title
             field: title
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.field
-          /shortsummary:
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-            caption: Summary
-            field: shortsummary
             hint: ''
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
-          /link:
+          /iconlistitems:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-            caption: External Link
-            field: link
-            hint: ''
+            caption: Icon list items
+            compoundList: website:iconlistitem
+            contentPickerType: links
+            field: iconlistitems
             jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            plugin.class: org.onehippo.forge.contentblocks.ContentBlocksFieldPlugin
             wicket.id: ${cluster.id}.field
         jcr:primaryType: editor:templateset
       /hipposysedit:nodetype:
         /hipposysedit:nodetype:
-          /link:
+          /iconlistitems:
             hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: website:link
-            hipposysedit:primary: false
-            hipposysedit:type: String
+            hipposysedit:multiple: true
+            hipposysedit:ordered: true
+            hipposysedit:path: website:iconlistitems
+            hipposysedit:type: hippo:compound
             hipposysedit:validators:
-            - non-empty
-            - required
-            - valid-url
-            jcr:primaryType: hipposysedit:field
-          /shortsummary:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: website:shortsummary
-            hipposysedit:primary: false
-            hipposysedit:type: Text
-            hipposysedit:validators:
-            - non-empty
-            - required
+            - contentblocks-validator
             jcr:primaryType: hipposysedit:field
           /title:
             hipposysedit:mandatory: false
@@ -78,9 +57,6 @@ definitions:
             hipposysedit:path: website:title
             hipposysedit:primary: false
             hipposysedit:type: String
-            hipposysedit:validators:
-            - non-empty
-            - required
             jcr:primaryType: hipposysedit:field
           hipposysedit:node: true
           hipposysedit:supertype:
@@ -96,9 +72,7 @@ definitions:
         jcr:primaryType: hippo:handle
       /hipposysedit:prototypes:
         /hipposysedit:prototype:
-          jcr:primaryType: website:externallink
-          website:link: ''
-          website:shortsummary: ''
+          jcr:primaryType: website:iconlist
           website:title: ''
         jcr:primaryType: hipposysedit:prototypeset
       jcr:mixinTypes:

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/website/iconlistitem.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/website/iconlistitem.yaml
@@ -1,7 +1,7 @@
 ---
 definitions:
   config:
-    /hippo:namespaces/website/externallink:
+    /hippo:namespaces/website/iconlistitem:
       /editor:templates:
         /_default_:
           jcr:primaryType: frontend:plugincluster
@@ -16,70 +16,83 @@ definitions:
           - wicket.id
           - validator.id
           /root:
-            item: ${cluster.id}.field
+            extension.left: ${cluster.id}.left
+            extension.right: ${cluster.id}.right
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.layout.TwoColumn
+            wicket.extensions:
+            - extension.left
+            - extension.right
+          /left:
+            item: ${cluster.id}.left.item
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
-          /title:
+            wicket.id: ${cluster.id}.left
+          /right:
+            item: ${cluster.id}.right.item
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+            wicket.id: ${cluster.id}.right
+          /heading:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-            caption: Title
-            field: title
+            caption: Heading
+            field: heading
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.field
-          /shortsummary:
+            wicket.id: ${cluster.id}.left.item
+          /description:
+            /cluster.options:
+              ckeditor.config.appended.json: '{toolbar: [{ name: ''summarytoolbar'',
+                items: [''Link'',''PickInternalLink'',''Source''] }] }'
+              ckeditor.config.overlayed.json: '{linkShowAdvancedTab: true, extraPlugins:''wordcount''}'
+              jcr:primaryType: frontend:pluginconfig
+            caption: Description
+            field: description
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.left.item
+          /image:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
-            caption: Summary
-            field: shortsummary
-            hint: ''
+            caption: Image
+            field: image
+            hint: SVG ONLY
             jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.field
-          /link:
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-            caption: External Link
-            field: link
-            hint: ''
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.field
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.right.item
         jcr:primaryType: editor:templateset
       /hipposysedit:nodetype:
         /hipposysedit:nodetype:
-          /link:
+          /description:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
             hipposysedit:ordered: false
-            hipposysedit:path: website:link
+            hipposysedit:path: website:description
+            hipposysedit:primary: false
+            hipposysedit:type: hippostd:html
+            hipposysedit:validators:
+            - required
+            jcr:primaryType: hipposysedit:field
+          /heading:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: website:heading
             hipposysedit:primary: false
             hipposysedit:type: String
             hipposysedit:validators:
             - non-empty
             - required
-            - valid-url
             jcr:primaryType: hipposysedit:field
-          /shortsummary:
+          /image:
             hipposysedit:mandatory: false
             hipposysedit:multiple: false
             hipposysedit:ordered: false
-            hipposysedit:path: website:shortsummary
+            hipposysedit:path: website:image
             hipposysedit:primary: false
-            hipposysedit:type: Text
+            hipposysedit:type: hippogallerypicker:imagelink
             hipposysedit:validators:
-            - non-empty
-            - required
-            jcr:primaryType: hipposysedit:field
-          /title:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: website:title
-            hipposysedit:primary: false
-            hipposysedit:type: String
-            hipposysedit:validators:
-            - non-empty
             - required
             jcr:primaryType: hipposysedit:field
           hipposysedit:node: true
@@ -96,10 +109,17 @@ definitions:
         jcr:primaryType: hippo:handle
       /hipposysedit:prototypes:
         /hipposysedit:prototype:
-          jcr:primaryType: website:externallink
-          website:link: ''
-          website:shortsummary: ''
-          website:title: ''
+          /website:description:
+            hippostd:content: ''
+            jcr:primaryType: hippostd:html
+          /website:image:
+            hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+            hippo:facets: []
+            hippo:modes: []
+            hippo:values: []
+            jcr:primaryType: hippogallerypicker:imagelink
+          jcr:primaryType: website:iconlistitem
+          website:heading: ''
         jcr:primaryType: hipposysedit:prototypeset
       jcr:mixinTypes:
       - editor:editable

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/website/publishedwork.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/website/publishedwork.yaml
@@ -162,7 +162,7 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
             caption: Sections
-            compoundList: website:section,publicationsystem:chartSection,publicationsystem:mapSection,website:emphasisBox
+            compoundList: website:section,publicationsystem:chartSection,publicationsystem:mapSection,website:emphasisBox,website:gallerysection
             contentPickerType: links
             field: sections
             hint: ''

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/website/service.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/website/service.yaml
@@ -83,7 +83,7 @@ definitions:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
             caption: Sections
-            compoundList: website:section,publicationsystem:chartSection,publicationsystem:mapSection,website:emphasisBox
+            compoundList: website:section,publicationsystem:chartSection,publicationsystem:mapSection,website:emphasisBox,website:iconlist,website:gallerysection
             contentPickerType: links
             field: sections
             hint: ''

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/website/general-type.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/website/general-type.yaml
@@ -71,6 +71,10 @@
       selection:label: Service
     /selection:listitem[18]:
       jcr:primaryType: selection:listitem
+      selection:key: style-guide
+      selection:label: Style guide
+    /selection:listitem[19]:
+      jcr:primaryType: selection:listitem
       selection:key: tool
       selection:label: Tool
     hippo:availability:

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/administration/website/labels.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/administration/website/labels.yaml
@@ -18,10 +18,12 @@
     - labels.service
     - labels.roadmap
     - labels.roadmapitem
+    - labels.glossarylist
     resourcebundle:messages:
     - Service
     - Roadmap
     - Roadmap Item
+    - Glossary list
   /labels[2]:
     hippo:availability: []
     hippostd:state: draft
@@ -39,10 +41,12 @@
     - labels.service
     - labels.roadmap
     - labels.roadmapitem
+    - labels.glossarylist
     resourcebundle:messages:
     - Service
     - Roadmap
     - Roadmap Item
+    - Glossary list
   /labels[3]:
     hippo:availability:
     - live
@@ -62,10 +66,12 @@
     - labels.service
     - labels.roadmap
     - labels.roadmapitem
+    - labels.glossarylist
     resourcebundle:messages:
     - Service
     - Roadmap
     - Roadmap Item
+    - Glossary list
   hippo:name: Labels
   jcr:mixinTypes:
   - hippo:named

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/website-acceptance-tests.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/website-acceptance-tests.yaml
@@ -304,7 +304,13 @@
         website:link: https://www.bbc.co.uk
         website:shortsummary: some summary text
         website:title: General external link
-      /website:sections:
+      /website:pageicon:
+        hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+        hippo:facets: []
+        hippo:modes: []
+        hippo:values: []
+        jcr:primaryType: hippogallerypicker:imagelink
+      /website:sections[1]:
         /website:html:
           hippostd:content: <p>General Section One lorem content</p>
           jcr:primaryType: hippostd:html
@@ -312,6 +318,22 @@
         website:numberedList: false
         website:title: Section One
         website:type: ''
+      /website:sections[2]:
+        /website:body:
+          hippostd:content: |-
+            <h3>Some important note in&nbsp;the content</h3>
+
+            <p>add some content here.</p>
+          jcr:primaryType: hippostd:html
+        /website:image:
+          hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+          hippo:facets: []
+          hippo:modes: []
+          hippo:values: []
+          jcr:primaryType: hippogallerypicker:imagelink
+        jcr:primaryType: website:emphasisBox
+        website:emphasisType: Emphasis
+        website:heading: Important note heading
       /website:summary:
         hippostd:content: |-
           <p>General Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
@@ -326,7 +348,7 @@
       hippostd:state: draft
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2018-10-26T08:47:16.366Z
-      hippostdpubwf:lastModificationDate: 2018-10-26T10:47:05.260Z
+      hippostdpubwf:lastModificationDate: 2019-03-12T12:09:53.465Z
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: 6684c917-2061-438a-949a-ac0ffe6b10a1
       hippotranslation:locale: en
@@ -352,7 +374,13 @@
         website:link: https://www.bbc.co.uk
         website:shortsummary: some summary text
         website:title: General external link
-      /website:sections:
+      /website:pageicon:
+        hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+        hippo:facets: []
+        hippo:modes: []
+        hippo:values: []
+        jcr:primaryType: hippogallerypicker:imagelink
+      /website:sections[1]:
         /website:html:
           hippostd:content: <p>General Section One lorem content</p>
           jcr:primaryType: hippostd:html
@@ -360,6 +388,22 @@
         website:numberedList: false
         website:title: Section One
         website:type: ''
+      /website:sections[2]:
+        /website:body:
+          hippostd:content: |-
+            <h3>Some important note in&nbsp;the content</h3>
+
+            <p>add some content here.</p>
+          jcr:primaryType: hippostd:html
+        /website:image:
+          hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+          hippo:facets: []
+          hippo:modes: []
+          hippo:values: []
+          jcr:primaryType: hippogallerypicker:imagelink
+        jcr:primaryType: website:emphasisBox
+        website:emphasisType: Emphasis
+        website:heading: Important note heading
       /website:summary:
         hippostd:content: |-
           <p>General Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
@@ -375,7 +419,7 @@
       hippostd:state: unpublished
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2018-10-26T08:47:16.366Z
-      hippostdpubwf:lastModificationDate: 2018-10-26T10:47:10.488Z
+      hippostdpubwf:lastModificationDate: 2019-03-12T12:07:58.549Z
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: 6684c917-2061-438a-949a-ac0ffe6b10a1
       hippotranslation:locale: en
@@ -402,7 +446,13 @@
         website:link: https://www.bbc.co.uk
         website:shortsummary: some summary text
         website:title: General external link
-      /website:sections:
+      /website:pageicon:
+        hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+        hippo:facets: []
+        hippo:modes: []
+        hippo:values: []
+        jcr:primaryType: hippogallerypicker:imagelink
+      /website:sections[1]:
         /website:html:
           hippostd:content: <p>General Section One lorem content</p>
           jcr:primaryType: hippostd:html
@@ -410,6 +460,22 @@
         website:numberedList: false
         website:title: Section One
         website:type: ''
+      /website:sections[2]:
+        /website:body:
+          hippostd:content: |-
+            <h3>Some important note in&nbsp;the content</h3>
+
+            <p>add some content here.</p>
+          jcr:primaryType: hippostd:html
+        /website:image:
+          hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+          hippo:facets: []
+          hippo:modes: []
+          hippo:values: []
+          jcr:primaryType: hippogallerypicker:imagelink
+        jcr:primaryType: website:emphasisBox
+        website:emphasisType: Emphasis
+        website:heading: Important note heading
       /website:summary:
         hippostd:content: |-
           <p>General Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
@@ -425,9 +491,9 @@
       hippostd:state: published
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2018-10-26T08:47:16.366Z
-      hippostdpubwf:lastModificationDate: 2018-10-26T10:47:10.488Z
+      hippostdpubwf:lastModificationDate: 2019-03-12T12:07:58.549Z
       hippostdpubwf:lastModifiedBy: admin
-      hippostdpubwf:publicationDate: 2018-10-26T10:47:13.005Z
+      hippostdpubwf:publicationDate: 2019-03-12T12:08:03.548Z
       hippotranslation:id: 6684c917-2061-438a-949a-ac0ffe6b10a1
       hippotranslation:locale: en
       jcr:mixinTypes:
@@ -440,8 +506,10 @@
       website:title: General AcceptanceTestDocument
       website:type: guidance
     hippo:name: General test document
+    hippo:versionHistory: cbe60b6b-5d01-4fc0-94ff-dbc5d7b1121a
     jcr:mixinTypes:
     - hippo:named
+    - hippo:versionInfo
     - mix:referenceable
     jcr:primaryType: hippo:handle
   /hub-test-document:

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/general-article.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/general-article.ftl
@@ -23,6 +23,8 @@
 <#assign hasSummaryContent = document.summary.content?has_content />
 <#assign hasSectionContent = document.sections?has_content />
 <#assign hasChildPages = childPages?has_content />
+<#assign hasHtmlCode = document.htmlCode?has_content />
+<#assign hasPageIcon = document.pageIcon?has_content />
 <#assign sectionTitlesFound = countSectionTitles(document.sections) />
 <#assign renderNav = ((hasSummaryContent || hasChildPages) && sectionTitlesFound gte 1) || sectionTitlesFound gt 1 || (hasSummaryContent && hasChildPages) />
 
@@ -71,4 +73,6 @@
     </div>
 </article>
 
-${document.htmlCode?no_esc}
+<#if hasHtmlCode>
+    ${document.htmlCode?no_esc}
+</#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/glossary-list.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/glossary-list.ftl
@@ -1,0 +1,47 @@
+<#ftl output_format="HTML">
+
+<#-- @ftlvariable name="document" type="uk.nhs.digital.website.beans.GlossaryList" -->
+
+<#include "../include/imports.ftl">
+<#include "macro/metaTags.ftl">
+<#include "macro/component/lastModified.ftl">
+
+<#-- Add meta tags -->
+<@metaTags></@metaTags>
+
+<@hst.setBundle basename="rb.generic.headers,publicationsystem.headers"/>
+
+<#assign hasSummaryContent = document.summary.content?has_content />
+
+
+<#-- TODO: Complete frontend display
+
+<article class="article article--general">
+    <div class="grid-wrapper grid-wrapper--article">
+        <div class="grid-row">
+            <div class="column column--reset">
+                <div class="local-header article-header">
+                    <h1 class="local-header__title" data-uipath="document.title">${document.title}</h1>
+                </div>
+            </div>
+        </div>
+
+        <div class="grid-row">
+
+            <div class="column column--two-thirds page-block page-block--main">
+                <#if hasSummaryContent>
+                    <div id="${slugify('Summary')}" class="article-section article-section--summary article-section--reset-top">
+                        <h2><@fmt.message key="headers.summary" /></h2>
+                        <div data-uipath="website.general.summary" class="article-section--summary"><@hst.html hippohtml=document.summary contentRewriter=gaContentRewriter/></div>
+                    </div>
+                </#if>
+
+                <div class="article-section muted">
+                    <@lastModified document.lastModified false></@lastModified>
+                </div>
+            </div>
+        </div>
+    </div>
+</article>
+
+-->

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/results.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/results.ftl
@@ -37,6 +37,8 @@
                 <@roadmap item=document />
             <#elseif document.class.name == "uk.nhs.digital.website.beans.RoadmapItem">
                 <@roadmapitem item=document />
+            <#elseif document.class.name == "uk.nhs.digital.website.beans.GlossaryList">
+                <@glossarylist item=document />
             </#if>
         </#list>
     </div>
@@ -318,6 +320,18 @@
 <div class="cta cta--detailed" data-uipath="ps.search-results.result">
     <div>
         <span class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.roadmapitem"/></span>
+    </div>
+    <a class="cta__title cta__button" href="<@hst.link hippobean=item/>" title="${item.title}" data-uipath="ps.search-results.result.title">
+        ${item.title}
+    </a>
+    <p class="cta__text" data-uipath="ps.search-results.result.summary"><@truncate text=item.shortsummary size="300"/></p>
+</div>
+</#macro>
+
+<#macro glossarylist item>
+<div class="cta cta--detailed" data-uipath="ps.search-results.result">
+    <div>
+        <span class="cta__label" data-uipath="ps.search-results.result.type"><@fmt.message key="labels.glossarylist"/></span>
     </div>
     <a class="cta__title cta__button" href="<@hst.link hippobean=item/>" title="${item.title}" data-uipath="ps.search-results.result.title">
         ${item.title}

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/sections/emphasisBox.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/sections/emphasisBox.ftl
@@ -18,10 +18,10 @@
     </#if>
     <div class="emphasis-box emphasis-box-${slugify(section.emphasisType)}"${ariaAttribute}>
         <#if section.heading?has_content>
-            <h3 id="${slugify(slug)}">${section.heading}</h3>
+            <h3 data-uipath="website.contentblock.emphasis.heading" id="${slugify(slug)}">${section.heading}</h3>
         </#if>
         <#if section.body.content?has_content>
-            <div><@hst.html hippohtml=section.body contentRewriter=gaContentRewriter /></div>
+            <div data-uipath="website.contentblock.emphasis.content"><@hst.html hippohtml=section.body contentRewriter=gaContentRewriter /></div>
         </#if>
     </div>
 

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/sections/gallerySection.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/sections/gallerySection.ftl
@@ -1,0 +1,31 @@
+<#ftl output_format="HTML">
+
+<#macro gallerySection section>
+
+    <#-- TODO
+    CREATE FRONTEND DISPLAY.
+    SYNTAX FOR ACCESSING THE OBJECT PROPERTIES BELOW
+    -->
+
+    ${section.heading}
+    ${section.headingLevel}
+    <@hst.html hippohtml=section.description contentRewriter=gaContentRewriter />
+
+    <#list section.galleryItems as galleryItem>
+        ${galleryItem.title}
+        ${galleryItem.imageWarning}
+        <@hst.link hippobean=galleryItem.image.original fullyQualified=true var="image" />
+        <img src="${image}" alt="${galleryItem.title}" />
+        <@hst.html hippohtml=galleryItem.description contentRewriter=gaContentRewriter />
+
+        <#list galleryItem.relatedFiles as file>
+            <a class="cta__title cta__button" href="<@hst.link hippobean=file.link/>" title="${file.filename}" data-uipath="ps.search-results.result.title">
+                ${file.filename}
+            </a>
+        </#list>
+
+
+    </#list>
+
+
+</#macro>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/sections/iconList.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/sections/iconList.ftl
@@ -1,0 +1,26 @@
+<#ftl output_format="HTML">
+
+<#macro iconList section>
+
+<#-- TODO
+    CREATE FRONTEND DISPLAY.
+    SYNTAX FOR ACCESSING THE OBJECT PROPERTIES BELOW
+-->
+
+
+    <#if section.title?has_content>
+        <h3>${section.title}</h3>
+    </#if>
+
+    <#list section.iconList as iconListItem>
+        HEADING : ${iconListItem.heading}
+
+        DESCRIPTION : <div><@hst.html hippohtml=iconListItem.description contentRewriter=gaContentRewriter /></div>
+
+        ICON:   <@hst.link hippobean=iconListItem.image.original fullyQualified=true var="iconImage" />
+                <img src="${iconImage}" />
+
+    </#list>
+
+
+</#macro>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/sections/sections.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/sections/sections.ftl
@@ -6,6 +6,8 @@
 <#include "chartSection.ftl">
 <#include "related-linkSection.ftl">
 <#include "emphasisBox.ftl">
+<#include "iconList.ftl">
+<#include "gallerySection.ftl">
 
 <!-- This is a load of global setup for the highcharts config -->
 <#include "highChartsSetup.ftl">
@@ -40,6 +42,13 @@
             <#-- set flag to alter styling (no top line between emphasis boxes) -->
             <#assign isPreviousEmphasisBox = true />
             <@emphasisBox section=section />
+
+        <#-- TODO: enable once frontend tickets complete
+        <#elseif section.sectionType == 'iconList'>
+            <@iconList section=section />
+        <#elseif section.sectionType == 'gallerySection'>
+            <@gallerySection section=section/>
+        -->
         </#if>
     </#list>
 </#macro>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/sections/websiteSection.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/sections/websiteSection.ftl
@@ -3,14 +3,14 @@
 <#macro websiteSection section isPreviousSectionEmphasisBox numberedListCount>
     <#if section.title?has_content>
         <div id="${slugify(section.title)}" class="article-section <#if isPreviousSectionEmphasisBox>article-section--highlighted</#if>">
-            <h2><#if section.isNumberedList>${numberedListCount}. </#if>${section.title}</h2>
-            <div class="rich-text-content">
+            <h2 data-uipath="website.contentblock.section.title"><#if section.isNumberedList>${numberedListCount}. </#if>${section.title}</h2>
+            <div data-uipath="website.contentblock.section.content" class="rich-text-content">
                 <@hst.html hippohtml=section.html contentRewriter=gaContentRewriter/>
             </div>
         </div>
     <#else>
         <div class="article-section">
-            <div class="rich-text-content">
+            <div data-uipath="website.contentblock.section.content" class="rich-text-content">
                 <@hst.html hippohtml=section.html contentRewriter=gaContentRewriter/>
             </div>
         </div>

--- a/site/src/main/java/uk/nhs/digital/common/components/SearchComponent.java
+++ b/site/src/main/java/uk/nhs/digital/common/components/SearchComponent.java
@@ -380,6 +380,15 @@ public class SearchComponent extends CommonComponent {
     }
 
     /**
+     * Adding the GlossaryList document type
+     */
+    private void addGlossaryList(HstQueryBuilder query) {
+        query.ofTypes(
+            GlossaryList.class
+        );
+    }
+
+    /**
      * Adding all the document types supported by the SearchComponent
      */
     private void addAllTypes(HstQueryBuilder query) {
@@ -392,6 +401,7 @@ public class SearchComponent extends CommonComponent {
         addPublishedWorkTypes(query);
         addRoadmapTypes(query);
         addComponentList(query);
+        addGlossaryList(query);
     }
 
 }

--- a/site/src/main/java/uk/nhs/digital/website/beans/EmphasisBox.java
+++ b/site/src/main/java/uk/nhs/digital/website/beans/EmphasisBox.java
@@ -2,6 +2,7 @@ package uk.nhs.digital.website.beans;
 
 import org.hippoecm.hst.content.beans.Node;
 import org.hippoecm.hst.content.beans.standard.HippoCompound;
+import org.hippoecm.hst.content.beans.standard.HippoGalleryImageSet;
 import org.hippoecm.hst.content.beans.standard.HippoHtml;
 import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
 
@@ -27,6 +28,11 @@ public class EmphasisBox extends HippoCompound {
 
     public String getSectionType() {
         return "emphasisBox";
+    }
+
+    @HippoEssentialsGenerated(internalName = "website:image")
+    public HippoGalleryImageSet getImage() {
+        return getLinkedBean("website:image", HippoGalleryImageSet.class);
     }
 
 }

--- a/site/src/main/java/uk/nhs/digital/website/beans/ExternalLinkBase.java
+++ b/site/src/main/java/uk/nhs/digital/website/beans/ExternalLinkBase.java
@@ -1,0 +1,21 @@
+package uk.nhs.digital.website.beans;
+
+import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoCompound;
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+
+@HippoEssentialsGenerated(internalName = "website:externallinkbase")
+@Node(jcrType = "website:externallinkbase")
+public class ExternalLinkBase extends HippoCompound {
+
+    // used to differentiate between different types of content blocks
+    public String getLinkType() {
+        return "external";
+    }
+
+    @HippoEssentialsGenerated(internalName = "website:link")
+    public String getLink() {
+        return getProperty("website:link");
+    }
+
+}

--- a/site/src/main/java/uk/nhs/digital/website/beans/Externallink.java
+++ b/site/src/main/java/uk/nhs/digital/website/beans/Externallink.java
@@ -1,22 +1,11 @@
 package uk.nhs.digital.website.beans;
 
 import org.hippoecm.hst.content.beans.Node;
-import org.hippoecm.hst.content.beans.standard.HippoCompound;
 import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
 
 @HippoEssentialsGenerated(internalName = "website:externallink")
 @Node(jcrType = "website:externallink")
-public class Externallink extends HippoCompound {
-
-    // used to differentiate between different types of content blocks
-    public String getLinkType() {
-        return "external";
-    }
-
-    @HippoEssentialsGenerated(internalName = "website:link")
-    public String getLink() {
-        return getProperty("website:link");
-    }
+public class Externallink extends ExternalLinkBase {
 
     @HippoEssentialsGenerated(internalName = "website:title")
     public String getTitle() {

--- a/site/src/main/java/uk/nhs/digital/website/beans/GalleryItem.java
+++ b/site/src/main/java/uk/nhs/digital/website/beans/GalleryItem.java
@@ -1,0 +1,42 @@
+package uk.nhs.digital.website.beans;
+
+import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
+import org.hippoecm.hst.content.beans.standard.HippoCompound;
+import org.hippoecm.hst.content.beans.standard.HippoGalleryImageSet;
+import org.hippoecm.hst.content.beans.standard.HippoHtml;
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+
+import java.util.List;
+
+
+@HippoEssentialsGenerated(internalName = "website:galleryitem")
+@Node(jcrType = "website:galleryitem")
+public class GalleryItem extends HippoCompound {
+
+    @HippoEssentialsGenerated(internalName = "website:title")
+    public String getTitle() {
+        return getProperty("website:title");
+    }
+
+    @HippoEssentialsGenerated(internalName = "website:image")
+    public HippoGalleryImageSet getImage() {
+        return getLinkedBean("website:image", HippoGalleryImageSet.class);
+    }
+
+    @HippoEssentialsGenerated(internalName = "website:imagewarning")
+    public String getImageWarning() {
+        return getProperty("website:imagewarning");
+    }
+
+    @HippoEssentialsGenerated(internalName = "website:description")
+    public HippoHtml getDescription() {
+        return getHippoHtml("website:description");
+    }
+
+    @HippoEssentialsGenerated(internalName = "website:relatedfiles")
+    public List<HippoBean> getRelatedFiles() {
+        return getChildBeansByName("website:relatedfiles");
+    }
+
+}

--- a/site/src/main/java/uk/nhs/digital/website/beans/GallerySection.java
+++ b/site/src/main/java/uk/nhs/digital/website/beans/GallerySection.java
@@ -1,0 +1,40 @@
+package uk.nhs.digital.website.beans;
+
+import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
+import org.hippoecm.hst.content.beans.standard.HippoCompound;
+import org.hippoecm.hst.content.beans.standard.HippoHtml;
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+
+import java.util.List;
+
+
+@HippoEssentialsGenerated(internalName = "website:gallerysection")
+@Node(jcrType = "website:gallerysection")
+public class GallerySection extends HippoCompound {
+
+    @HippoEssentialsGenerated(internalName = "website:heading")
+    public String getHeading() {
+        return getProperty("website:heading");
+    }
+
+    @HippoEssentialsGenerated(internalName = "website:headinglevel")
+    public String getHeadingLevel() {
+        return getProperty("website:headinglevel");
+    }
+
+    @HippoEssentialsGenerated(internalName = "website:description")
+    public HippoHtml getDescription() {
+        return getHippoHtml("website:description");
+    }
+
+    @HippoEssentialsGenerated(internalName = "website:galleryitems")
+    public List<HippoBean> getGalleryItems() {
+        return getChildBeansByName("website:galleryitems");
+    }
+
+    public String getSectionType() {
+        return "gallerySection";
+    }
+    
+}

--- a/site/src/main/java/uk/nhs/digital/website/beans/General.java
+++ b/site/src/main/java/uk/nhs/digital/website/beans/General.java
@@ -2,6 +2,7 @@ package uk.nhs.digital.website.beans;
 
 import org.hippoecm.hst.content.beans.Node;
 import org.hippoecm.hst.content.beans.standard.HippoBean;
+import org.hippoecm.hst.content.beans.standard.HippoGalleryImageSet;
 import org.hippoecm.hst.content.beans.standard.HippoHtml;
 import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
 
@@ -43,6 +44,11 @@ public class General extends CommonFieldsBean {
     @HippoEssentialsGenerated(internalName = "website:metadata")
     public String[] getMetadata() {
         return getProperty("website:metadata");
+    }
+
+    @HippoEssentialsGenerated(internalName = "website:pageicon")
+    public HippoGalleryImageSet getPageIcon()  {
+        return getLinkedBean("website:pageicon", HippoGalleryImageSet.class);
     }
 
 }

--- a/site/src/main/java/uk/nhs/digital/website/beans/GlossaryItem.java
+++ b/site/src/main/java/uk/nhs/digital/website/beans/GlossaryItem.java
@@ -1,0 +1,30 @@
+package uk.nhs.digital.website.beans;
+
+import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoCompound;
+import org.hippoecm.hst.content.beans.standard.HippoHtml;
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+
+import java.util.List;
+
+
+@HippoEssentialsGenerated(internalName = "website:glossaryitem")
+@Node(jcrType = "website:glossaryitem")
+public class GlossaryItem extends HippoCompound {
+
+    @HippoEssentialsGenerated(internalName = "website:heading")
+    public String getHeading() {
+        return getProperty("website:heading");
+    }
+
+    @HippoEssentialsGenerated(internalName = "website:definition")
+    public HippoHtml getDefinition() {
+        return getHippoHtml("website:definition");
+    }
+
+    @HippoEssentialsGenerated(internalName = "website:items")
+    public List<?> getBlocks() {
+        return getChildBeansByName("website:items");
+    }
+
+}

--- a/site/src/main/java/uk/nhs/digital/website/beans/GlossaryList.java
+++ b/site/src/main/java/uk/nhs/digital/website/beans/GlossaryList.java
@@ -1,0 +1,23 @@
+package uk.nhs.digital.website.beans;
+
+import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+
+import java.util.List;
+
+@HippoEssentialsGenerated(internalName = "website:glossarylist")
+@Node(jcrType = "website:glossarylist")
+public class GlossaryList extends CommonFieldsBean {
+
+    @HippoEssentialsGenerated(internalName = "website:indexpage")
+    public Boolean getIndexPage() {
+        return getProperty("website:indexpage");
+    }
+
+    @HippoEssentialsGenerated(internalName = "website:glossaryitems")
+    public List<HippoBean> getGlossaryItems() {
+        return getChildBeansByName("website:glossaryitems");
+    }
+
+}

--- a/site/src/main/java/uk/nhs/digital/website/beans/IconList.java
+++ b/site/src/main/java/uk/nhs/digital/website/beans/IconList.java
@@ -1,0 +1,29 @@
+package uk.nhs.digital.website.beans;
+
+import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
+import org.hippoecm.hst.content.beans.standard.HippoCompound;
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+
+import java.util.List;
+
+
+@HippoEssentialsGenerated(internalName = "website:iconlist")
+@Node(jcrType = "website:iconlist")
+public class IconList extends HippoCompound {
+
+    @HippoEssentialsGenerated(internalName = "website:title")
+    public String getTitle() {
+        return getProperty("website:title");
+    }
+
+    @HippoEssentialsGenerated(internalName = "website:iconlist")
+    public List<HippoBean> getIconList() {
+        return getChildBeansByName("website:iconlist");
+    }
+
+    public String getSectionType() {
+        return "iconList";
+    }
+
+}

--- a/site/src/main/java/uk/nhs/digital/website/beans/IconListItem.java
+++ b/site/src/main/java/uk/nhs/digital/website/beans/IconListItem.java
@@ -1,0 +1,29 @@
+package uk.nhs.digital.website.beans;
+
+import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoCompound;
+import org.hippoecm.hst.content.beans.standard.HippoGalleryImageSet;
+import org.hippoecm.hst.content.beans.standard.HippoHtml;
+import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+
+
+@HippoEssentialsGenerated(internalName = "website:iconlistitem")
+@Node(jcrType = "website:iconlistitem")
+public class IconListItem extends HippoCompound {
+
+    @HippoEssentialsGenerated(internalName = "website:image")
+    public HippoGalleryImageSet getImage() {
+        return getLinkedBean("website:image", HippoGalleryImageSet.class);
+    }
+
+    @HippoEssentialsGenerated(internalName = "website:heading")
+    public String getHeading() {
+        return getProperty("website:heading");
+    }
+
+    @HippoEssentialsGenerated(internalName = "website:description")
+    public HippoHtml getDescription() {
+        return getHippoHtml("website:description");
+    }
+
+}


### PR DESCRIPTION
Also includes:
DW-740 Back end - Change header of General doctype
DW-648 Back end - Style guide type marker
DW-681 Back end - Create 'gallery' section module
DW-683 Back end - Create icon list body section
DW-685 Back end - Allow for insertion of image in emphasis boxes
DW-564 - Disable collection/sending of CMS usage statistics to BR