### PR TITLE
[ADZ-529] Examples header correct form

### DIFF
--- a/cms/src/main/java/uk/nhs/digital/apispecs/swagger/HasOneItemHelper.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/swagger/HasOneItemHelper.java
@@ -1,0 +1,33 @@
+package uk.nhs.digital.apispecs.swagger;
+
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Optional;
+
+public class HasOneItemHelper implements Helper<Collection<?>> {
+
+    public static final HasOneItemHelper INSTANCE = new HasOneItemHelper();
+
+    public static final String NAME = "hasOneItem";
+
+    @Override public Object apply(final Collection<?> items, final Options options) throws IOException {
+        final Options.Buffer buffer = options.buffer();
+
+        if (hasOneItem(items)) {
+            buffer.append(options.fn());
+        } else {
+            buffer.append(options.inverse());
+        }
+
+        return buffer;
+    }
+
+    private boolean hasOneItem(final Collection<?> items) {
+        return Optional.ofNullable(items)
+            .map(objects -> objects.size() == 1)
+            .orElse(false);
+    }
+}

--- a/cms/src/main/java/uk/nhs/digital/apispecs/swagger/MarkdownToHtmlRendererHelper.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/swagger/MarkdownToHtmlRendererHelper.java
@@ -1,0 +1,25 @@
+package uk.nhs.digital.apispecs.swagger;
+
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
+import uk.nhs.digital.apispecs.commonmark.CommonmarkMarkdownConverter;
+
+import java.util.Optional;
+
+public class MarkdownToHtmlRendererHelper implements Helper<String> {
+
+    public static final String NAME = "markdown";
+
+    private final CommonmarkMarkdownConverter commonmarkMarkdownConverter;
+
+    public MarkdownToHtmlRendererHelper(final CommonmarkMarkdownConverter commonmarkMarkdownConverter) {
+        this.commonmarkMarkdownConverter = commonmarkMarkdownConverter;
+    }
+
+    @Override public Object apply(final String markdown, final Options options) {
+
+        return Optional.ofNullable(markdown)
+            .map(commonmarkMarkdownConverter::toHtml)
+            .orElse("");
+    }
+}

--- a/cms/src/main/java/uk/nhs/digital/apispecs/swagger/model/BodyWithMediaTypeObjects.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/swagger/model/BodyWithMediaTypeObjects.java
@@ -1,6 +1,7 @@
 package uk.nhs.digital.apispecs.swagger.model;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.builder.ToStringStyle.MULTI_LINE_STYLE;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -34,7 +35,7 @@ public class BodyWithMediaTypeObjects {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this)
+        return new ToStringBuilder(this, MULTI_LINE_STYLE)
             .append("content", content)
             .toString();
     }

--- a/cms/src/main/java/uk/nhs/digital/apispecs/swagger/model/BodyWithMediaTypesExtractor.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/swagger/model/BodyWithMediaTypesExtractor.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public class BodyWithMediaTypesExtractor {
 
-    private final ObjectMapper jsonObjectMapper = new ObjectMapper()
+    public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper()
         .configure(MapperFeature.USE_ANNOTATIONS, true);
 
     public Optional<BodyWithMediaTypeObjects> bodyObjectFromJsonSchema(final String jsonSchema, final String elementType) {
@@ -24,6 +24,6 @@ public class BodyWithMediaTypesExtractor {
     }
 
     private Optional<BodyWithMediaTypeObjects> extractBody(final String jsonSchema) throws JsonProcessingException {
-        return Optional.ofNullable(jsonObjectMapper.readValue(jsonSchema, BodyWithMediaTypeObjects.class));
+        return Optional.ofNullable(OBJECT_MAPPER.readValue(jsonSchema, BodyWithMediaTypeObjects.class));
     }
 }

--- a/cms/src/main/java/uk/nhs/digital/apispecs/swagger/model/ExampleObject.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/swagger/model/ExampleObject.java
@@ -1,5 +1,7 @@
 package uk.nhs.digital.apispecs.swagger.model;
 
+import static org.apache.commons.lang3.builder.ToStringStyle.MULTI_LINE_STYLE;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -37,7 +39,7 @@ public class ExampleObject {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this)
+        return new ToStringBuilder(this, MULTI_LINE_STYLE)
             .append("summary", summary)
             .append("description", description)
             .append("value", value)

--- a/cms/src/main/java/uk/nhs/digital/apispecs/swagger/model/MediaTypeObject.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/swagger/model/MediaTypeObject.java
@@ -1,6 +1,7 @@
 package uk.nhs.digital.apispecs.swagger.model;
 
 import static java.util.Collections.emptyMap;
+import static org.apache.commons.lang3.builder.ToStringStyle.MULTI_LINE_STYLE;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -49,7 +50,7 @@ public class MediaTypeObject {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this)
+        return new ToStringBuilder(this, MULTI_LINE_STYLE)
             .append("name", name)
             .append("example", example)
             .append("examples", examples)

--- a/cms/src/main/java/uk/nhs/digital/apispecs/swagger/model/SchemaObject.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/swagger/model/SchemaObject.java
@@ -1,5 +1,7 @@
 package uk.nhs.digital.apispecs.swagger.model;
 
+import static org.apache.commons.lang3.builder.ToStringStyle.MULTI_LINE_STYLE;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -19,7 +21,7 @@ public class SchemaObject {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this)
+        return new ToStringBuilder(this, MULTI_LINE_STYLE)
             .append("example", example)
             .toString();
     }

--- a/cms/src/main/java/uk/nhs/digital/apispecs/swagger/request/bodyextractor/ToPrettyJsonStringDeserializer.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/swagger/request/bodyextractor/ToPrettyJsonStringDeserializer.java
@@ -1,5 +1,8 @@
 package uk.nhs.digital.apispecs.swagger.request.bodyextractor;
 
+import static org.apache.commons.lang3.StringUtils.removeEnd;
+import static org.apache.commons.lang3.StringUtils.removeStart;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -18,7 +21,34 @@ public class ToPrettyJsonStringDeserializer extends StdDeserializer<String> {
     }
 
     @Override
-    public String deserialize(final JsonParser p, final DeserializationContext ctxt) throws IOException {
-        return p.getCodec().<JsonNode>readTree(p).toPrettyString();
+    public String deserialize(final JsonParser parser, final DeserializationContext context) throws IOException {
+
+        final String prettyString = parseAsJson(parser);
+
+        return sanitise(prettyString);
+    }
+
+    private String sanitise(final String text) {
+
+        String sanitisedText = stripLeadingAndTrailingQuoteCharacters(text);
+        sanitisedText = unescapeQuotes(sanitisedText);
+
+        return sanitisedText;
+    }
+
+    private String unescapeQuotes(final String text) {
+        return text.replaceAll("\\\\\"", "\"");
+    }
+
+    private String parseAsJson(final JsonParser parser) throws IOException {
+        return parser.getCodec().<JsonNode>readTree(parser).toPrettyString();
+    }
+
+    private String stripLeadingAndTrailingQuoteCharacters(final String inputString) {
+
+        String cleanedString = removeStart(inputString, "\"");
+        cleanedString = removeEnd(cleanedString, "\"");
+
+        return cleanedString;
     }
 }

--- a/cms/src/main/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/CodegenParamDefinition.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/CodegenParamDefinition.java
@@ -4,6 +4,8 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableMap;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import uk.nhs.digital.apispecs.swagger.request.bodyextractor.ToPrettyJsonStringDeserializer;
 
 import java.util.Map;
 import java.util.Optional;
