### PR TITLE
[DW-1806] Adds widemode/narrow view groovy scripts

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-1806-remove-wide-mode-property.groovy
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-1806-remove-wide-mode-property.groovy
@@ -1,0 +1,46 @@
+package org.hippoecm.frontend.plugins.cms.admin.updater
+
+import org.hippoecm.repository.util.JcrUtils
+import org.onehippo.repository.update.BaseNodeUpdateVisitor
+
+import javax.jcr.Node
+
+class UpdaterTemplate extends BaseNodeUpdateVisitor {
+
+    private static final String PROPERTY_WIDE_MODE = 'website:wideMode'
+    private static final String PROPERTY_NAVIGATION_CONTROLLER = 'website:navigationcontroller'
+
+    boolean doUpdate(Node node) {
+        try {
+            if (node.hasNodes()) {
+                return updateNode(node)
+            }
+        } catch (e) {
+            log.error("Failed to process record.", e)
+        }
+        return false
+    }
+
+    boolean updateNode(Node node) {
+        def path = node.getPath()
+        def nodeType = node.getPrimaryNodeType().getName()
+        if ("website:general".equals(nodeType)) {
+            JcrUtils.ensureIsCheckedOut(node)
+            if (node.hasProperty(PROPERTY_WIDE_MODE)) {
+                if (node.getProperty(PROPERTY_WIDE_MODE).getString() == 'true') {
+                    log.info("attempting to update: " + path + " => current node type: " + nodeType + " => setting " + PROPERTY_NAVIGATION_CONTROLLER + " to 'withoutNavWide'")
+                    node.setProperty(PROPERTY_NAVIGATION_CONTROLLER, 'withoutNavWide')
+                }
+                log.info("attempting to update: " + path + " => current node type: " + nodeType + " => removing " + PROPERTY_WIDE_MODE)
+                node.getProperty(PROPERTY_WIDE_MODE).remove();
+                return true
+            }
+        }
+        return false
+    }
+
+    boolean undoUpdate(Node node) {
+        throw new UnsupportedOperationException("Not implemented.")
+    }
+
+}

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-1806-remove-wide-mode-property.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-1806-remove-wide-mode-property.yaml
@@ -1,0 +1,16 @@
+---
+definitions:
+  config:
+    /hippo:configuration/hippo:update/hippo:registry/DW-1806-remove-wide-mode-property:
+      hipposys:batchsize: 10
+      hipposys:description: Removes the website:wideview property. If the property
+        was set to true then it gives website:navigationcontroller an equialent value.
+      hipposys:dryrun: false
+      hipposys:loglevel: DEBUG
+      hipposys:parameters: ''
+      hipposys:query: /jcr:root/content/documents/corporate-website//*[@jcr:primaryType='website:general']
+      hipposys:script:
+        resource: /configuration/update/DW-1806-remove-wide-mode-property.groovy
+        type: string
+      hipposys:throttle: 1000
+      jcr:primaryType: hipposys:updaterinfo

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-1806-set-narrow-view-as-default.groovy
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-1806-set-narrow-view-as-default.groovy
@@ -1,0 +1,43 @@
+package org.hippoecm.frontend.plugins.cms.admin.updater
+
+import org.hippoecm.repository.util.JcrUtils
+import org.onehippo.repository.update.BaseNodeUpdateVisitor
+
+import javax.jcr.Node
+
+class UpdaterTemplate extends BaseNodeUpdateVisitor {
+
+    private static final String PROPERTY_NAVIGATION_CONTROLLER = 'website:navigationcontroller'
+    private static final String DEFAULT_SELECTION = 'withNav'
+
+    boolean doUpdate(Node node) {
+        try {
+            if (node.hasNodes()) {
+                return updateNode(node)
+            }
+        } catch (e) {
+            log.error("Failed to process record.", e)
+        }
+        return false
+    }
+
+    boolean updateNode(Node node) {
+        def path = node.getPath()
+        def nodeType = node.getPrimaryNodeType().getName()
+        if ("website:general" == nodeType || "website:service" == nodeType) {
+            log.info("checking node: " + path + " => current node type: " + nodeType)
+            JcrUtils.ensureIsCheckedOut(node)
+            if (!node.hasProperty(PROPERTY_NAVIGATION_CONTROLLER) || !node.getProperty(PROPERTY_NAVIGATION_CONTROLLER)?.getString()) {
+                log.info("attempting to update node: " + path + " => current node type: " + nodeType)
+                node.setProperty(PROPERTY_NAVIGATION_CONTROLLER, DEFAULT_SELECTION)
+                return true
+            }
+        }
+        return false
+    }
+
+    boolean undoUpdate(Node node) {
+        throw new UnsupportedOperationException("Not implemented.")
+    }
+
+}

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-1806-set-narrow-view-as-default.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/DW-1806-set-narrow-view-as-default.yaml
@@ -1,0 +1,17 @@
+---
+definitions:
+  config:
+    /hippo:configuration/hippo:update/hippo:registry/DW-1806-set-narrow-view-as-defaul:
+      hipposys:batchsize: 10
+      hipposys:description: Adds a website:navigationcontroller if it does not exist
+        and gives it a default value.
+      hipposys:dryrun: false
+      hipposys:loglevel: DEBUG
+      hipposys:parameters: ''
+      hipposys:query: /jcr:root/content/documents/corporate-website//*[@jcr:primaryType='website:general'
+        or @jcr:primaryType='website:service']
+      hipposys:script:
+        resource: /configuration/update/DW-1806-set-narrow-view-as-default.groovy
+        type: string
+      hipposys:throttle: 1000
+      jcr:primaryType: hipposys:updaterinfo

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/website/general.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/website/general.yaml
@@ -54,15 +54,6 @@ definitions:
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
-          /wideMode:
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-            caption: Display in full width
-            field: wideMode
-            hint: Used for special content that is not meant for mobile screen sizes.
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.field
           /summary:
             /cluster.options:
               ckeditor.config.appended.json: '{toolbar: [{ name: ''summarytoolbar'',
