### PR TITLE
[DW-1633] Add News Hub

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/translations/templates.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/translations/templates.yaml
@@ -325,7 +325,7 @@ definitions:
         jcr:primaryType: hipposys:resourcebundles
       /website:dschomepage:
         /en:
-          jcr:name: Digital Security Homepage
+          jcr:name: Generic Homepage
           jcr:primaryType: hipposys:resourcebundle
         jcr:primaryType: hipposys:resourcebundles
       /website:dynamicchartsection:
@@ -516,6 +516,11 @@ definitions:
       /website:news:
         /en:
           jcr:name: News
+          jcr:primaryType: hipposys:resourcebundle
+        jcr:primaryType: hipposys:resourcebundles
+      /website:newshub:
+        /en:
+          jcr:name: News Hub
           jcr:primaryType: hipposys:resourcebundle
         jcr:primaryType: hipposys:resourcebundles
       /website:nonmandatoryexternalbaselink:

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/website.cnd
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/website.cnd
@@ -3,16 +3,9 @@
 <'hippostd'='http://www.onehippo.org/jcr/hippostd/nt/2.0'>
 <'hippostdpubwf'='http://www.onehippo.org/jcr/hippostdpubwf/nt/1.0'>
 <'common'='http://digital.nhs.uk/jcr/common/nt/1.0'>
-<'hippotranslation'='http://www.onehippo.org/jcr/hippotranslation/nt/1.0'>
 <'hippotaxonomy'='http://www.hippoecm.org/hippotaxonomy/nt/1.2'>
+<'hippotranslation'='http://www.onehippo.org/jcr/hippotranslation/nt/1.0'>
 <'hippogallery'='http://www.onehippo.org/jcr/hippogallery/nt/2.0'>
-
-[website:basedocument] > hippo:document, hippostd:publishableSummary, hippostdpubwf:document
-  orderable
-  - common:searchable (boolean) = 'true' autocreated
-
-[website:financial] > hippostd:relaxed, hippotranslation:translated, website:basedocument
-  orderable
 
 [website:aboutapi] > hippo:compound, hippostd:relaxed
   orderable
@@ -20,8 +13,9 @@
 [website:address] > hippo:compound, hippostd:relaxed
   orderable
 
-[website:hubnewsandevents] > hippostd:relaxed, hippotaxonomy:classifiable, hippotranslation:translated, website:basedocument
+[website:basedocument] > hippo:document, hippostd:publishableSummary, hippostdpubwf:document
   orderable
+  - common:searchable (boolean) = 'true' autocreated
 
 [website:apiendpoint] > hippostd:relaxed, hippotaxonomy:classifiable, hippotranslation:translated, website:basedocument
   orderable
@@ -154,6 +148,9 @@
 [website:externallinkbase] > hippo:compound, hippostd:relaxed
   orderable
 
+[website:financial] > hippostd:relaxed, hippotranslation:translated, website:basedocument
+  orderable
+
 [website:friendlyurls] > hippo:compound, hippostd:relaxed
   orderable
 
@@ -245,6 +242,9 @@
   orderable
 
 [website:news] > hippostd:relaxed, hippotranslation:translated, website:basedocument
