### PR TITLE
[DW-0000] Fix channel manager content clash

### DIFF
--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/pages/news-hub.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/pages/news-hub.yaml
@@ -4,10 +4,10 @@ definitions:
     /hst:hst/hst:configurations/common/hst:pages/news-hub:
       /main:
         /banner:
-          hst:referencecomponent: cyber-security-homepage/banner
+          hst:referencecomponent: news-hub/banner
           jcr:primaryType: hst:containercomponentreference
         /main:
-          hst:referencecomponent: cyber-security-homepage/main
+          hst:referencecomponent: news-hub/main
           jcr:primaryType: hst:containercomponentreference
         hst:template: news-hub
         jcr:primaryType: hst:component


### PR DESCRIPTION
The news hub page was using the Cyber Security page's banner and main
content containers. This led to some content clashing between the two.