### PR TITLE
[DW-000] Adds a Dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,57 @@
+version: 1
+update_configs:
+  - package_manager: "java:maven"
+    directory: "/"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "[DW-000] "
+      include_scope: true
+
+  - package_manager: "java:maven"
+    directory: "/acceptance-tests"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "[DW-000] "
+      include_scope: true
+
+  - package_manager: "java:maven"
+    directory: "/cms"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "[DW-000] "
+      include_scope: true
+
+  - package_manager: "java:maven"
+    directory: "/essentials"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "[DW-000] "
+      include_scope: true
+
+  - package_manager: "java:maven"
+    directory: "/repository"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "[DW-000] "
+      include_scope: true
+
+  - package_manager: "java:maven"
+    directory: "/repository-data"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "[DW-000] "
+      include_scope: true
+
+  - package_manager: "java:maven"
+    directory: "/s3connector"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "[DW-000] "
+      include_scope: true
+
+  - package_manager: "java:maven"
+    directory: "/site"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "[DW-000] "
+      include_scope: true


### PR DESCRIPTION
Now that GitHub will make auto PR to Maven dependencies that are
know to have security issues, the commit message must conform.