+  orderable
+
+[website:newshub] > hippostd:relaxed, hippotranslation:translated, website:basedocument
   orderable
 
 [website:nonmandatoryexternallinkbase] > hippo:compound, hippostd:relaxed

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/website/newshub.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/website/newshub.yaml
@@ -1,0 +1,133 @@
+---
+definitions:
+  config:
+    /hippo:namespaces/website/newshub:
+      /editor:templates:
+        /_default_:
+          jcr:primaryType: frontend:plugincluster
+          frontend:properties:
+          - mode
+          frontend:references:
+          - wicket.model
+          - model.compareTo
+          - engine
+          - validator.id
+          frontend:services:
+          - wicket.id
+          - validator.id
+          /root:
+            item: ${cluster.id}.field
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.service.render.ListViewPlugin
+          /title:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Title
+            field: title
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /summary:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Summary
+            field: summary
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /seoSummary:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: seoSummary
+            field: seoSummary
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.field
+          /bannerimagelink:
+            /cluster.options:
+              jcr:primaryType: frontend:pluginconfig
+            caption: Link to Banner image
+            field: bannerimagelink
+            hint: ''
+            jcr:primaryType: frontend:plugin
+            plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
+            wicket.id: ${cluster.id}.field
+        jcr:primaryType: editor:templateset
+      /hipposysedit:nodetype:
+        /hipposysedit:nodetype:
+          /bannerimagelink:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: website:bannerimagelink
+            hipposysedit:primary: false
+            hipposysedit:type: hippogallerypicker:imagelink
+            jcr:primaryType: hipposysedit:field
+          /seoSummary:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: website:seoSummary
+            hipposysedit:primary: false
+            hipposysedit:type: hippostd:seoSummary
+            jcr:primaryType: hipposysedit:field
+          /summary:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: website:summary
+            hipposysedit:primary: false
+            hipposysedit:type: String
+            jcr:primaryType: hipposysedit:field
+          /title:
+            hipposysedit:mandatory: false
+            hipposysedit:multiple: false
+            hipposysedit:ordered: false
+            hipposysedit:path: website:title
+            hipposysedit:primary: false
+            hipposysedit:type: String
+            jcr:primaryType: hipposysedit:field
+          hipposysedit:node: true
+          hipposysedit:supertype:
+          - website:basedocument
+          - hippostd:relaxed
+          - hippotranslation:translated
+          hipposysedit:uri: http://digital.nhs.uk/jcr/website/nt/1.0
+          jcr:mixinTypes:
+          - mix:referenceable
+          - hipposysedit:remodel
+          jcr:primaryType: hipposysedit:nodetype
+        jcr:mixinTypes:
+        - mix:referenceable
+        jcr:primaryType: hippo:handle
+      /hipposysedit:prototypes:
+        /hipposysedit:prototype:
+          /website:bannerimagelink:
+            hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
+            hippo:facets: []
+            hippo:modes: []
+            hippo:values: []
+            jcr:primaryType: hippogallerypicker:imagelink
+          /website:seoSummary:
+            hippostd:content: ''
+            jcr:primaryType: hippostd:html
+          common:searchable: true
+          hippostd:holder: holder
+          hippostd:state: draft
+          hippostdpubwf:createdBy: ''
+          hippostdpubwf:creationDate: 2020-03-16T14:47:50.794Z
+          hippostdpubwf:lastModificationDate: 2020-03-16T14:47:50.793Z
+          hippostdpubwf:lastModifiedBy: ''
+          hippotranslation:id: document-type-locale-id
+          hippotranslation:locale: document-type-locale
+          jcr:mixinTypes:
+          - mix:referenceable
+          jcr:primaryType: website:newshub
+          website:summary: ''
+          website:title: ''
+        jcr:primaryType: hipposysedit:prototypeset
+      jcr:mixinTypes:
+      - editor:editable
+      - mix:referenceable
+      jcr:primaryType: hipposysedit:templatetype

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/news.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/news.yaml
@@ -1,8 +1,7 @@
 ---
-/content/documents/corporate-website/news-and-events:
-  .meta:order-before: news
-  /news-hub:
-    /news-hub[1]:
+/content/documents/corporate-website/news:
+  /content:
+    /content[1]:
       /website:bannerimagelink:
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
         hippo:facets: []
@@ -16,17 +15,18 @@
       hippo:availability: []
       hippostd:state: draft
       hippostdpubwf:createdBy: admin
-      hippostdpubwf:creationDate: 2020-10-12T22:01:00.856Z
-      hippostdpubwf:lastModificationDate: 2020-10-12T22:01:00.856Z
+      hippostdpubwf:creationDate: 2020-10-23T10:12:58.159Z
+      hippostdpubwf:lastModificationDate: 2020-10-23T10:12:58.159Z
       hippostdpubwf:lastModifiedBy: admin
-      hippotranslation:id: 1a223e01-87fe-45b2-b3f8-4d7718122fe5
+      hippotranslation:id: e9ae3d3e-3ce9-4542-8553-7f6167a8163f
       hippotranslation:locale: en
       jcr:mixinTypes:
       - mix:referenceable
-      jcr:primaryType: website:newshub
+      jcr:primaryType: website:dschomepage
+      jcr:uuid: 8bec3604-6649-42a0-8e4b-432e31595405
       website:summary: ''
-      website:title: News Hub
-    /news-hub[2]:
+      website:title: ''
+    /content[2]:
       /website:bannerimagelink:
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
         hippo:facets: []
@@ -41,18 +41,19 @@
       - preview
       hippostd:state: unpublished
       hippostdpubwf:createdBy: admin