@@ -401,14 +392,6 @@ definitions:
             hipposysedit:primary: false
             hipposysedit:type: website:userNeedandcontact
             jcr:primaryType: hipposysedit:field
-          /wideMode:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: website:wideMode
-            hipposysedit:primary: false
-            hipposysedit:type: Boolean
-            jcr:primaryType: hipposysedit:field
           hipposysedit:node: true
           hipposysedit:supertype:
           - website:basedocument
@@ -502,7 +485,6 @@ definitions:
           website:shortsummary: ''
           website:title: ''
           website:type: ''
-          website:wideMode: false
         jcr:primaryType: hipposysedit:prototypeset
       jcr:mixinTypes:
       - editor:editable

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/general.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/general.yaml
@@ -304,13 +304,12 @@
         - mix:referenceable
         jcr:primaryType: website:general
         website:gossid: 0
-        website:navigationcontroller: withoutNav
+        website:navigationcontroller: withoutNavWide
         website:shortsummary: Enthusiastically reintermediate exceptional networks
           for interactive methods of empowerment. Professionally network installed
           basenavigationcontroller
         website:title: 'General Child Document #1'
         website:type: ''
-        website:wideMode: false
       /content[2]:
         /website:component:
           hippostd:content: |-
@@ -404,13 +403,12 @@
         - mix:versionable
         jcr:primaryType: website:general
         website:gossid: 0
-        website:navigationcontroller: withoutNav
+        website:navigationcontroller: withoutNavWide
         website:shortsummary: Enthusiastically reintermediate exceptional networks
           for interactive methods of empowerment. Professionally network installed
           base
         website:title: 'General Child Document #1'
         website:type: ''
-        website:wideMode: false
       /content[3]:
         /website:component:
           hippostd:content: |-
@@ -504,13 +502,12 @@
         - mix:referenceable
         jcr:primaryType: website:general
         website:gossid: 0
-        website:navigationcontroller: withoutNav
+        website:navigationcontroller: withoutNavWide
         website:shortsummary: Enthusiastically reintermediate exceptional networks
           for interactive methods of empowerment. Professionally network installed
           base
         website:title: 'General Child Document #1'
         website:type: ''
-        website:wideMode: false
       hippo:name: 'Genera Child Document #1'
       hippo:versionHistory: 34e4f5be-b4c6-4480-a0c1-ead800985701
       jcr:mixinTypes:

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/general-article.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/general-article.ftl
@@ -31,7 +31,6 @@
 <#assign hasHtmlCode = document.htmlCode?has_content />
 <#assign sectionTitlesFound = countSectionTitles(document.sections) />
 <#assign renderNav = ((hasSummaryContent || hasChildPages) && sectionTitlesFound gte 1) || sectionTitlesFound gt 1 || (hasSummaryContent && hasChildPages) />
