### PR TITLE
[ADV-123] Create stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "30 1 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Stale issue message'
+        stale-pr-message: 'Stale pull request message'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/stale@v3
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }} # https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow
         stale-issue-message: 'Stale issue message'
         stale-pr-message: 'Stale pull request message'
         stale-issue-label: 'no-issue-activity'


### PR DESCRIPTION
When this action runs, it will run the stale action which will look at the issues and pull requests in the hippo repository and find the ones that haven't had any action for a few months. It will then post a message in the issue and add a label indicating that the issue is stale. If that issue stays stale for another week, it's closed.

Stale Action

This makes sure that every stale issue is identified, but it also gives people enough time to tell the stale action to keep an issue or pull request open – a lot of these old issues and PRs to have value after all!

Ultimately, this will allow everyone to "work clean".