-      hippostdpubwf:creationDate: 2020-10-12T22:01:00.856Z
-      hippostdpubwf:lastModificationDate: 2020-10-12T22:01:12.222Z
+      hippostdpubwf:creationDate: 2020-10-23T10:12:58.159Z
+      hippostdpubwf:lastModificationDate: 2020-10-23T10:13:06.243Z
       hippostdpubwf:lastModifiedBy: admin
-      hippotranslation:id: 1a223e01-87fe-45b2-b3f8-4d7718122fe5
+      hippotranslation:id: e9ae3d3e-3ce9-4542-8553-7f6167a8163f
       hippotranslation:locale: en
       jcr:mixinTypes:
       - mix:referenceable
       - mix:versionable
-      jcr:primaryType: website:newshub
+      jcr:primaryType: website:dschomepage
+      jcr:uuid: 2fdcbaec-3c0e-4b46-8131-38832c1887f0
       website:summary: ''
-      website:title: News Hub
-    /news-hub[3]:
+      website:title: ''
+    /content[3]:
       /website:bannerimagelink:
         hippo:docbase: cafebabe-cafe-babe-cafe-babecafebabe
         hippo:facets: []
@@ -67,32 +68,35 @@
       - live
       hippostd:state: published
       hippostdpubwf:createdBy: admin
-      hippostdpubwf:creationDate: 2020-10-12T22:01:00.856Z
-      hippostdpubwf:lastModificationDate: 2020-10-12T22:01:12.222Z
+      hippostdpubwf:creationDate: 2020-10-23T10:12:58.159Z
+      hippostdpubwf:lastModificationDate: 2020-10-23T10:13:06.243Z
       hippostdpubwf:lastModifiedBy: admin
-      hippostdpubwf:publicationDate: 2020-10-12T22:01:16.965Z
-      hippotranslation:id: 1a223e01-87fe-45b2-b3f8-4d7718122fe5
+      hippostdpubwf:publicationDate: 2020-10-23T10:13:22.995Z
+      hippotranslation:id: e9ae3d3e-3ce9-4542-8553-7f6167a8163f
       hippotranslation:locale: en
       jcr:mixinTypes:
       - mix:referenceable
-      jcr:primaryType: website:newshub
+      jcr:primaryType: website:dschomepage
+      jcr:uuid: 3a511f6d-0527-4732-a708-dd46cd703e21
       website:summary: ''
-      website:title: News Hub
-    hippo:name: News Hub
-    hippo:versionHistory: dedb995e-af33-41aa-821a-dd88db454404
+      website:title: ''
+    hippo:name: News
+    hippo:versionHistory: 96ce7243-b700-4924-b7ed-f95143b983d4
     jcr:mixinTypes:
     - hippo:named
     - hippo:versionInfo
     - mix:referenceable
     jcr:primaryType: hippo:handle
-  hippo:name: News and events
+    jcr:uuid: 652f8467-d098-47ea-b542-ae9957dfaf8a
+  hippo:name: News
   hippostd:foldertype:
-  - new-digital-website-folder
-  - new-digital-website-document
-  hippotranslation:id: c0c0facf-0411-44eb-97bf-21e45e7b0baa
+  - new-translated-folder
+  - new-document
+  hippotranslation:id: 16d9cf63-e9ca-4bbc-ad97-e14d385cc760
   hippotranslation:locale: en
   jcr:mixinTypes:
   - hippo:named
   - hippotranslation:translated
   - mix:versionable
   jcr:primaryType: hippostd:folder
+  jcr:uuid: 2e93866c-21b0-4204-a92b-d459245eaf08

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/pages/news.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/pages/news.yaml
@@ -3,8 +3,10 @@ definitions:
   config:
     /hst:hst/hst:configurations/common/hst:pages/news:
       /main:
-        hst:componentclassname: uk.nhs.digital.common.components.NewsArticleComponent
-        hst:template: news-article
+        /main:
+          hst:referencecomponent: news-hub/main
+          jcr:primaryType: hst:containercomponentreference
+        hst:template: news-hub
         jcr:primaryType: hst:component
       hst:referencecomponent: hst:abstractpages/apppage
       jcr:primaryType: hst:component

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
@@ -310,6 +310,10 @@ definitions:
         hst:componentconfigurationid: hst:pages/icon-library
         hst:relativecontentpath: icon-library
         jcr:primaryType: hst:sitemapitem
