### PR TITLE
Adz 483

### DIFF
--- a/cms/src/main/java/uk/nhs/digital/apispecs/jobs/ApiSpecRerenderJob.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/jobs/ApiSpecRerenderJob.java
@@ -1,0 +1,45 @@
+package uk.nhs.digital.apispecs.jobs;
+
+import org.onehippo.repository.scheduling.RepositoryJob;
+import org.onehippo.repository.scheduling.RepositoryJobExecutionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import uk.nhs.digital.apispecs.ApiSpecificationPublicationService;
+import uk.nhs.digital.apispecs.jcr.ApiSpecificationDocumentJcrRepository;
+import uk.nhs.digital.apispecs.swagger.SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverter;
+
+import java.util.Optional;
+import javax.jcr.Session;
+
+public class ApiSpecRerenderJob implements RepositoryJob {
+
+    private static final Logger log = LoggerFactory.getLogger(ApiSpecRerenderJob.class);
+
+    @Override
+    public void execute(final RepositoryJobExecutionContext context) {
+
+        log.debug("API Specifications refresh: start.");
+
+        Session session = null;
+
+        try {
+            session = context.createSystemSession();
+
+            final ApiSpecificationPublicationService apiSpecificationPublicationService =
+                new ApiSpecificationPublicationService(
+                    null,
+                    new ApiSpecificationDocumentJcrRepository(session),
+                    new SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverter()
+                );
+
+            apiSpecificationPublicationService.rerenderSpecifications();
+
+            log.debug("API Specifications refresh: done.");
+
+        } catch (final Exception ex) {
+            log.error("Failed to publish specifications.", ex);
+        } finally {
+            Optional.ofNullable(session).ifPresent(Session::logout);
+        }
+    }
+}

--- a/cms/src/main/java/uk/nhs/digital/apispecs/model/ApiSpecificationDocument.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/model/ApiSpecificationDocument.java
@@ -3,6 +3,7 @@ package uk.nhs.digital.apispecs.model;
 import static org.hippoecm.repository.util.WorkflowUtils.Variant.DRAFT;
 import static uk.nhs.digital.apispecs.model.ApiSpecificationDocument.Properties.*;
 
+import org.hippoecm.repository.util.WorkflowUtils;
 import uk.nhs.digital.apispecs.jcr.JcrDocumentLifecycleSupport;
 
 import java.time.Instant;
@@ -26,8 +27,18 @@ public class ApiSpecificationDocument {
             ;
     }
 