@@ -19,7 +21,9 @@ class CodegenParamDefinition {
     // https://swagger.io/specification/#parameter-object
     // https://swagger.io/specification/#header-object
 
+    @JsonDeserialize(using = ToPrettyJsonStringDeserializer.class)
     private String example;
+
     private Map<String, ParamExample> examples;
 
     private CodegenParamSchema schema;

--- a/cms/src/main/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/CodegenParamSchema.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/CodegenParamSchema.java
@@ -1,12 +1,16 @@
 package uk.nhs.digital.apispecs.swagger.request.examplerenderer;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import uk.nhs.digital.apispecs.swagger.request.bodyextractor.ToPrettyJsonStringDeserializer;
 
 import java.util.Optional;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 class CodegenParamSchema {
     // subset of https://swagger.io/specification/#schema-object
+
+    @JsonDeserialize(using = ToPrettyJsonStringDeserializer.class)
     private String example;
 
     public Optional<String> getExample() {

--- a/cms/src/main/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/CodegenParameterExampleHtmlRenderer.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/CodegenParameterExampleHtmlRenderer.java
@@ -28,14 +28,14 @@ import java.util.Optional;
  * <li><a href="https://swagger.io/specification/#header-object"/>OAS Header Object (response headers)</li>
  * </ul>
  */
-public class CodegenParameterExampleRenderer {
+public class CodegenParameterExampleHtmlRenderer {
 
     private final CommonmarkMarkdownConverter markdownConverter;
 
     private final ObjectMapper jsonObjectMapper = new ObjectMapper()
         .configure(MapperFeature.USE_ANNOTATIONS, true);
 
-    public CodegenParameterExampleRenderer(final CommonmarkMarkdownConverter markdownConverter) {
+    public CodegenParameterExampleHtmlRenderer(final CommonmarkMarkdownConverter markdownConverter) {
         this.markdownConverter = markdownConverter;
     }
 
@@ -68,7 +68,9 @@ public class CodegenParameterExampleRenderer {
     private String htmlFrom(final Collection<ParamExample> complexExamplesFromParamSchema) {
 
         //noinspection OptionalGetWithoutIsPresent
-        return new StringBuilder("<div class=\"httpparams__examples__header\">Examples</div>\n")
+        return new StringBuilder("<div class=\"httpparams__examples__header\">")
+            .append(complexExamplesFromParamSchema.size() == 1 ? "Example" : "Examples")
+            .append("</div>\n")
             .append(
                 complexExamplesFromParamSchema.stream()
                     .map(example -> {

--- a/cms/src/main/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/ParamExample.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/ParamExample.java
@@ -1,6 +1,8 @@
 package uk.nhs.digital.apispecs.swagger.request.examplerenderer;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import uk.nhs.digital.apispecs.swagger.request.bodyextractor.ToPrettyJsonStringDeserializer;
 
 import java.util.Optional;
 
@@ -9,7 +11,10 @@ class ParamExample {
     // subset of https://swagger.io/specification/#example-object
 
     private String summary;
+
     private String description;
+
+    @JsonDeserialize(using = ToPrettyJsonStringDeserializer.class)
     private String value;
 
     public Optional<String> getSummary() {

--- a/cms/src/main/resources/api-specification/codegen-templates/body_param.mustache
+++ b/cms/src/main/resources/api-specification/codegen-templates/body_param.mustache
@@ -22,7 +22,11 @@
 
         {{#examples}}
             {{#@first}}
-            <div class="body__example__header">Examples</div>
+                {{#hasOneItem examples}}
+                    <div class="body__example__header">Example</div>
+                {{else}}
+                    <div class="body__example__header">Examples</div>
+                {{/hasOneItem}}
             {{/@first}}
 
             {{#summary}}
@@ -30,7 +34,7 @@
             {{/summary}}
 
             {{#description}}
-            <div class="body__example__description">{{description}}</div>
+            <div class="body__example__description">{{{markdown description}}}</div>
             {{/description}}
 
             <div><pre><code>{{value}}</code></pre></div>

--- a/cms/src/main/resources/api-specification/codegen-templates/index.mustache
+++ b/cms/src/main/resources/api-specification/codegen-templates/index.mustache
@@ -44,7 +44,7 @@
     <!-- API Title: {{{appName}}} -->
 
     <div id="api-description" class="article-section">
-        {{{appDescription}}}
+        {{{markdown appDescription}}}
     </div>
 
         {{#apiInfo}}
@@ -66,7 +66,7 @@
                                                 <div class="try"><a onclick="tryEndpointNow('/{{baseName}}/{{operationIdSnakeCase}}')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
                                             </div>
 
-                                            <p>{{notes}}</p>
+                                            <p>{{{markdown notes}}}</p>
                                             <p></p>
                                             <br/>
 
@@ -147,7 +147,7 @@
                                             <h2>Response</h2>
                                             {{#responses}}
                                                 <h3>HTTP status: {{code}}</h3>
-                                                <div>{{message}}</div>
+                                                <div>{{{markdown message}}}</div>
 
                                                 {{#hasHeaders}}
                                                     <div class="httpparams">

--- a/cms/src/main/resources/api-specification/codegen-templates/request_param.mustache
+++ b/cms/src/main/resources/api-specification/codegen-templates/request_param.mustache
@@ -14,7 +14,7 @@
                 {{/defaultValue}}
 
                 {{#description}}
-                    <div>{{description}}</div>
+                    <div>{{{markdown description}}}</div>
                 {{/description}}
 
                 {{#pattern}}

--- a/cms/src/main/resources/api-specification/codegen-templates/response_header.mustache
+++ b/cms/src/main/resources/api-specification/codegen-templates/response_header.mustache
@@ -14,7 +14,7 @@
                 {{/defaultValue}}
 
                 {{#description}}
-                    <div>{{description}}</div>
+                    <div>{{{markdown description}}}</div>
                 {{/description}}
 
                 {{#pattern}}

--- a/cms/src/test/java/uk/nhs/digital/apispecs/swagger/BodyRenderingTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/swagger/BodyRenderingTest.java
@@ -1,0 +1,195 @@
+package uk.nhs.digital.apispecs.swagger;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThat;
+import static uk.nhs.digital.test.util.FileUtils.fileContentFromClasspath;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.codegen.v3.templates.HandlebarTemplateEngine;
+import org.junit.Test;
+import uk.nhs.digital.apispecs.swagger.model.BodyWithMediaTypeObjects;
+import uk.nhs.digital.apispecs.swagger.model.BodyWithMediaTypesExtractor;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class BodyRenderingTest {
+
+    private static final String TEST_DATA_FILES_PATH = "/test-data/api-specifications/BodyRenderingTest";
+
+    private static final ObjectMapper OBJECT_MAPPER = BodyWithMediaTypesExtractor.OBJECT_MAPPER;
+
+    private static String fromFile(final String testFileName) {
+        return fileContentFromClasspath(TEST_DATA_FILES_PATH + "/" + testFileName);
+    }
+
+    @Test
+    public void rendersExampleSpecifiedOnMediaTypeObject_evenWhenExampleIsSpecifiedOnSchema() throws IOException {
+
+        // given
+        final String bodyJson = fromFile("exampleOnMediaTypeObjectAndOnSchema.json");
+
+        // when
+        final String actualHtml = renderFor(bodyJson);
+
+        // then
+        assertThat("Renders example from MediaTypeObject's 'example' field.",
+            actualHtml,
+            containsString("simple example specified in MediaTypeObject's definition")
+        );
+        assertThat("Does not render example from MediaTypeObject's Schema.",
+            actualHtml,
+            not(containsString("example specified in MediaTypeObject's schema"))
+        );
+    }
+
+    @Test
+    public void rendersExamplesSpecifiedOnMediaTypeObject_evenWhenExampleIsSpecifiedOnSchema() throws IOException {
+
+        // given
+        final String bodyJson = fromFile("examplesOnMediaTypeObjectAndOnSchema.json");
+
+        // when
+        final String actualHtml = renderFor(bodyJson);
+
+        // then
+        assertThat("Renders examples from MediaTypeObject's 'examples' field.",
+            actualHtml,
+            allOf(
+                containsString("first example from request MediaTypeObject's definition"),
+                containsString("second example from request MediaTypeObject's definition")
+            )
+        );
+        assertThat("Does not render example from MediaTypeObject's Schema.",
+            actualHtml,
+            not(containsString("example specified in MediaTypeObject's schema"))
+        );
+    }
+
+    @Test
+    public void rendersExampleSpecifiedOnSchema_whenThereIsNoExampleOnMediaTypeObject() throws IOException {
+
+        // given
+        final String bodyJson = fromFile("exampleOnSchemaNoneOnMediaTypeObject.json");
+
+        // when
+        final String actualHtml = renderFor(bodyJson);
+
+        // then
+        assertThat("Renders example from MediaTypeObject's Schema.",
+            actualHtml,
+            containsString("example specified in MediaTypeObject's schema")
+        );
+    }
+
+    @Test
+    public void rendersExamplesHeader_whenMultipleExamplesSpecifiedInExamplesFieldOnMediaTypeObject() throws IOException {
+
+        // given
+        final String bodyJson = fromFile("multipleExamplesInCollectionOnMediaTypeObject.json");
+
+        // when
+        final String actualHtml = renderFor(bodyJson);
+
+        // then
+        assertThat("Renders plural version of the header for multiple examples in the collection.",
+            actualHtml,
+            containsString(">Examples<")
+        );
+    }
+
+    @Test
+    public void rendersExampleHeader_whenSingleExampleSpecifiedInExamplesFieldOnMediaTypeObject() throws IOException {
+
+        // given
+        final String bodyJson = fromFile("singleExampleInCollectionOnMediaTypeObject.json");
+
+        // when
+        final String actualHtml = renderFor(bodyJson);
+
+        // then
+        assertThat("Renders singular version of the header for single examples in the collection.",
+            actualHtml,
+            containsString(">Example<")
+        );
+    }
+
+    @Test
+    public void rendersCompleteExampleObject_withAllComponentsAndInTheRightOrder() throws IOException {
+        // Other test cases verify variants of individual aspects of examples' rendering.
+        // This test verifies that all components of an individual Example Object are rendered.
+
+        // given
+        final String bodyJson = fromFile("bodyWithMediaTypeObjectWithExampleObject.json");
+        final String expectedHtml = fromFile("bodyWithMediaTypeObjectWithExampleObject.html");
+
+        // when
+        final String actualHtml = renderFor(bodyJson);
+
+        // then
+        // Here we only care that Markdown-to-HTML conversion is applied here at all,
+        // choosing backticks-to-<code> as an indicator that this happens.
+        // A separate test, dedicated to the converter itself provides a more complete coverage.
+        assertThat("Renders complete body with all components and in the right order.",
+            actualHtml,
+            is(expectedHtml)
+        );
+    }
+
+    @Test
+    public void rendersCompleteContentTypeSections_withAllComponentsInTheRightOrder() throws IOException {
+        // Other test cases verify small, focused features in isolation.
+        // This is a higher-level test, to verify that all components come together and that correct overall
+        // HTML structure is rendered, as the other test cases tend to check for 'marker' texts rather than HTML
+        // elements.
+        //
+        // Note that we don't need to model all minute edge cases here - this is what the other test methods/cases
+        // are for.
+
+        // given
+        final String bodyJson = fromFile("completeBodyWithMultipleMediaTypeObjects.json");
+        final String expectedHtml = fromFile("completeBodyWithMultipleMediaTypeObjects.html");
+
+        // when
+        final String actualHtml = renderFor(bodyJson);
+
+        // then
+        assertThat("Renders complete body with all components and in the right order.",
+            actualHtml,
+            is(expectedHtml)
+        );
+    }
+
+    private String renderFor(final String jsonDefinition) throws IOException {
+
+        final String parameterJsonDefinition = jsonDefinition;
+
+        final BodyWithMediaTypeObjects bodyWithMediaTypeObjects = fromJson(parameterJsonDefinition, BodyWithMediaTypeObjects.class);
+
+        final Map<String, Object> model = new HashMap<>();
+        model.put("mediaTypes", bodyWithMediaTypeObjects.getMediaTypes());
+
+        final ApiSpecificationStaticHtml2Codegen config = new ApiSpecificationStaticHtml2Codegen();
+
+        final String templateDir = "api-specification/codegen-templates";
+
+        config.setTemplateDir(templateDir);
+
+        final HandlebarTemplateEngine handlebars = new HandlebarTemplateEngine(config);
+
+        final String templateFileName = "body_param.mustache";
+
+        return handlebars.getRendered(templateDir + "/" + templateFileName, model);
+    }
+
+    private <T> T fromJson(final String parameterJsonDefinition, final Class<T> valueType) {
+
+        try {
+            return OBJECT_MAPPER.readValue(parameterJsonDefinition, valueType);
+        } catch (final JsonProcessingException e) {
+            throw new RuntimeException("Failed to create test data objects from JSON.", e);
+        }
+    }
+}

--- a/cms/src/test/java/uk/nhs/digital/apispecs/swagger/HasOneItemHelperTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/swagger/HasOneItemHelperTest.java
@@ -1,0 +1,122 @@
+package uk.nhs.digital.apispecs.swagger;
+
+import static com.onehippo.cms7.inference.engine.core.util.ArraysUtils.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.github.jknack.handlebars.Options;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.io.IOException;
+import java.util.Collection;
+
+public class HasOneItemHelperTest {
+
+    private static final String TEMPLATE_CONTENT_FROM_THE_POSITIVE_BLOCK = RandomStringUtils.random(10);
+    private static final String TEMPLATE_CONTENT_FROM_THE_INVERSE_BLOCK = RandomStringUtils.random(10);
+
+    private final HasOneItemHelper hasOneItemHelper = HasOneItemHelper.INSTANCE;
+
+    @Mock private Options options;
+    @Mock private Options.Buffer buffer;
+
+    @Before
+    public void setUp() throws Exception {
+        initMocks(this);
+
+        given(options.fn()).willReturn(TEMPLATE_CONTENT_FROM_THE_POSITIVE_BLOCK);
+        given(options.inverse()).willReturn(TEMPLATE_CONTENT_FROM_THE_INVERSE_BLOCK);
+        given(options.buffer()).willReturn(buffer);
+    }
+
+    @Test
+    public void rendersBlockWhenCollectionHasExactlyOneItem() throws IOException {
+
+        // given
+        final Collection<?> collectionWithOneItem = singletonList("single item in the list, actual content irrelevant");
+
+        // when
+        final Object buffer = hasOneItemHelper.apply(collectionWithOneItem, options);
+
+        // then
+        assertThat("Returns Options.Buffer",
+            buffer,
+            instanceOf(Options.Buffer.class)
+        );
+
+        final Options.Buffer actualBuffer = (Options.Buffer) buffer;
+
+        then(actualBuffer).should().append(TEMPLATE_CONTENT_FROM_THE_POSITIVE_BLOCK);
+    }
+
+    @Test
+    public void doesNotRenderBlockWhenCollectionIsNull() throws IOException {
+
+        // given
+        final Collection<?> nullCollection = null;
+
+        // when
+        final Object buffer = hasOneItemHelper.apply(nullCollection, options);
+
+        // then
+        assertThat("Returns Options.Buffer",
+            buffer,
+            instanceOf(Options.Buffer.class)
+        );
+
+        final Options.Buffer actualBuffer = (Options.Buffer) buffer;
+
+        then(actualBuffer).should().append(TEMPLATE_CONTENT_FROM_THE_INVERSE_BLOCK);
+    }
+
+    @Test
+    public void doesNotRenderBlockWhenCollectionHasZeroItems() throws IOException {
+
+        // given
+        final Collection<?> emptyCollection = emptyList();
+
+        // when
+        final Object buffer = hasOneItemHelper.apply(emptyCollection, options);
+
+        // then
+        assertThat("Returns Options.Buffer",
+            buffer,
+            instanceOf(Options.Buffer.class)
+        );
+
+        final Options.Buffer actualBuffer = (Options.Buffer) buffer;
+
+        then(actualBuffer).should().append(TEMPLATE_CONTENT_FROM_THE_INVERSE_BLOCK);
+    }
+
+    @Test
+    public void doesNotRenderBlockWhenCollectionHasManyItems() throws IOException {
+
+        // given
+        final Collection<?> collectionWithManyItems = asList(
+            "first item in the list, actual content irrelevant",
+            "second item in the list, actual content irrelevant"
+        );
+
+        // when
+        final Object buffer = hasOneItemHelper.apply(collectionWithManyItems, options);
+
+        // then
+        assertThat("Returns Options.Buffer",
+            buffer,
+            instanceOf(Options.Buffer.class)
+        );
+
+        final Options.Buffer actualBuffer = (Options.Buffer) buffer;
+
+        then(actualBuffer).should().append(TEMPLATE_CONTENT_FROM_THE_INVERSE_BLOCK);
+    }
+}

--- a/cms/src/test/java/uk/nhs/digital/apispecs/swagger/MarkdownToHtmlRendererHelperTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/swagger/MarkdownToHtmlRendererHelperTest.java
@@ -1,0 +1,39 @@
+package uk.nhs.digital.apispecs.swagger;
+
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+import uk.nhs.digital.apispecs.commonmark.CommonmarkMarkdownConverter;
+
+public class MarkdownToHtmlRendererHelperTest {
+
+    private CommonmarkMarkdownConverter commonmarkMarkdownConverter = mock(CommonmarkMarkdownConverter.class);
+
+    private final MarkdownToHtmlRendererHelper markdownToHtmlRendererHelper
+        = new MarkdownToHtmlRendererHelper(commonmarkMarkdownConverter);
+
+    @Test
+    public void delegatesToCommonMarkRenderer() {
+
+        // given
+        final String markdownToRender = "random text with Markdown elements";
+        final String expectedRenderedValue = "random text received from the actual renderer";
+
+        given(commonmarkMarkdownConverter.toHtml(markdownToRender)).willReturn(expectedRenderedValue);
+
+        // when
+        final Object actualRenderedValue = markdownToHtmlRendererHelper.apply(
+            markdownToRender,
+            null // ignored
+        );
+
+        // then
+        assertThat("Returns value received from the actual renderer.",
+            actualRenderedValue,
+            sameInstance(expectedRenderedValue)
+        );
+    }
+}

--- a/cms/src/test/java/uk/nhs/digital/apispecs/swagger/model/BodyWithMediaTypesExtractorTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/swagger/model/BodyWithMediaTypesExtractorTest.java
@@ -68,19 +68,19 @@ public class BodyWithMediaTypesExtractorTest {
         final ExampleObject exampleObjectA = new ExampleObject();
         setField(exampleObjectA, "summary", "Example A summary");
         setField(exampleObjectA, "description", "Example A description");
-        setField(exampleObjectA, "value", "\"Example A value\"");
+        setField(exampleObjectA, "value", "Example A value");
 
         final ExampleObject exampleObjectB = new ExampleObject();
         setField(exampleObjectB, "summary", "Example B summary");
         setField(exampleObjectB, "description", "Example B description");
-        setField(exampleObjectB, "value", "\"Example B value\"");
+        setField(exampleObjectB, "value", "Example B value");
 
         final SchemaObject schemaYml = new SchemaObject();
-        setField(schemaYml, "example", "\"Example on schema YML\"");
+        setField(schemaYml, "example", "Example on schema YML");
 
         final MediaTypeObject mediaTypeObjectYml = new MediaTypeObject();
         setField(mediaTypeObjectYml, "schema", schemaYml);
-        setField(mediaTypeObjectYml, "example", "\"Example on Media Type Object YML\"");
+        setField(mediaTypeObjectYml, "example", "Example on Media Type Object YML");
         setField(mediaTypeObjectYml, "examples", ImmutableMap.builder()
             .put("example-a", exampleObjectA)
             .put("example-b", exampleObjectB)
@@ -90,19 +90,19 @@ public class BodyWithMediaTypesExtractorTest {
         final ExampleObject exampleObjectC = new ExampleObject();
         setField(exampleObjectC, "summary", "Example C summary");
         setField(exampleObjectC, "description", "Example C description");
-        setField(exampleObjectC, "value", "\"Example C value\"");
+        setField(exampleObjectC, "value", "Example C value");
 
         final ExampleObject exampleObjectD = new ExampleObject();
         setField(exampleObjectD, "summary", "Example D summary");
         setField(exampleObjectD, "description", "Example D description");
-        setField(exampleObjectD, "value", "\"Example D value\"");
+        setField(exampleObjectD, "value", "Example D value");
 
         final SchemaObject schemaXml = new SchemaObject();
-        setField(schemaXml, "example", "\"Example on schema XML\"");
+        setField(schemaXml, "example", "Example on schema XML");
 
         final MediaTypeObject mediaTypeObjectXml = new MediaTypeObject();
         setField(mediaTypeObjectXml, "schema", schemaXml);
-        setField(mediaTypeObjectXml, "example", "\"Example on Media Type Object XML\"");
+        setField(mediaTypeObjectXml, "example", "Example on Media Type Object XML");
         setField(mediaTypeObjectXml, "examples", ImmutableMap.builder()
             .put("example-c", exampleObjectC)
             .put("example-d", exampleObjectD)

--- a/cms/src/test/java/uk/nhs/digital/apispecs/swagger/model/ExampleObjectTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/swagger/model/ExampleObjectTest.java
@@ -1,0 +1,19 @@
+package uk.nhs.digital.apispecs.swagger.model;
+
+import static uk.nhs.digital.test.util.AssertionUtils.assertClassHasFieldWithAnnotationWithAttributeValue;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.junit.Test;
+import uk.nhs.digital.apispecs.swagger.request.bodyextractor.ToPrettyJsonStringDeserializer;
+
+public class ExampleObjectTest {
+
+    @Test
+    public void exampleValueIsDeserialised_usingCustomDeserializer() {
+
+        assertClassHasFieldWithAnnotationWithAttributeValue(
+            ExampleObject.class, "value",
+            JsonDeserialize.class, "using", ToPrettyJsonStringDeserializer.class
+        );
+    }
+}

--- a/cms/src/test/java/uk/nhs/digital/apispecs/swagger/model/MediaTypeObjectTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/swagger/model/MediaTypeObjectTest.java
@@ -5,13 +5,25 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyZeroInteractions;
+import static uk.nhs.digital.test.util.AssertionUtils.assertClassHasFieldWithAnnotationWithAttributeValue;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.junit.Test;
+import uk.nhs.digital.apispecs.swagger.request.bodyextractor.ToPrettyJsonStringDeserializer;
 import uk.nhs.digital.test.util.ReflectionTestUtils;
 
 import java.util.*;
 
 public class MediaTypeObjectTest {
+
+    @Test
+    public void exampleValueIsDeserialised_usingCustomDeserializer() {
+
+        assertClassHasFieldWithAnnotationWithAttributeValue(
+            MediaTypeObject.class, "example",
+            JsonDeserialize.class, "using", ToPrettyJsonStringDeserializer.class
+        );
+    }
 
     @Test
     public void getExamples_returnsExamplesFromValuesOfInternalMap() {

--- a/cms/src/test/java/uk/nhs/digital/apispecs/swagger/model/SchemaObjectTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/swagger/model/SchemaObjectTest.java
@@ -1,0 +1,19 @@
+package uk.nhs.digital.apispecs.swagger.model;
+
+import static uk.nhs.digital.test.util.AssertionUtils.assertClassHasFieldWithAnnotationWithAttributeValue;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.junit.Test;
+import uk.nhs.digital.apispecs.swagger.request.bodyextractor.ToPrettyJsonStringDeserializer;
+
+public class SchemaObjectTest {
+
+    @Test
+    public void exampleValueIsDeserialised_usingCustomDeserializer() {
+
+        assertClassHasFieldWithAnnotationWithAttributeValue(
+            SchemaObject.class, "example",
+            JsonDeserialize.class, "using", ToPrettyJsonStringDeserializer.class
+        );
+    }
+}

--- a/cms/src/test/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/CodegenParamDefinitionTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/CodegenParamDefinitionTest.java
@@ -1,0 +1,19 @@
+package uk.nhs.digital.apispecs.swagger.request.examplerenderer;
+
+import static uk.nhs.digital.test.util.AssertionUtils.assertClassHasFieldWithAnnotationWithAttributeValue;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.junit.Test;
+import uk.nhs.digital.apispecs.swagger.request.bodyextractor.ToPrettyJsonStringDeserializer;
+
+public class CodegenParamDefinitionTest {
+
+    @Test
+    public void exampleValueIsDeserialised_usingCustomDeserializer() {
+
+        assertClassHasFieldWithAnnotationWithAttributeValue(
+            CodegenParamDefinition.class, "example",
+            JsonDeserialize.class, "using", ToPrettyJsonStringDeserializer.class
+        );
+    }
+}

--- a/cms/src/test/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/CodegenParamSchemaTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/CodegenParamSchemaTest.java
@@ -1,0 +1,19 @@
+package uk.nhs.digital.apispecs.swagger.request.examplerenderer;
+
+import static uk.nhs.digital.test.util.AssertionUtils.assertClassHasFieldWithAnnotationWithAttributeValue;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.junit.Test;
+import uk.nhs.digital.apispecs.swagger.request.bodyextractor.ToPrettyJsonStringDeserializer;
+
+public class CodegenParamSchemaTest {
+
+    @Test
+    public void exampleValueIsDeserialised_usingCustomDeserializer() {
+
+        assertClassHasFieldWithAnnotationWithAttributeValue(
+            CodegenParamSchema.class, "example",
+            JsonDeserialize.class, "using", ToPrettyJsonStringDeserializer.class
+        );
+    }
+}

--- a/cms/src/test/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/CodegenParameterExampleHtmlRendererTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/CodegenParameterExampleHtmlRendererTest.java
@@ -1,7 +1,6 @@
 package uk.nhs.digital.apispecs.swagger.request.examplerenderer;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -18,7 +17,7 @@ import org.junit.rules.ExpectedException;
 import org.mockito.Mock;
 import uk.nhs.digital.apispecs.commonmark.CommonmarkMarkdownConverter;
 
-public class CodegenParameterExampleRendererTest {
+public class CodegenParameterExampleHtmlRendererTest {
 
     private static final String TEST_DATA_FILES_PATH = "/test-data/api-specifications/CodegenRequestParameterExampleGeneratorTest";
 
@@ -26,26 +25,27 @@ public class CodegenParameterExampleRendererTest {
 
     @Mock private CommonmarkMarkdownConverter markdownConverter;
 
-    private CodegenParameterExampleRenderer codegenParameterExampleRenderer;
+    private CodegenParameterExampleHtmlRenderer codegenParameterExampleHtmlRenderer;
 
     @Before
     public void setUp() {
         initMocks(this);
 
-        codegenParameterExampleRenderer = new CodegenParameterExampleRenderer(markdownConverter);
+        codegenParameterExampleHtmlRenderer = new CodegenParameterExampleHtmlRenderer(markdownConverter);
     }
 
     @Test
-    public void generatesHtml_forExampleSpecifiedInParamDefinition_evenWhenExampleIsSpecifiedInParamSchema() {
+    public void rendersExampleSpecifiedInParamDefinition_evenWhenExampleIsSpecifiedInParamSchema() {
 
         // given
-        final String expectedHtmlForExampleValue = from("exampleSpecifiedInParamDefinitionAndInSchema_expectedHtml.html");
+        final String expectedHtmlForExampleValue =
+            "Example: <code class=\"codeinline\">simple example specified in parameter's definition</code>";
 
         final String parameterJsonDefinition = from("exampleSpecifiedInParamDefinitionAndInSchema_parameterDefinition.json");
         final CodegenParameter codegenParameter = codegenParameterWith(parameterJsonDefinition);
 
         // when
-        final String actualHtmlForExampleValue = codegenParameterExampleRenderer.htmlForExampleValueOf(codegenParameter.getJsonSchema());
+        final String actualHtmlForExampleValue = codegenParameterExampleHtmlRenderer.htmlForExampleValueOf(codegenParameter.getJsonSchema());
 
         // then
         assertThat("Returns HTML for single example from parameter's schema.",
@@ -55,7 +55,7 @@ public class CodegenParameterExampleRendererTest {
     }
 
     @Test
-    public void generatesHtml_forExamplesSpecifiedInParamDefinition_evenWhenExampleIsSpecifiedInParamSchema() {
+    public void rendersExamplesSpecifiedInParamDefinition_evenWhenExampleIsSpecifiedInParamSchema() {
 
         // given
         final String expectedHtmlForExampleValue = from("examplesSpecifiedInParamDefinition_expectedHtml.html");
@@ -69,7 +69,7 @@ public class CodegenParameterExampleRendererTest {
 
         // when
         final String actualHtmlForExampleValue =
-            codegenParameterExampleRenderer.htmlForExampleValueOf(codegenParameter.getJsonSchema());
+            codegenParameterExampleHtmlRenderer.htmlForExampleValueOf(codegenParameter.getJsonSchema());
 
         // then
         assertThat("Returns HTML for single example from parameter's schema.",
@@ -82,21 +82,55 @@ public class CodegenParameterExampleRendererTest {
     }
 
     @Test
-    public void generatesHtml_forExampleSpecifiedInParamSchema_whenThereIsNoExampleInParamDefinition() {
+    public void rendersExampleSpecifiedInParamSchema_whenThereIsNoExampleInParamDefinition() {
 
         // given
-        final String expectedHtmlForExampleValue = from("exampleSpecifiedInParamSchemaNoneInDefinition_expectedHtml.html");
+        final String expectedHtmlForExampleValue = "Example: <code class=\"codeinline\">example specified in parameter's schema</code>";
 
         final String parameterJsonDefinition = from("exampleSpecifiedInParamSchemaNoneInDefinition_parameterDefinition.json");
         final CodegenParameter codegenParameter = codegenParameterWith(parameterJsonDefinition);
 
         // when
-        final String actualHtmlForExampleValue = codegenParameterExampleRenderer.htmlForExampleValueOf(codegenParameter.getJsonSchema());
+        final String actualHtmlForExampleValue = codegenParameterExampleHtmlRenderer.htmlForExampleValueOf(codegenParameter.getJsonSchema());
 
         // then
         assertThat("Returns HTML for single example from parameter's schema.",
             actualHtmlForExampleValue,
             is(expectedHtmlForExampleValue)
+        );
+    }
+
+    @Test
+    public void rendersExamplesHeader_whenMultipleExamplesSpecifiedInExamplesField() {
+
+        // given
+        final String parameterJsonDefinition = from("multipleExamplesSpecifiedInParamDefinition_paramDefinition.json");
+        final CodegenParameter codegenParameter = codegenParameterWith(parameterJsonDefinition);
+
+        // when
+        final String actualHtmlForExampleValue = codegenParameterExampleHtmlRenderer.htmlForExampleValueOf(codegenParameter.getJsonSchema());
+
+        // then
+        assertThat("Renders plural version of the header for multiple examples in the collection.",
+            actualHtmlForExampleValue,
+            containsString(">Examples<")
+        );
+    }
+
+    @Test
+    public void rendersExampleHeader_whenSingleExampleSpecifiedInExamplesField() {
+
+        // given
+        final String parameterJsonDefinition = from("singleExampleSpecifiedInParamDefinition_paramDefinition.json");
+        final CodegenParameter codegenParameter = codegenParameterWith(parameterJsonDefinition);
+
+        // when
+        final String actualHtmlForExampleValue = codegenParameterExampleHtmlRenderer.htmlForExampleValueOf(codegenParameter.getJsonSchema());
+
+        // then
+        assertThat("Renders singular version of the header for single example in the collection.",
+            actualHtmlForExampleValue,
+            containsString(">Example<")
         );
     }
 
@@ -111,7 +145,7 @@ public class CodegenParameterExampleRendererTest {
         this.expectedException.expectCause(instanceOf(JsonParseException.class));
 
         // when
-        codegenParameterExampleRenderer.htmlForExampleValueOf(codegenParameter.getJsonSchema());
+        codegenParameterExampleHtmlRenderer.htmlForExampleValueOf(codegenParameter.getJsonSchema());
 
         // then
         // expectations set up in 'given' are satisfied

--- a/cms/src/test/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/ParamExampleTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/ParamExampleTest.java
@@ -1,0 +1,19 @@
+package uk.nhs.digital.apispecs.swagger.request.examplerenderer;
+
+import static uk.nhs.digital.test.util.AssertionUtils.assertClassHasFieldWithAnnotationWithAttributeValue;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.junit.Test;
+import uk.nhs.digital.apispecs.swagger.request.bodyextractor.ToPrettyJsonStringDeserializer;
+
+public class ParamExampleTest {
+
+    @Test
+    public void exampleValueIsDeserialised_usingCustomDeserializer() {
+
+        assertClassHasFieldWithAnnotationWithAttributeValue(
+            ParamExample.class, "value",
+            JsonDeserialize.class, "using", ToPrettyJsonStringDeserializer.class
+        );
+    }
+}

--- a/cms/src/test/java/uk/nhs/digital/test/util/AssertionUtils.java
+++ b/cms/src/test/java/uk/nhs/digital/test/util/AssertionUtils.java
@@ -1,0 +1,74 @@
+package uk.nhs.digital.test.util;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+public class AssertionUtils {
+
+    public static <A extends Annotation> void assertClassHasFieldWithAnnotationWithAttributeValue(
+        final Class<?> targetClass,
+        final String fieldName,
+        final Class<A> annotationClass,
+        final String annotationAttributeName,
+        final Object annotationAttributeValue
+    ) {
+        FieldUtils.getFieldsListWithAnnotation(targetClass, annotationClass)
+            .stream()
+            .filter(fieldsWithname(fieldName))
+            .findFirst()
+            .map(fieldToItsAnnotationOfType(annotationClass))
+            .map(annotationToValueOfItsAttributeWith(annotationAttributeName))
+            .filter(attributesWithValueMatching(annotationAttributeValue))
+            .orElseThrow(() ->
+                //noinspection ThrowableNotThrown
+                new AssertionError(
+                    "No matching field was found on given class.\n"
+                        + "\n              On class '" + targetClass.getName() + "'"
+                        + "\nexpected to find field '" + fieldName + "'"
+                        + "\n       with annotation '" + annotationClass.getName() + "'"
+                        + "\n        with attribute '" + annotationAttributeName + "'"
+                        + "\n                set to '" + annotationAttributeValue + "'"
+                        + "\n"
+                        + "\n...but no field was found to match all of these conditions."
+                )
+            );
+    }
+
+    @NotNull private static Predicate<Object> attributesWithValueMatching(final Object annotationAttributeValue) {
+        return obj -> annotationAttributeValue.equals(obj);
+    }
+
+    @NotNull private static <A extends Annotation> Function<Field, A> fieldToItsAnnotationOfType(final Class<A> annotationClass) {
+        return field -> field.getAnnotation(annotationClass);
+    }
+
+    @NotNull private static <A extends Annotation> Function<A, Object> annotationToValueOfItsAttributeWith(final String annotationAttributeName) {
+        return annotationInstance -> {
+            try {
+                final Method method = annotationInstance
+                    .annotationType()
+                    .getDeclaredMethod(annotationAttributeName);
+
+                if (method.getParameterCount() == 0 && method.getReturnType() != void.class) {
+                    return method.invoke(annotationInstance);
+                }
+
+            } catch (final Exception e) {
+                // Exception means we don't have a match and that's all we care about.
+                e.printStackTrace();
+            }
+
+            return null;
+        };
+    }
+
+    private static Predicate<Field> fieldsWithname(final String fieldName) {
+        return field -> field.getName().equals(fieldName);
+    }
+}

--- a/cms/src/test/resources/test-data/api-specifications/ApiSpecSyncFromApigeeJobIntegrationTest/customised-codegen-v3-generated-spec.html
+++ b/cms/src/test/resources/test-data/api-specifications/ApiSpecSyncFromApigeeJobIntegrationTest/customised-codegen-v3-generated-spec.html
@@ -1245,95 +1245,6 @@ You can request a single, exact match using <code class="codeinline">_exact-matc
                                                     
                                                             <h5 class="body__contenttype">
                                                                 <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/render-no-example-where-none-present</span>
-                                                            </h5>
-                                                    
-                                                    
-                                                    
-                                                    
-                                                            <div class="body__schema__header">Schema</div>
-                                                            <p>
-                                                                To see the schema, open
-                                                                <a class="body__schema__trythisapi__link" onclick="tryEndpointNow('/Patients/search_patient')" onkeyup="return vjsu.onKeyUp(event)">Try this API</a>
-                                                                and select the 'Schema' tab.
-                                                            </p>
-                                                    
-                                                    
-                                                            <h5 class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/render-examples-from-object-where-present-on-object-and-on-schema</span>
-                                                            </h5>
-                                                    
-                                                    
-                                                    
-                                                                <div class="body__example__header">Examples</div>
-                                                    
-                                                                <div class="body__example__summary">example A summary</div>
-                                                    
-                                                                <div class="body__example__description">example A <code class="codeinline">description</code> - should render Markdown as HTML</div>
-                                                    
-                                                                <div><pre><code>{
-  "example-value" : "example A value - should render as pretty-printed JSON"
-}</code></pre></div>
-                                                    
-                                                                <div class="body__example__summary">example B summary</div>
-                                                    
-                                                                <div class="body__example__description">example B <code class="codeinline">description</code> - should render Markdown as HTML</div>
-                                                    
-                                                                <div><pre><code>{
-  "example-value" : "example B value - should render as pretty-printed JSON"
-}</code></pre></div>
-                                                    
-                                                            <div class="body__schema__header">Schema</div>
-                                                            <p>
-                                                                To see the schema, open
-                                                                <a class="body__schema__trythisapi__link" onclick="tryEndpointNow('/Patients/search_patient')" onkeyup="return vjsu.onKeyUp(event)">Try this API</a>
-                                                                and select the 'Schema' tab.
-                                                            </p>
-                                                    
-                                                    
-                                                            <h5 class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/render-example-from-object-where-present-on-object-and-on-schema</span>
-                                                            </h5>
-                                                    
-                                                                <div class="body__example__header">Example</div>
-                                                                <div><pre><code>{
-  "example-value" : "example on media object - should render, winning over the example in the schema"
-}</code></pre></div>
-                                                    
-                                                    
-                                                    
-                                                            <div class="body__schema__header">Schema</div>
-                                                            <p>
-                                                                To see the schema, open
-                                                                <a class="body__schema__trythisapi__link" onclick="tryEndpointNow('/Patients/search_patient')" onkeyup="return vjsu.onKeyUp(event)">Try this API</a>
-                                                                and select the 'Schema' tab.
-                                                            </p>
-                                                    
-                                                    
-                                                            <h5 class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/render-example-from-schema-where-none-present-on-object</span>
-                                                            </h5>
-                                                    
-                                                    
-                                                                        <div class="body__example__header">Example</div>
-                                                                        <div><pre><code>{
-  "example-value" : "example on schema - should render as pretty-printed JSON"
-}</code></pre></div>
-                                                    
-                                                    
-                                                            <div class="body__schema__header">Schema</div>
-                                                            <p>
-                                                                To see the schema, open
-                                                                <a class="body__schema__trythisapi__link" onclick="tryEndpointNow('/Patients/search_patient')" onkeyup="return vjsu.onKeyUp(event)">Try this API</a>
-                                                                and select the 'Schema' tab.
-                                                            </p>
-                                                    
-                                                    
-                                                            <h5 class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
                                                                 <span class="body__contenttype__value">application/fhir+json</span>
                                                             </h5>
                                                     
@@ -1516,7 +1427,7 @@ You can request a single, exact match using <code class="codeinline">_exact-matc
                                                     
                                                     
                                                     
-                                                                <div class="body__example__header">Examples</div>
+                                                                        <div class="body__example__header">Examples</div>
                                                     
                                                                 <div class="body__example__summary">too few search params</div>
                                                     
@@ -2224,101 +2135,12 @@ The fourth value of gender, <code class="codeinline">other</code>, meaning indet
                                                         
                                                                 <h5 class="body__contenttype">
                                                                     <span class="body__contenttype__label">Content type: </span>
-                                                                    <span class="body__contenttype__value">application/render-no-example-where-none-present</span>
-                                                                </h5>
-                                                        
-                                                        
-                                                        
-                                                        
-                                                                <div class="body__schema__header">Schema</div>
-                                                                <p>
-                                                                    To see the schema, open
-                                                                    <a class="body__schema__trythisapi__link" onclick="tryEndpointNow('/Patients/update_patient_partial')" onkeyup="return vjsu.onKeyUp(event)">Try this API</a>
-                                                                    and select the 'Schema' tab.
-                                                                </p>
-                                                        
-                                                        
-                                                                <h5 class="body__contenttype">
-                                                                    <span class="body__contenttype__label">Content type: </span>
-                                                                    <span class="body__contenttype__value">application/render-examples-from-object-where-present-on-object-and-on-schema</span>
-                                                                </h5>
-                                                        
-                                                        
-                                                        
-                                                                    <div class="body__example__header">Examples</div>
-                                                        
-                                                                    <div class="body__example__summary">example A summary</div>
-                                                        
-                                                                    <div class="body__example__description">example A <code class="codeinline">description</code> - should render Markdown as HTML</div>
-                                                        
-                                                                    <div><pre><code>{
-  "example-value" : "example A value - should render as pretty-printed JSON"
-}</code></pre></div>
-                                                        
-                                                                    <div class="body__example__summary">example B summary</div>
-                                                        
-                                                                    <div class="body__example__description">example B <code class="codeinline">description</code> - should render Markdown as HTML</div>
-                                                        
-                                                                    <div><pre><code>{
-  "example-value" : "example B value - should render as pretty-printed JSON"
-}</code></pre></div>
-                                                        
-                                                                <div class="body__schema__header">Schema</div>
-                                                                <p>
-                                                                    To see the schema, open
-                                                                    <a class="body__schema__trythisapi__link" onclick="tryEndpointNow('/Patients/update_patient_partial')" onkeyup="return vjsu.onKeyUp(event)">Try this API</a>
-                                                                    and select the 'Schema' tab.
-                                                                </p>
-                                                        
-                                                        
-                                                                <h5 class="body__contenttype">
-                                                                    <span class="body__contenttype__label">Content type: </span>
-                                                                    <span class="body__contenttype__value">application/render-example-from-object-where-present-on-object-and-on-schema</span>
-                                                                </h5>
-                                                        
-                                                                    <div class="body__example__header">Example</div>
-                                                                    <div><pre><code>{
-  "example-value" : "example on media object - should render, winning over the example in the schema"
-}</code></pre></div>
-                                                        
-                                                        
-                                                        
-                                                                <div class="body__schema__header">Schema</div>
-                                                                <p>
-                                                                    To see the schema, open
-                                                                    <a class="body__schema__trythisapi__link" onclick="tryEndpointNow('/Patients/update_patient_partial')" onkeyup="return vjsu.onKeyUp(event)">Try this API</a>
-                                                                    and select the 'Schema' tab.
-                                                                </p>
-                                                        
-                                                        
-                                                                <h5 class="body__contenttype">
-                                                                    <span class="body__contenttype__label">Content type: </span>
-                                                                    <span class="body__contenttype__value">application/render-example-from-schema-where-none-present-on-object</span>
-                                                                </h5>
-                                                        
-                                                        
-                                                                            <div class="body__example__header">Example</div>
-                                                                            <div><pre><code>{
-  "example-value" : "example on schema - should render as pretty-printed JSON"
-}</code></pre></div>
-                                                        
-                                                        
-                                                                <div class="body__schema__header">Schema</div>
-                                                                <p>
-                                                                    To see the schema, open
-                                                                    <a class="body__schema__trythisapi__link" onclick="tryEndpointNow('/Patients/update_patient_partial')" onkeyup="return vjsu.onKeyUp(event)">Try this API</a>
-                                                                    and select the 'Schema' tab.
-                                                                </p>
-                                                        
-                                                        
-                                                                <h5 class="body__contenttype">
-                                                                    <span class="body__contenttype__label">Content type: </span>
                                                                     <span class="body__contenttype__value">application/json</span>
                                                                 </h5>
                                                         
                                                         
                                                         
-                                                                    <div class="body__example__header">Examples</div>
+                                                                            <div class="body__example__header">Examples</div>
                                                         
                                                                     <div class="body__example__summary">Add a new single item (deceasedDateTime) to the patient</div>
                                                         
@@ -2607,7 +2429,7 @@ The fourth value of gender, <code class="codeinline">other</code>, meaning indet
                                                     
                                                     
                                                     
-                                                                <div class="body__example__header">Examples</div>
+                                                                        <div class="body__example__header">Examples</div>
                                                     
                                                                 <div class="body__example__summary">Invalid NHS number supplied</div>
                                                     
@@ -2690,7 +2512,7 @@ The fourth value of gender, <code class="codeinline">other</code>, meaning indet
                                                     
                                                     
                                                     
-                                                                <div class="body__example__header">Examples</div>
+                                                                        <div class="body__example__header">Examples</div>
                                                     
                                                                 <div class="body__example__summary">Invalid If-Match header</div>
                                                     
@@ -2961,7 +2783,7 @@ Retrieval of the outcome will not occur any faster by polling more frequently. T
                                                     
                                                     
                                                     
-                                                                <div class="body__example__header">Examples</div>
+                                                                        <div class="body__example__header">Example</div>
                                                     
                                                                 <div class="body__example__summary">Business rule failure; start date was after the end date.</div>
                                                     
@@ -3004,7 +2826,7 @@ Retrieval of the outcome will not occur any faster by polling more frequently. T
                                                     
                                                     
                                                     
-                                                                <div class="body__example__header">Examples</div>
+                                                                        <div class="body__example__header">Example</div>
                                                     
                                                                 <div class="body__example__summary">Date of death cannot be removed once it has been set.</div>
                                                     
@@ -3088,7 +2910,7 @@ Retrieval of the outcome will not occur any faster by polling more frequently. T
                                                     
                                                     
                                                     
-                                                                <div class="body__example__header">Examples</div>
+                                                                        <div class="body__example__header">Example</div>
                                                     
                                                                 <div class="body__example__summary">Version mis-match</div>
                                                     

--- a/cms/src/test/resources/test-data/api-specifications/ApiSpecSyncFromApigeeJobIntegrationTest/openapi-v3-specification.json
+++ b/cms/src/test/resources/test-data/api-specifications/ApiSpecSyncFromApigeeJobIntegrationTest/openapi-v3-specification.json
@@ -248,51 +248,6 @@
                     "200": {
                         "description": "A completed search, containing zero, one, or many matching patients.",
                         "content": {
-                            "application/render-no-example-where-none-present": {
-                                "schema": {
-                                    "description": "no example on schema"
-                                }
-                            },
-                            "application/render-examples-from-object-where-present-on-object-and-on-schema": {
-                                "examples": {
-                                    "example-a": {
-                                        "summary": "example A summary",
-                                        "description": "example A `description` - should render Markdown as HTML",
-                                        "value": {
-                                            "example-value": "example A value - should render as pretty-printed JSON"
-                                        }
-                                    },
-                                    "example-b": {
-                                        "summary": "example B summary",
-                                        "description": "example B `description` - should render Markdown as HTML",
-                                        "value": {
-                                            "example-value": "example B value - should render as pretty-printed JSON"
-                                        }
-                                    }
-                                },
-                                "schema": {
-                                    "example": {
-                                        "example-value": "example on schema - should NOT render, overridden by examples on the Media Type Object"
-                                    }
-                                }
-                            },
-                            "application/render-example-from-object-where-present-on-object-and-on-schema": {
-                                "example": {
-                                    "example-value": "example on media object - should render, winning over the example in the schema"
-                                },
-                                "schema": {
-                                    "example": {
-                                        "example-value": "example on schema - should NOT render, overridden by example on the Media Type Object"
-                                    }
-                                }
-                            },
-                            "application/render-example-from-schema-where-none-present-on-object": {
-                                "schema": {
-                                    "example": {
-                                        "example-value": "example on schema - should render as pretty-printed JSON"
-                                    }
-                                }
-                            },
                             "application/fhir+json": {
                                 "schema": {
                                     "type": "object",
@@ -3798,51 +3753,6 @@
                 "requestBody": {
                     "required": true,
                     "content": {
-                        "application/render-no-example-where-none-present": {
-                            "schema": {
-                                "description": "no example on schema"
-                            }
-                        },
-                        "application/render-examples-from-object-where-present-on-object-and-on-schema": {
-                            "examples": {
-                                "example-a": {
-                                    "summary": "example A summary",
-                                    "description": "example A `description` - should render Markdown as HTML",
-                                    "value": {
-                                        "example-value": "example A value - should render as pretty-printed JSON"
-                                    }
-                                },
-                                "example-b": {
-                                    "summary": "example B summary",
-                                    "description": "example B `description` - should render Markdown as HTML",
-                                    "value": {
-                                        "example-value": "example B value - should render as pretty-printed JSON"
-                                    }
-                                }
-                            },
-                            "schema": {
-                                "example": {
-                                    "example-value": "example on schema - should NOT render, overridden by examples on the Media Type Object"
-                                }
-                            }
-                        },
-                        "application/render-example-from-object-where-present-on-object-and-on-schema": {
-                            "example": {
-                                "example-value": "example on media object - should render, winning over the example in the schema"
-                            },
-                            "schema": {
-                                "example": {
-                                    "example-value": "example on schema - should NOT render, overridden by example on the Media Type Object"
-                                }
-                            }
-                        },
-                        "application/render-example-from-schema-where-none-present-on-object": {
-                            "schema": {
-                                "example": {
-                                    "example-value": "example on schema - should render as pretty-printed JSON"
-                                }
-                            }
-                        },
                         "application/json": {
                             "schema": {
                                 "type": "object",

--- a/cms/src/test/resources/test-data/api-specifications/BodyRenderingTest/bodyWithMediaTypeObjectWithExampleObject.html
+++ b/cms/src/test/resources/test-data/api-specifications/BodyRenderingTest/bodyWithMediaTypeObjectWithExampleObject.html
@@ -1,0 +1,27 @@
+
+
+        <h5 class="body__contenttype">
+            <span class="body__contenttype__label">Content type: </span>
+            <span class="body__contenttype__value">application/json</span>
+        </h5>
+
+
+
+                    <div class="body__example__header">Example</div>
+
+            <div class="body__example__summary">Example Object's summary - one liner, plain text</div>
+
+            <div class="body__example__description">Example Object's summary - multiline <code class="codeinline">CommonMark</code></div>
+
+            <div><pre><code>{
+  "json" : "Example Object's value as JSON"
+}</code></pre></div>
+
+        <div class="body__schema__header">Schema</div>
+        <p>
+            To see the schema, open
+            <a class="body__schema__trythisapi__link" onclick="tryEndpointNow('//')" onkeyup="return vjsu.onKeyUp(event)">Try this API</a>
+            and select the 'Schema' tab.
+        </p>
+
+

--- a/cms/src/test/resources/test-data/api-specifications/BodyRenderingTest/bodyWithMediaTypeObjectWithExampleObject.json
+++ b/cms/src/test/resources/test-data/api-specifications/BodyRenderingTest/bodyWithMediaTypeObjectWithExampleObject.json
@@ -1,0 +1,15 @@
+{
+    "content": {
+        "application/json": {
+            "examples": {
+                "complete-example-object": {
+                    "summary": "Example Object's summary - one liner, plain text",
+                    "description": "Example Object's summary - multiline `CommonMark`",
+                    "value": {
+                        "json": "Example Object's value as JSON"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/cms/src/test/resources/test-data/api-specifications/BodyRenderingTest/completeBodyWithMultipleMediaTypeObjects.html
+++ b/cms/src/test/resources/test-data/api-specifications/BodyRenderingTest/completeBodyWithMultipleMediaTypeObjects.html
@@ -1,0 +1,53 @@
+
+
+        <h5 class="body__contenttype">
+            <span class="body__contenttype__label">Content type: </span>
+            <span class="body__contenttype__value">application/first-content-type</span>
+        </h5>
+
+            <div class="body__example__header">Example</div>
+            <div><pre><code>{
+  "simple" : "example defined as JSON"
+}</code></pre></div>
+
+
+
+        <div class="body__schema__header">Schema</div>
+        <p>
+            To see the schema, open
+            <a class="body__schema__trythisapi__link" onclick="tryEndpointNow('//')" onkeyup="return vjsu.onKeyUp(event)">Try this API</a>
+            and select the 'Schema' tab.
+        </p>
+
+
+        <h5 class="body__contenttype">
+            <span class="body__contenttype__label">Content type: </span>
+            <span class="body__contenttype__value">application/second-content-type</span>
+        </h5>
+
+
+
+                    <div class="body__example__header">Examples</div>
+
+            <div class="body__example__summary">first example - summary</div>
+
+            <div class="body__example__description">first example - description with <code class="codeinline">Markdown</code></div>
+
+            <div><pre><code>{
+  "first" : "example with value as JSON"
+}</code></pre></div>
+
+            <div class="body__example__summary">second example - summary</div>
+
+            <div class="body__example__description">second example - description with <code class="codeinline">Markdown</code></div>
+
+            <div><pre><code>second example with simple text value</code></pre></div>
+
+        <div class="body__schema__header">Schema</div>
+        <p>
+            To see the schema, open
+            <a class="body__schema__trythisapi__link" onclick="tryEndpointNow('//')" onkeyup="return vjsu.onKeyUp(event)">Try this API</a>
+            and select the 'Schema' tab.
+        </p>
+
+

--- a/cms/src/test/resources/test-data/api-specifications/BodyRenderingTest/completeBodyWithMultipleMediaTypeObjects.json
+++ b/cms/src/test/resources/test-data/api-specifications/BodyRenderingTest/completeBodyWithMultipleMediaTypeObjects.json
@@ -1,0 +1,25 @@
+{
+    "content": {
+        "application/first-content-type": {
+            "example": {
+                "simple": "example defined as JSON"
+            }
+        },
+        "application/second-content-type": {
+            "examples": {
+                "first": {
+                    "summary": "first example - summary",
+                    "description": "first example - description with `Markdown`",
+                    "value": {
+                        "first" : "example with value as JSON"
+                    }
+                },
+                "second": {
+                    "summary": "second example - summary",
+                    "description": "second example - description with `Markdown`",
+                    "value": "second example with simple text value"
+                }
+            }
+        }
+    }
+}

--- a/cms/src/test/resources/test-data/api-specifications/BodyRenderingTest/exampleOnMediaTypeObjectAndOnSchema.json
+++ b/cms/src/test/resources/test-data/api-specifications/BodyRenderingTest/exampleOnMediaTypeObjectAndOnSchema.json
@@ -1,0 +1,10 @@
+{
+    "content": {
+        "application/json": {
+            "example": "simple example specified in MediaTypeObject's definition",
+            "schema": {
+                "example": "example specified in MediaTypeObject's schema"
+            }
+        }
+    }
+}

--- a/cms/src/test/resources/test-data/api-specifications/BodyRenderingTest/exampleOnSchemaNoneOnMediaTypeObject.json
+++ b/cms/src/test/resources/test-data/api-specifications/BodyRenderingTest/exampleOnSchemaNoneOnMediaTypeObject.json
@@ -1,0 +1,9 @@
+{
+    "content": {
+        "application/json": {
+            "schema": {
+                "example": "example specified in MediaTypeObject's schema"
+            }
+        }
+    }
+}

--- a/cms/src/test/resources/test-data/api-specifications/BodyRenderingTest/examplesOnMediaTypeObjectAndOnSchema.json
+++ b/cms/src/test/resources/test-data/api-specifications/BodyRenderingTest/examplesOnMediaTypeObjectAndOnSchema.json
@@ -1,0 +1,17 @@
+{
+    "content": {
+        "application/json": {
+            "examples": {
+                "first": {
+                    "value": "first example from request MediaTypeObject's definition"
+                },
+                "second": {
+                    "value": "second example from request MediaTypeObject's definition"
+                }
+            },
+            "schema": {
+                "example": "example specified in MediaTypeObject's schema"
+            }
+        }
+    }
+}

--- a/cms/src/test/resources/test-data/api-specifications/BodyRenderingTest/multipleExamplesInCollectionOnMediaTypeObject.json
+++ b/cms/src/test/resources/test-data/api-specifications/BodyRenderingTest/multipleExamplesInCollectionOnMediaTypeObject.json
@@ -1,0 +1,10 @@
+{
+    "content": {
+        "application/json": {
+            "examples": {
+                "first": {},
+                "second": {}
+            }
+        }
+    }
+}

--- a/cms/src/test/resources/test-data/api-specifications/BodyRenderingTest/singleExampleInCollectionOnMediaTypeObject.json
+++ b/cms/src/test/resources/test-data/api-specifications/BodyRenderingTest/singleExampleInCollectionOnMediaTypeObject.json
@@ -1,0 +1,9 @@
+{
+    "content": {
+        "application/json": {
+            "examples": {
+                "first": {}
+            }
+        }
+    }
+}

--- a/cms/src/test/resources/test-data/api-specifications/CodegenRequestParameterExampleGeneratorTest/exampleSpecifiedInParamDefinitionAndInSchema_expectedHtml.html
+++ b/cms/src/test/resources/test-data/api-specifications/CodegenRequestParameterExampleGeneratorTest/exampleSpecifiedInParamDefinitionAndInSchema_expectedHtml.html
@@ -1,1 +1,0 @@
-Example: <code class="codeinline">simple example specified in parameter's definition</code>

--- a/cms/src/test/resources/test-data/api-specifications/CodegenRequestParameterExampleGeneratorTest/exampleSpecifiedInParamSchemaNoneInDefinition_expectedHtml.html
+++ b/cms/src/test/resources/test-data/api-specifications/CodegenRequestParameterExampleGeneratorTest/exampleSpecifiedInParamSchemaNoneInDefinition_expectedHtml.html
@@ -1,1 +1,0 @@
-Example: <code class="codeinline">example specified in parameter's schema</code>

--- a/cms/src/test/resources/test-data/api-specifications/CodegenRequestParameterExampleGeneratorTest/multipleExamplesSpecifiedInParamDefinition_paramDefinition.json
+++ b/cms/src/test/resources/test-data/api-specifications/CodegenRequestParameterExampleGeneratorTest/multipleExamplesSpecifiedInParamDefinition_paramDefinition.json
@@ -1,0 +1,17 @@
+{
+  "examples": {
+    "first": {
+      "summary": "Example A from request parameter's definition - summary",
+      "description": "Example A from request parameter's definition - description with `Markdown`",
+      "value": "Example A from request parameter's definition - value"
+    },
+    "second": {
+      "summary": "Example B from request parameter's definition - summary",
+      "description": "Example B from request parameter's definition - description with `Markdown`",
+      "value": "Example B from request parameter's definition - value"
+    }
+  },
+  "schema": {
+    "example": "example specified in parameter's schema"
+  }
+}

--- a/cms/src/test/resources/test-data/api-specifications/CodegenRequestParameterExampleGeneratorTest/singleExampleSpecifiedInParamDefinition_paramDefinition.json
+++ b/cms/src/test/resources/test-data/api-specifications/CodegenRequestParameterExampleGeneratorTest/singleExampleSpecifiedInParamDefinition_paramDefinition.json
@@ -1,0 +1,9 @@
+{
+  "examples": {
+    "first": {
+      "summary": "Example A from request parameter's definition - summary",
+      "description": "Example A from request parameter's definition - description with `Markdown`",
+      "value": "Example A from request parameter's definition - value"
+    }
+  }
+}

--- a/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/customised-codegen-v3-generated-spec.html
+++ b/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/customised-codegen-v3-generated-spec.html
@@ -1245,95 +1245,6 @@ You can request a single, exact match using <code class="codeinline">_exact-matc
                                                     
                                                             <h5 class="body__contenttype">
                                                                 <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/render-no-example-where-none-present</span>
-                                                            </h5>
-                                                    
-                                                    
-                                                    
-                                                    
-                                                            <div class="body__schema__header">Schema</div>
-                                                            <p>
-                                                                To see the schema, open
-                                                                <a class="body__schema__trythisapi__link" onclick="tryEndpointNow('/Patients/search_patient')" onkeyup="return vjsu.onKeyUp(event)">Try this API</a>
-                                                                and select the 'Schema' tab.
-                                                            </p>
-                                                    
-                                                    
-                                                            <h5 class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/render-examples-from-object-where-present-on-object-and-on-schema</span>
-                                                            </h5>
-                                                    
-                                                    
-                                                    
-                                                                <div class="body__example__header">Examples</div>
-                                                    
-                                                                <div class="body__example__summary">example A summary</div>
-                                                    
-                                                                <div class="body__example__description">example A <code class="codeinline">description</code> - should render Markdown as HTML</div>
-                                                    
-                                                                <div><pre><code>{
-  "example-value" : "example A value - should render as pretty-printed JSON"
-}</code></pre></div>
-                                                    
-                                                                <div class="body__example__summary">example B summary</div>
-                                                    
-                                                                <div class="body__example__description">example B <code class="codeinline">description</code> - should render Markdown as HTML</div>
-                                                    
-                                                                <div><pre><code>{
-  "example-value" : "example B value - should render as pretty-printed JSON"
-}</code></pre></div>
-                                                    
-                                                            <div class="body__schema__header">Schema</div>
-                                                            <p>
-                                                                To see the schema, open
-                                                                <a class="body__schema__trythisapi__link" onclick="tryEndpointNow('/Patients/search_patient')" onkeyup="return vjsu.onKeyUp(event)">Try this API</a>
-                                                                and select the 'Schema' tab.
-                                                            </p>
-                                                    
-                                                    
-                                                            <h5 class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/render-example-from-object-where-present-on-object-and-on-schema</span>
-                                                            </h5>
-                                                    
-                                                                <div class="body__example__header">Example</div>
-                                                                <div><pre><code>{
-  "example-value" : "example on media object - should render, winning over the example in the schema"
-}</code></pre></div>
-                                                    
-                                                    
-                                                    
-                                                            <div class="body__schema__header">Schema</div>
-                                                            <p>
-                                                                To see the schema, open
-                                                                <a class="body__schema__trythisapi__link" onclick="tryEndpointNow('/Patients/search_patient')" onkeyup="return vjsu.onKeyUp(event)">Try this API</a>
-                                                                and select the 'Schema' tab.
-                                                            </p>
-                                                    
-                                                    
-                                                            <h5 class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/render-example-from-schema-where-none-present-on-object</span>
-                                                            </h5>
-                                                    
-                                                    
-                                                                        <div class="body__example__header">Example</div>
-                                                                        <div><pre><code>{
-  "example-value" : "example on schema - should render as pretty-printed JSON"
-}</code></pre></div>
-                                                    
-                                                    
-                                                            <div class="body__schema__header">Schema</div>
-                                                            <p>
-                                                                To see the schema, open
-                                                                <a class="body__schema__trythisapi__link" onclick="tryEndpointNow('/Patients/search_patient')" onkeyup="return vjsu.onKeyUp(event)">Try this API</a>
-                                                                and select the 'Schema' tab.
-                                                            </p>
-                                                    
-                                                    
-                                                            <h5 class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
                                                                 <span class="body__contenttype__value">application/fhir+json</span>
                                                             </h5>
                                                     
@@ -1516,7 +1427,7 @@ You can request a single, exact match using <code class="codeinline">_exact-matc
                                                     
                                                     
                                                     
-                                                                <div class="body__example__header">Examples</div>
+                                                                        <div class="body__example__header">Examples</div>
                                                     
                                                                 <div class="body__example__summary">too few search params</div>
                                                     
@@ -2224,101 +2135,12 @@ The fourth value of gender, <code class="codeinline">other</code>, meaning indet
                                                         
                                                                 <h5 class="body__contenttype">
                                                                     <span class="body__contenttype__label">Content type: </span>
-                                                                    <span class="body__contenttype__value">application/render-no-example-where-none-present</span>
-                                                                </h5>
-                                                        
-                                                        
-                                                        
-                                                        
-                                                                <div class="body__schema__header">Schema</div>
-                                                                <p>
-                                                                    To see the schema, open
-                                                                    <a class="body__schema__trythisapi__link" onclick="tryEndpointNow('/Patients/update_patient_partial')" onkeyup="return vjsu.onKeyUp(event)">Try this API</a>
-                                                                    and select the 'Schema' tab.
-                                                                </p>
-                                                        
-                                                        
-                                                                <h5 class="body__contenttype">
-                                                                    <span class="body__contenttype__label">Content type: </span>
-                                                                    <span class="body__contenttype__value">application/render-examples-from-object-where-present-on-object-and-on-schema</span>
-                                                                </h5>
-                                                        
-                                                        
-                                                        
-                                                                    <div class="body__example__header">Examples</div>
-                                                        
-                                                                    <div class="body__example__summary">example A summary</div>
-                                                        
-                                                                    <div class="body__example__description">example A <code class="codeinline">description</code> - should render Markdown as HTML</div>
-                                                        
-                                                                    <div><pre><code>{
-  "example-value" : "example A value - should render as pretty-printed JSON"
-}</code></pre></div>
-                                                        
-                                                                    <div class="body__example__summary">example B summary</div>
-                                                        
-                                                                    <div class="body__example__description">example B <code class="codeinline">description</code> - should render Markdown as HTML</div>
-                                                        
-                                                                    <div><pre><code>{
-  "example-value" : "example B value - should render as pretty-printed JSON"
-}</code></pre></div>
-                                                        
-                                                                <div class="body__schema__header">Schema</div>
-                                                                <p>
-                                                                    To see the schema, open
-                                                                    <a class="body__schema__trythisapi__link" onclick="tryEndpointNow('/Patients/update_patient_partial')" onkeyup="return vjsu.onKeyUp(event)">Try this API</a>
-                                                                    and select the 'Schema' tab.
-                                                                </p>
-                                                        
-                                                        
-                                                                <h5 class="body__contenttype">
-                                                                    <span class="body__contenttype__label">Content type: </span>
-                                                                    <span class="body__contenttype__value">application/render-example-from-object-where-present-on-object-and-on-schema</span>
-                                                                </h5>
-                                                        
-                                                                    <div class="body__example__header">Example</div>
-                                                                    <div><pre><code>{
-  "example-value" : "example on media object - should render, winning over the example in the schema"
-}</code></pre></div>
-                                                        
-                                                        
-                                                        
-                                                                <div class="body__schema__header">Schema</div>
-                                                                <p>
-                                                                    To see the schema, open
-                                                                    <a class="body__schema__trythisapi__link" onclick="tryEndpointNow('/Patients/update_patient_partial')" onkeyup="return vjsu.onKeyUp(event)">Try this API</a>
-                                                                    and select the 'Schema' tab.
-                                                                </p>
-                                                        
-                                                        
-                                                                <h5 class="body__contenttype">
-                                                                    <span class="body__contenttype__label">Content type: </span>
-                                                                    <span class="body__contenttype__value">application/render-example-from-schema-where-none-present-on-object</span>
-                                                                </h5>
-                                                        
-                                                        
-                                                                            <div class="body__example__header">Example</div>
-                                                                            <div><pre><code>{
-  "example-value" : "example on schema - should render as pretty-printed JSON"
-}</code></pre></div>
-                                                        
-                                                        
-                                                                <div class="body__schema__header">Schema</div>
-                                                                <p>
-                                                                    To see the schema, open
-                                                                    <a class="body__schema__trythisapi__link" onclick="tryEndpointNow('/Patients/update_patient_partial')" onkeyup="return vjsu.onKeyUp(event)">Try this API</a>
-                                                                    and select the 'Schema' tab.
-                                                                </p>
-                                                        
-                                                        
-                                                                <h5 class="body__contenttype">
-                                                                    <span class="body__contenttype__label">Content type: </span>
                                                                     <span class="body__contenttype__value">application/json</span>
                                                                 </h5>
                                                         
                                                         
                                                         
-                                                                    <div class="body__example__header">Examples</div>
+                                                                            <div class="body__example__header">Examples</div>
                                                         
                                                                     <div class="body__example__summary">Add a new single item (deceasedDateTime) to the patient</div>
                                                         
@@ -2607,7 +2429,7 @@ The fourth value of gender, <code class="codeinline">other</code>, meaning indet
                                                     
                                                     
                                                     
-                                                                <div class="body__example__header">Examples</div>
+                                                                        <div class="body__example__header">Examples</div>
                                                     
                                                                 <div class="body__example__summary">Invalid NHS number supplied</div>
                                                     
@@ -2690,7 +2512,7 @@ The fourth value of gender, <code class="codeinline">other</code>, meaning indet
                                                     
                                                     
                                                     
-                                                                <div class="body__example__header">Examples</div>
+                                                                        <div class="body__example__header">Examples</div>
                                                     
                                                                 <div class="body__example__summary">Invalid If-Match header</div>
                                                     
@@ -2961,7 +2783,7 @@ Retrieval of the outcome will not occur any faster by polling more frequently. T
                                                     
                                                     
                                                     
-                                                                <div class="body__example__header">Examples</div>
+                                                                        <div class="body__example__header">Example</div>
                                                     
                                                                 <div class="body__example__summary">Business rule failure; start date was after the end date.</div>
                                                     
@@ -3004,7 +2826,7 @@ Retrieval of the outcome will not occur any faster by polling more frequently. T
                                                     
                                                     
                                                     
-                                                                <div class="body__example__header">Examples</div>
+                                                                        <div class="body__example__header">Example</div>
                                                     
                                                                 <div class="body__example__summary">Date of death cannot be removed once it has been set.</div>
                                                     
@@ -3088,7 +2910,7 @@ Retrieval of the outcome will not occur any faster by polling more frequently. T
                                                     
                                                     
                                                     
-                                                                <div class="body__example__header">Examples</div>
+                                                                        <div class="body__example__header">Example</div>
                                                     
                                                                 <div class="body__example__summary">Version mis-match</div>
                                                     

--- a/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/openapi-v3-specification.json
+++ b/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/openapi-v3-specification.json
@@ -248,51 +248,6 @@
                     "200": {
                         "description": "A completed search, containing zero, one, or many matching patients.",
                         "content": {
-                            "application/render-no-example-where-none-present": {
-                                "schema": {
-                                    "description": "no example on schema"
-                                }
-                            },
-                            "application/render-examples-from-object-where-present-on-object-and-on-schema": {
-                                "examples": {
-                                    "example-a": {
-                                        "summary": "example A summary",
-                                        "description": "example A `description` - should render Markdown as HTML",
-                                        "value": {
-                                            "example-value": "example A value - should render as pretty-printed JSON"
-                                        }
-                                    },
-                                    "example-b": {
-                                        "summary": "example B summary",
-                                        "description": "example B `description` - should render Markdown as HTML",
-                                        "value": {
-                                            "example-value": "example B value - should render as pretty-printed JSON"
-                                        }
-                                    }
-                                },
-                                "schema": {
-                                    "example": {
-                                        "example-value": "example on schema - should NOT render, overridden by examples on the Media Type Object"
-                                    }
-                                }
-                            },
-                            "application/render-example-from-object-where-present-on-object-and-on-schema": {
-                                "example": {
-                                    "example-value": "example on media object - should render, winning over the example in the schema"
-                                },
-                                "schema": {
-                                    "example": {
-                                        "example-value": "example on schema - should NOT render, overridden by example on the Media Type Object"
-                                    }
-                                }
-                            },
-                            "application/render-example-from-schema-where-none-present-on-object": {
-                                "schema": {
-                                    "example": {
-                                        "example-value": "example on schema - should render as pretty-printed JSON"
-                                    }
-                                }
-                            },
                             "application/fhir+json": {
                                 "schema": {
                                     "type": "object",
@@ -3798,51 +3753,6 @@
                 "requestBody": {
                     "required": true,
                     "content": {
-                        "application/render-no-example-where-none-present": {
-                            "schema": {
-                                "description": "no example on schema"
-                            }
-                        },
-                        "application/render-examples-from-object-where-present-on-object-and-on-schema": {
-                            "examples": {
-                                "example-a": {
-                                    "summary": "example A summary",
-                                    "description": "example A `description` - should render Markdown as HTML",
-                                    "value": {
-                                        "example-value": "example A value - should render as pretty-printed JSON"
-                                    }
-                                },
-                                "example-b": {
-                                    "summary": "example B summary",
-                                    "description": "example B `description` - should render Markdown as HTML",
-                                    "value": {
-                                        "example-value": "example B value - should render as pretty-printed JSON"
-                                    }
-                                }
-                            },
-                            "schema": {
-                                "example": {
-                                    "example-value": "example on schema - should NOT render, overridden by examples on the Media Type Object"
-                                }
-                            }
-                        },
-                        "application/render-example-from-object-where-present-on-object-and-on-schema": {
-                            "example": {
-                                "example-value": "example on media object - should render, winning over the example in the schema"
-                            },
-                            "schema": {
-                                "example": {
-                                    "example-value": "example on schema - should NOT render, overridden by example on the Media Type Object"
-                                }
-                            }
-                        },
-                        "application/render-example-from-schema-where-none-present-on-object": {
-                            "schema": {
-                                "example": {
-                                    "example-value": "example on schema - should render as pretty-printed JSON"
-                                }
-                            }
-                        },
                         "application/json": {
                             "schema": {
                                 "type": "object",

--- a/cms/src/test/resources/test-data/api-specifications/ToPrettyJsonStringDeserializerTest/nestedJsonWithQuotes.json
+++ b/cms/src/test/resources/test-data/api-specifications/ToPrettyJsonStringDeserializerTest/nestedJsonWithQuotes.json
@@ -1,0 +1,5 @@
+{
+    "property" : {
+        "nested-property": "with \"quotes\""
+    }
+}

--- a/cms/src/test/resources/test-data/api-specifications/ToPrettyJsonStringDeserializerTest/plainText.json
+++ b/cms/src/test/resources/test-data/api-specifications/ToPrettyJsonStringDeserializerTest/plainText.json
@@ -1,0 +1,3 @@
+{
+    "property" : "plain text"
+}

--- a/cms/src/test/resources/test-data/api-specifications/ToPrettyJsonStringDeserializerTest/plainTextWithQuotes.json
+++ b/cms/src/test/resources/test-data/api-specifications/ToPrettyJsonStringDeserializerTest/plainTextWithQuotes.json
@@ -1,0 +1,3 @@
+{
+    "property" : "plain text with \"quotes\""
+}

--- a/vars.mk
+++ b/vars.mk
@@ -11,14 +11,25 @@ SPLUNK_URL ?= http://localhost
 PROFILE_RUN ?= cargo.run
 S3_BUCKET ?= files.local.nhsd.io
 S3_REGION ?= eu-west-1
+
+# Settings related to automated imports of OAS specifications
+# into API Specification documents from Apigee.
+# Override relevant variables (typically only APIGEE_USER, APIGEE_PASS and APIGEE_OTPKEY)
+# in env.mk if you actually need to work on this integration.
+#
+# Note that the default value of APIGEE_BASIC is not really a secret,
+# as it is a static, publicly available header value required by Apigee to obtain
+# OAuth2 access and refresh tokens:
+# https://docs.apigee.com/api-platform/system-administration/management-api-tokens#note
+#
 APIGEE_SYNC_ENABLED ?= false
 APIGEE_SYNC_CRON ?= 0 0/1 * ? * *
 APIGEE_TOKEN_URL ?= https://login.apigee.com/oauth/token
 APIGEE_SPECS_ALL_URL ?= https://apigee.com/dapi/api/organizations/nhsd-nonprod/specs/folder/home
 APIGEE_SPECS_ONE_URL ?= https://apigee.com/dapi/api/organizations/nhsd-nonprod/specs/doc/{specificationId}/content
-APIGEE_USER ?=
-APIGEE_PASS ?=
-APIGEE_OTPKEY ?=
+APIGEE_USER ?= REPLACE_WITH_ACTUAL_APIGEE_USERNAME
+APIGEE_PASS ?= REPLACE_WITH_ACTUAL_APIGEE_PASSWORD
+APIGEE_OTPKEY ?= REPLACE_WITH_ACTUAL_APIGEE_OTPKEY
 APIGEE_BASIC ?= ZWRnZWNsaTplZGdlY2xpc2VjcmV0
 
 #-Dsplunk.token=$(SPLUNK_TOKEN) \


### PR DESCRIPTION
Fixes the 'Example/Examples' headers to apply
plural form only when there is more than one
example to render.

Moves rendering of Markdown-to-HTML to the
templates rendering phase, rather than do it
in the model preparation phase.

Makes the template/rendering tests more
fine-grained and targeted to make them easier
to manage and improve test coverage.

Configures default (bogus) values of Aigee details
used when running the application using
'make serve'. Apparently, their lack was breaking
all CRISP clients (i.e. not just the one used for
communication with Apigee which actually uses those
parameters), at least in the CMS module.