### PR TITLE
[DW-1458] Make sure navigation tiles have equal spacing

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/scss/components/_navigation-tiles.scss
+++ b/repository-data/webfiles/src/main/resources/site/scss/components/_navigation-tiles.scss
@@ -16,7 +16,8 @@
 .navigation-tile:visited,
 .navigation-tile:link {
     display: block;
-    margin-bottom: 20px;
+    margin-top: 0;
+    margin-bottom: 25px;
     padding: 40px 40px 60px 40px;
     border: 3px solid transparent;
     color: $text-colour;


### PR DESCRIPTION
This is specifically to override the
`.article-section * + *` selector.

Before:
<img width="1038" alt="image" src="https://user-images.githubusercontent.com/1337003/83533975-29455900-a4e8-11ea-99ea-9992f95a0435.png">

After:
<img width="1037" alt="image" src="https://user-images.githubusercontent.com/1337003/83534027-3a8e6580-a4e8-11ea-86ff-ed5b3d4af707.png">
