### PR TITLE
add includeSubDomains for security header Strict-Transport-Security f…

### DIFF
--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/dev.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/dev.yaml
@@ -27,7 +27,7 @@ definitions:
               hst:homepage: root
               hst:mountpoint: /hst:hst/hst:sites/common
               hst:responseheaders:
-              - 'Strict-Transport-Security : max-age=31536000'
+              - 'Strict-Transport-Security : max-age=31536000; includeSubDomains'
               - 'Content-Security-Policy: upgrade-insecure-requests'
               - 'Referrer-Policy: no-referrer-when-downgrade'
               - 'Feature-Policy: vibrate ''none''; microphone ''none''; camera ''none'';

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/internal/127.0.0.1.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/internal/127.0.0.1.yaml
@@ -32,7 +32,7 @@ definitions:
         hst:homepage: root
         hst:mountpoint: /hst:hst/hst:sites/common
         hst:responseheaders:
-        - 'Strict-Transport-Security : max-age=31536000'
+        - 'Strict-Transport-Security : max-age=31536000; includeSubDomains'
         - 'Content-Security-Policy: upgrade-insecure-requests'
         - 'Referrer-Policy: no-referrer-when-downgrade'
         - 'Feature-Policy: vibrate ''none''; microphone ''none''; camera ''none'';

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/prd.yaml
@@ -34,7 +34,7 @@ definitions:
               hst:homepage: root
               hst:mountpoint: /hst:hst/hst:sites/common
               hst:responseheaders:
-              - 'Strict-Transport-Security : max-age=31536000'
+              - 'Strict-Transport-Security : max-age=31536000; includeSubDomains'
               - 'Content-Security-Policy: upgrade-insecure-requests'
               - 'Referrer-Policy: no-referrer-when-downgrade'
               - 'Feature-Policy: vibrate ''none''; microphone ''none''; camera ''none'';

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/training.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/training.yaml
@@ -28,7 +28,7 @@ definitions:
               hst:homepage: root
               hst:mountpoint: /hst:hst/hst:sites/common
               hst:responseheaders:
-              - 'Strict-Transport-Security : max-age=31536000'
+              - 'Strict-Transport-Security : max-age=31536000; includeSubDomains'
               - 'Content-Security-Policy: upgrade-insecure-requests'
               - 'Referrer-Policy: no-referrer-when-downgrade'
               - 'Feature-Policy: vibrate ''none''; microphone ''none''; camera ''none'';

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/tst.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/tst.yaml
@@ -28,7 +28,7 @@ definitions:
               hst:homepage: root
               hst:mountpoint: /hst:hst/hst:sites/common
               hst:responseheaders:
-              - 'Strict-Transport-Security : max-age=31536000'
+              - 'Strict-Transport-Security : max-age=31536000; includeSubDomains'
               - 'Content-Security-Policy: upgrade-insecure-requests'
               - 'Referrer-Policy: no-referrer-when-downgrade'
               - 'Feature-Policy: vibrate ''none''; microphone ''none''; camera ''none'';

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts/uat.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts/uat.yaml
@@ -28,7 +28,7 @@ definitions:
               hst:homepage: root
               hst:mountpoint: /hst:hst/hst:sites/common
               hst:responseheaders:
-              - 'Strict-Transport-Security : max-age=31536000'
+              - 'Strict-Transport-Security : max-age=31536000; includeSubDomains'
               - 'Content-Security-Policy: upgrade-insecure-requests'
               - 'Referrer-Policy: no-referrer-when-downgrade'
               - 'Feature-Policy: vibrate ''none''; microphone ''none''; camera ''none'';


### PR DESCRIPTION
as per the ticket, the security headers were amost as required with the exception that there is an includeSubDomains property on the content-security-policy header