+      /news:
+        hst:componentconfigurationid: hst:pages/news
+        hst:refId: newshub
+        jcr:primaryType: hst:sitemapitem
       /news-and-events:
         /events:
           /_any_:

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/templates.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/templates.yaml
@@ -173,8 +173,14 @@ definitions:
       /news-events-homepage:
         hst:renderpath: webfile:/freemarker/common/news-events-homepage.ftl
         jcr:primaryType: hst:template
+      /news-hub:
+        hst:renderpath: webfile:/freemarker/common/newshub.ftl
+        jcr:primaryType: hst:template
       /news-hub-article:
         hst:renderpath: webfile:/freemarker/common/news-hub-article.ftl
+        jcr:primaryType: hst:template
+      /news-hub-page:
+        hst:renderpath: webfile:/freemarker/common/visual-hub.ftl
         jcr:primaryType: hst:template
       /newslist-main-newslist:
         hst:renderpath: webfile:/freemarker/common/newslist-main-newslist.ftl

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/workspace/workspace/containers.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/workspace/workspace/containers.yaml
@@ -44,6 +44,18 @@ definitions:
           hst:xtype: HST.vBox
           jcr:primaryType: hst:containercomponent
         jcr:primaryType: hst:containercomponentfolder
+      /news-hub:
+        /banner:
+          .meta:residual-child-node-category: content
+          hst:label: Banner
+          hst:xtype: hst.vbox
+          jcr:primaryType: hst:containercomponent
+        /main:
+          .meta:residual-child-node-category: content
+          hst:lastmodified: 2020-10-23T10:16:15.921Z
+          hst:xtype: hst.nomarkup
+          jcr:primaryType: hst:containercomponent
+        jcr:primaryType: hst:containercomponentfolder
       /newshubpage:
         /newshubpage-right:
           .meta:residual-child-node-category: content

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/newshub.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/newshub.ftl
@@ -1,0 +1,15 @@
+<#ftl output_format="HTML">
+<#include "../include/imports.ftl">
+<#include "../../src/js/line-clamp-polyfill.js.ftl">
+
+<section class="news-hub" aria-label="News hub">
+
+    <@hst.include ref= "banner"/>
+
+    <div class="grid-wrapper">
+        <div class="site-main">
+            <@hst.include ref="main"/>
+        </div>
+    </div>
+
+</section>

--- a/repository-data/webfiles/src/main/resources/site/src/scss/components/_newshub.scss
+++ b/repository-data/webfiles/src/main/resources/site/src/scss/components/_newshub.scss
@@ -1,0 +1,16 @@
+.news-hub {
+    background: $white;
+}
+
+.news-hub .site-main > * {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+.news-hub .site-main > * + * {
+    margin-top: $vertical-gap--large;
+    @include media(desktop) {
+        margin-top: $vertical-gap--xlarge;
+    }
+}
+

--- a/repository-data/webfiles/src/main/resources/site/src/scss/environment/settings/_layout.scss
+++ b/repository-data/webfiles/src/main/resources/site/src/scss/environment/settings/_layout.scss
@@ -7,5 +7,8 @@ $desktop-width: 1024px;
 $min-wide-desktop-width: 1441px;
 $wide-desktop-width: 1520px;
 $gutter: $baseline-grid-unit * 4;
+$gutter: $baseline-grid-unit * 4;
 $vertical-gap: $gutter * 1.5;
+$vertical-gap--large: $gutter * 2.5;
+$vertical-gap--xlarge: $gutter * 3.75;
 $search-strip-height: 44px;

--- a/repository-data/webfiles/src/main/resources/site/src/scss/nhsuk.scss
+++ b/repository-data/webfiles/src/main/resources/site/src/scss/nhsuk.scss
@@ -126,5 +126,6 @@
 @import "components/priority-actions";
 @import "components/ie-banner";
 @import "components/viz";
+@import "components/newshub";
 
 @import "eforms";


### PR DESCRIPTION
- Create News page
- Rename Digital Security Homepage doctype to Generic Homepage
- Add white background styles
- Add consistent spacing between newshub items
- Set news to `/news` in the content

Please note: There may be some manual configuration needed in the console at `/hst:hst/hst:configurations/common-preview/hst:workspace/hst:containers/news-hub`. Make sure it matches the configuration at `/hst:hst/hst:configurations/common/hst:workspace/hst:containers/news-hub`, including creating the nodes if necessary.