### PR TITLE
[DW-1020] Ensure relevance characteristics persist

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,17 +297,17 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
-                <version>2.9.9</version>
+                <version>2.9.10</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.9.9.2</version>
+                <version>2.9.10</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>2.9.9</version>
+                <version>2.9.10</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>

--- a/repository-data/application/src/main/resources/hcm-config/targeting.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/targeting.yaml
@@ -2,6 +2,20 @@
 definitions:
   config:
     /targeting:targeting:
+      /targeting:characteristics:
+        /dayofweek:
+          .meta:residual-child-node-category: content
+        /documenttypes:
+          .meta:residual-child-node-category: content
+        /groups:
+          .meta:residual-child-node-category: content
+        /referrer:
+          .meta:residual-child-node-category: content
+        /returningvisitor:
+          .meta:residual-child-node-category: content
+        /tracking:
+          .meta:residual-child-node-category: content
+        jcr:primaryType: targeting:characteristics
       targeting:consentCookieEnabled: true
       targeting:consentCookieName: visitortracking
       targeting:consentCookieOptIn: true


### PR DESCRIPTION
The core product defines 4 characteristics which have
".meta:residual-child-node-category: content" set,
and treats newly added target groups as "Content".
More characteristics have since been added by BloomReach,
but they forgot to update the core config to include
".meta:residual-child-node-category: content"
with the new characteristics.  Therefore added in targeting.yaml
to ensure they are bootstrapped in.

Also includes security update to fasterxml jackson libs