### PR TITLE
[DW-831] Update buildspec Java and acceptance test Chromedriver

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -218,7 +218,15 @@
 
                     <plugin>
                         <!-- Automatically downloads and installs Chromederiver binaries within a temporary project
-                        space so that they don't have to be deployed manually. -->
+                        space so that they don't have to be deployed manually. Since April 2019 the latest recognised version from
+                        https://github.com/webdriverextensions/webdriverextensions-maven-plugin-repository/blob/master/repository-3.0.json
+                        is Chromedriver 2.45 (compatible with Chrome v70-72).  However, the latest Chrome version is now v74, and
+                        therefore incompatible with 2.45.
+                        As per https://github.com/webdriverextensions/webdriverextensions-maven-plugin#installing-a-driver-from-an-url
+                        an exact version of Chromedriver needs to be specified from a URL.  The disadvantage with this approach is it is
+                        now platform specific (i.e. linux), but impact is minimal since developers and deployment pipeline all use linux
+                        If running acceptance tests on MacOs or Windows, please update the below locally to test, but do not commit changes.
+                         -->
                         <groupId>com.github.webdriverextensions</groupId>
                         <artifactId>webdriverextensions-maven-plugin</artifactId>
                         <version>3.1.3</version>
@@ -233,7 +241,10 @@
                             <drivers>
                                 <driver>
                                     <name>chromedriver</name>
-                                    <version>2.45</version>
+                                    <platform>linux</platform>
+                                    <bit>64</bit>
+                                    <version>74.0.3729.6</version>
+                                    <url>http://chromedriver.storage.googleapis.com/74.0.3729.6/chromedriver_linux64.zip</url>
                                 </driver>
                             </drivers>
                         </configuration>

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,19 +13,17 @@ phases:
       - apt-get install -qqy build-essential git awscli curl python-pip python-dev
       - pip install virtualenv
 
+      # remove oracle java
+      - update-alternatives --remove "java" "/usr/lib/jvm/java-8-oracle/jre/bin/java"
+      - rm -r /usr/lib/jvm/java-8-oracle
+
       # Java 8 install
-      - echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections
-      - add-apt-repository -y ppa:webupd8team/java
       - apt-get update
-      - apt-get install -y oracle-java8-installer || echo "this should fail"
-      - cd /var/lib/dpkg/info
-        && sed -i 's|JAVA_VERSION=8u201|JAVA_VERSION=8u211|' oracle-java8-installer.*
-        && sed -i 's|PARTNER_URL=http://download.oracle.com/otn-pub/java/jdk/8u201-b09/42970487e3af4f5aa5bca3f542482c60/|PARTNER_URL=https://download.oracle.com/otn/java/jdk/8u211-b12/478a62b7d4e34b78b671c754eaaf38ab/|' oracle-java8-installer.*
-        && sed -i 's|SHA256SUM_TGZ="cb700cc0ac3ddc728a567c350881ce7e25118eaf7ca97ca9705d4580c506e370"|SHA256SUM_TGZ="c0b7e45330c3f79750c89de6ee0d949ed4af946849592154874d22abc9c4668d"|' oracle-java8-installer.*
-        && sed -i 's|J_DIR=jdk1.8.0_201|J_DIR=jdk1.8.0_211|' oracle-java8-installer.*
-      - apt-get install -y oracle-java8-installer maven
-      # - rm -rf /var/lib/apt/lists/*
-      - rm -rf /var/cache/oracle-jdk8-installer
+      - apt-get install -y openjdk-8-jdk
+      - apt-get install -y maven
+
+      - update-alternatives --config java
+      - java -version
 
       # SSH key
       - aws s3 cp s3://config.mgt.nhsd.io/codebuild/hippo_build/nhs-ci_rsa $HOME/.ssh/nhs-ci_rsa


### PR DESCRIPTION
Change buildspec to use OpenJDK instead of Oracle JDK given the
changes to the Oracle JDK License for releases starting April 16, 2019.

Also update Chromedriver download to use hardcoded URL since the latest
version (currently 74) is no longer referenced in repository-3.0.json