+    public String getHtml() {
+        Optional<String> html = jcrDocument().getStringProperty(HTML.value(), WorkflowUtils.Variant.PUBLISHED);
+        return html.orElse("");
+    }
+
     public void setHtml(final String html) {
         jcrDocument().setProperty(HTML.value(), html);
+    }
+
+    public String getSpecJson() {
+        Optional<String> json = jcrDocument().getStringProperty(JSON.value(), WorkflowUtils.Variant.PUBLISHED);
+        return json.orElse("");
     }
 
     public void setSpecJson(final String specificationJson) {

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,8 @@
         <devzone.apigee.resources.specs.individual.url ></devzone.apigee.resources.specs.individual.url>
         <!-- Apigee API specifications sync schedule properties -->
         <devzone.apispec.sync.enabled></devzone.apispec.sync.enabled>
-        <devzone.apispec.sync.cron-expression></devzone.apispec.sync.cron-expression>
+        <devzone.apispec.sync.daily-cron-expression></devzone.apispec.sync.daily-cron-expression>
+        <devzone.apispec.sync.nightly-cron-expression></devzone.apispec.sync.nightly-cron-expression>
 
         <!--<tomcatDistributionUrl>https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.48/bin/apache-tomcat-8.0.48.tar.gz</tomcatDistributionUrl>-->
 
@@ -953,7 +954,8 @@
                                     <devzone.apigee.resources.specs.individual.url>${devzone.apigee.resources.specs.individual.url}</devzone.apigee.resources.specs.individual.url>
                                     <!-- Apigee API specifications sync schedule properties -->
                                     <devzone.apispec.sync.enabled>${devzone.apispec.sync.enabled}</devzone.apispec.sync.enabled>
-                                    <devzone.apispec.sync.cron-expression>${devzone.apispec.sync.cron-expression}</devzone.apispec.sync.cron-expression>
+                                    <devzone.apispec.sync.daily-cron-expression>${devzone.apispec.sync.daily-cron-expression}</devzone.apispec.sync.daily-cron-expression>
+                                    <devzone.apispec.sync.nightly-cron-expression>${devzone.apispec.sync.nightly-cron-expression}</devzone.apispec.sync.nightly-cron-expression>
 
                                 </systemProperties>
                                 <dependencies>

--- a/vars.mk
+++ b/vars.mk
@@ -11,7 +11,8 @@ SPLUNK_URL ?= http://localhost
 PROFILE_RUN ?= cargo.run
 S3_BUCKET ?= files.local.nhsd.io
 S3_REGION ?= eu-west-1
-
+# Path to local JCR database (-Drepo.path=storage)
+REPO_PATH ?=
 # Settings related to automated imports of OAS specifications
 # into API Specification documents from Apigee.
 # Override relevant variables (typically only APIGEE_USER, APIGEE_PASS and APIGEE_OTPKEY)
@@ -22,8 +23,14 @@ S3_REGION ?= eu-west-1
 # OAuth2 access and refresh tokens:
 # https://docs.apigee.com/api-platform/system-administration/management-api-tokens#note
 #
-APIGEE_SYNC_ENABLED ?= false
-APIGEE_SYNC_CRON ?= 0 0/1 * ? * *
+# Both cron expression variables below will need to have a property set in the system to
+# enable the scheduled jobs in a local CMS instance. In order to keep this out of version
+# control, we recommend setting both variables in env.mk as needed, e.g.
+# 	APIGEE_SYNC_CRON = 0 0/2 * ? * *
+# 	APIGEE_RERENDER_CRON = 0 0/10 * ? * *
+
+APIGEE_SYNC_CRON ?=
+APIGEE_RERENDER_CRON ?=
 APIGEE_TOKEN_URL ?= https://login.apigee.com/oauth/token
 APIGEE_SPECS_ALL_URL ?= https://apigee.com/dapi/api/organizations/nhsd-nonprod/specs/folder/home
 APIGEE_SPECS_ONE_URL ?= https://apigee.com/dapi/api/organizations/nhsd-nonprod/specs/doc/{specificationId}/content
@@ -40,8 +47,8 @@ MVN_VARS = -Ddynamic.bean.generation=false \
 	-Dexternalstorage.aws.bucket=$(S3_BUCKET) \
 	-Dexternalstorage.aws.region=$(S3_REGION) \
 	-Dspring.profiles.active=local \
-    -Ddevzone.apispec.sync.enabled=$(APIGEE_SYNC_ENABLED) \
-    "-Ddevzone.apispec.sync.cron-expression=$(APIGEE_SYNC_CRON)" \
+    "-Ddevzone.apispec.sync.daily-cron-expression=$(APIGEE_SYNC_CRON)" \
+    "-Ddevzone.apispec.sync.nightly-cron-expression=$(APIGEE_RERENDER_CRON)" \
     -Ddevzone.apigee.resources.specs.all.url=$(APIGEE_SPECS_ALL_URL) \
     -Ddevzone.apigee.resources.specs.individual.url=$(APIGEE_SPECS_ONE_URL) \
 	-Ddevzone.apigee.oauth.token.url=$(APIGEE_TOKEN_URL)


### PR DESCRIPTION
PR covering changes for ADZ-483.

To get around the issue of changes to rendering logic not triggering the re-rendering of pages, a new scheduled job has been introduced that converts the JSON in a document, compares it to what is published, and publishes the new version if necessary.