### PR TITLE
[DW-1425] Published Work hero image

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/scss/components/_hero-module-header.scss
+++ b/repository-data/webfiles/src/main/resources/site/scss/components/_hero-module-header.scss
@@ -28,6 +28,7 @@ $hm-bg-vertical-spacing--large: 100px;
         display: block;
         height: auto;
         img {
+            height: auto;
             object-fit: initial;
         }
     }


### PR DESCRIPTION
- Fix image warping at tablet size

Screenshots at iPad portrait size of 768x1024:
Before:
![uat nhsd io_coronavirus_coronavirus-report-30-april-2020(iPad) (2)](https://user-images.githubusercontent.com/1337003/82067164-3f6daf80-96c8-11ea-8a85-a9474d2a324d.png)

After:
![uat nhsd io_coronavirus_coronavirus-report-30-april-2020(iPad) (3)](https://user-images.githubusercontent.com/1337003/82067173-45639080-96c8-11ea-8531-e9993a441f1e.png)