-<#assign wideMode = document.wideMode />
 <#assign idsuffix = slugify(document.title) />
 <#assign navStatus = document.navigationController />
 <#assign hasBannerImage = document.image?has_content />
@@ -74,7 +73,7 @@
             </div>
         </#if>
         <div class="grid-row">
-            <#if navStatus == "withNav" && renderNav && !wideMode>
+            <#if navStatus == "withNav" && renderNav>
                 <div class="column column--one-third page-block--sticky-nav page-block--sidebar article-section-nav-outer-wrapper">
                     <!-- start sticky-nav -->
                     <div id="sticky-nav">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/service/service-article.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/service/service-article.ftl
@@ -81,28 +81,27 @@
 
 
         <div class="grid-row">
-            <#if navStatus == "withNav">
-                <#if renderNav>
-                    <div class="column column--one-third page-block--sticky-nav page-block--sidebar article-section-nav-outer-wrapper">
-                        <!-- start sticky-nav -->
-                        <div id="sticky-nav">
-                            <#assign links = [{ "url": "#top", "title": "Top of page" }] />
-                            <#if document.latestNews?has_content >
-                                <#assign links += [{ "url": "#related-articles-latest-news-${idsuffix}", "title": 'Latest news' }] />
-                            </#if>
-                            <#assign links += getStickySectionNavLinks({ "document": document, "childPages": childPages, "includeTopLink": false }) />
-                            <#if document.relatedEvents?has_content >
-                                <#assign links += [{ "url": "#related-articles-events-${idsuffix}", "title": 'Forthcoming events' }] />
-                            </#if>
-                            <@stickyNavSections links=links></@stickyNavSections>
-                        </div>
-                        <!-- end sticky-nav -->
-                        <#-- Restore the bundle -->
-                        <@hst.setBundle basename="rb.generic.headers,publicationsystem.headers"/>
+            <#if navStatus == "withNav" && renderNav>
+                <div class="column column--one-third page-block--sticky-nav page-block--sidebar article-section-nav-outer-wrapper">
+                    <!-- start sticky-nav -->
+                    <div id="sticky-nav">
+                        <#assign links = [{ "url": "#top", "title": "Top of page" }] />
+                        <#if document.latestNews?has_content >
+                            <#assign links += [{ "url": "#related-articles-latest-news-${idsuffix}", "title": 'Latest news' }] />
+                        </#if>
+                        <#assign links += getStickySectionNavLinks({ "document": document, "childPages": childPages, "includeTopLink": false }) />
+                        <#if document.relatedEvents?has_content >
+                            <#assign links += [{ "url": "#related-articles-events-${idsuffix}", "title": 'Forthcoming events' }] />
+                        </#if>
+                        <@stickyNavSections links=links></@stickyNavSections>
                     </div>
-                </#if>
+                    <!-- end sticky-nav -->
+                    <#-- Restore the bundle -->
+                    <@hst.setBundle basename="rb.generic.headers,publicationsystem.headers"/>
+                </div>
             </#if>
-            <div class="column column--two-thirds page-block page-block--main">
+
+            <div class="column ${(navStatus == "withNav" || navStatus == "withoutNav")?then("column--two-thirds", "column--wide-mode")} page-block page-block--main">
                 <#if hasBannerImage>
                     <#if hasSummaryContent>
                         <div class="article-header__subtitle"

--- a/site/components/src/main/java/uk/nhs/digital/website/beans/General.java
+++ b/site/components/src/main/java/uk/nhs/digital/website/beans/General.java
@@ -57,10 +57,6 @@ public class General extends CommonFieldsBean {
         return getLinkedBean("website:leadimage", HippoGalleryImageSet.class);
     }
 
-    public Boolean getWideMode()  {
-        return getSingleProperty("website:wideMode",false);
-    }
-
     @HippoEssentialsGenerated(internalName = "website:navigationcontroller")
     public String getNavigationController() {
         return getSingleProperty("website:navigationcontroller", "withNav");


### PR DESCRIPTION
- A script to add 'website:navigationcontroller' with a default to
all general doctype entries.
- A script to remove 'website:wideMode' from all general doctype
entries. If it was set to true then 'website:navigationcontroller'
gets set accordingly.
- Removes the config for 'website:wideMode'.