### PR TITLE
[ADZ-987] Defer API Spec batch jobs scheduling

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -92,8 +92,6 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>3.1.6</version>
-            <scope>test</scope>
         </dependency>
 
         <!--
@@ -440,8 +438,9 @@
                                     <devzone.apigee.resources.specs.all.url>${devzone.apigee.resources.specs.all.url}</devzone.apigee.resources.specs.all.url>
                                     <devzone.apigee.resources.specs.individual.url>${devzone.apigee.resources.specs.individual.url}</devzone.apigee.resources.specs.individual.url>
                                     <!-- Apigee API specifications sync schedule properties -->
-                                    <devzone.apispec.sync.enabled>${devzone.apispec.sync.enabled}</devzone.apispec.sync.enabled>
-                                    <devzone.apispec.sync.cron-expression>${devzone.apispec.sync.cron-expression}</devzone.apispec.sync.cron-expression>
+                                    <devzone.apispec.sync.schedule-delay-duration>${devzone.apispec.sync.schedule-delay-duration}</devzone.apispec.sync.schedule-delay-duration>
+                                    <devzone.apispec.sync.daily-cron-expression>${devzone.apispec.sync.daily-cron-expression}</devzone.apispec.sync.daily-cron-expression>
+                                    <devzone.apispec.sync.nightly-cron-expression>${devzone.apispec.sync.nightly-cron-expression}</devzone.apispec.sync.nightly-cron-expression>
 
                                 </systemProperties>
 

--- a/cms/pom.xml
+++ b/cms/pom.xml
@@ -273,6 +273,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/cms/src/main/java/uk/nhs/digital/apispecs/exception/ApiCatalogueException.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/exception/ApiCatalogueException.java
@@ -1,0 +1,8 @@
+package uk.nhs.digital.apispecs.exception;
+
+public abstract class ApiCatalogueException extends RuntimeException {
+
+    public ApiCatalogueException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/cms/src/main/java/uk/nhs/digital/apispecs/exception/ApiCatalogueJobException.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/exception/ApiCatalogueJobException.java
@@ -1,0 +1,8 @@
+package uk.nhs.digital.apispecs.exception;
+
+public class ApiCatalogueJobException extends ApiCatalogueException {
+
+    public ApiCatalogueJobException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/cms/src/main/java/uk/nhs/digital/apispecs/module/ApiSpecSyncFromApigeeModule.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/module/ApiSpecSyncFromApigeeModule.java
@@ -1,7 +1,11 @@
 package uk.nhs.digital.apispecs.module;
 
+import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import org.apache.commons.lang3.StringUtils;
 import org.onehippo.cms7.services.HippoServiceRegistry;
-import org.onehippo.repository.modules.AbstractReconfigurableDaemonModule;
+import org.onehippo.repository.modules.DaemonModule;
 import org.onehippo.repository.modules.RequiresService;
 import org.onehippo.repository.scheduling.RepositoryJob;
 import org.onehippo.repository.scheduling.RepositoryJobCronTrigger;
@@ -9,80 +13,108 @@ import org.onehippo.repository.scheduling.RepositoryJobInfo;
 import org.onehippo.repository.scheduling.RepositoryScheduler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.nhs.digital.JcrNodeUtils;
+import uk.nhs.digital.apispecs.exception.ApiCatalogueJobException;
 import uk.nhs.digital.apispecs.jobs.ApiSpecRerenderJob;
 import uk.nhs.digital.apispecs.jobs.ApiSpecSyncFromApigeeJob;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Optional;
-import java.util.stream.Stream;
-import javax.jcr.Node;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import javax.jcr.RepositoryException;
 import javax.jcr.Session;
 
 @RequiresService(types = { RepositoryScheduler.class } )
-public class ApiSpecSyncFromApigeeModule extends AbstractReconfigurableDaemonModule {
+public class ApiSpecSyncFromApigeeModule implements DaemonModule {
 
     private static final Logger log = LoggerFactory.getLogger(ApiSpecSyncFromApigeeModule.class);
 
-    private final Object configurationLock = new Object();
+    // See JavaDoc of java.time.Duration.parse for format.
+    private static final String SCHEDULING_DELAY_DEFAULT_VALUE = "PT45M";
+
+    private static final String SCHEDULING_DELAY_PROPERTY_NAME = "devzone.apispec.sync.schedule-delay-duration";
 
     private static final String JOB_GROUP = "devzone";
     private static final String JOB_TRIGGER_NAME = "cronTrigger";
 
-    @Override protected void doConfigure(final Node moduleConfigNode) {
+    @Override public void initialize(final Session session) throws RepositoryException {
 
-        // This method is called both on system startup AND on update to the node through the admin console.
-        //
-        // Given that we need to update the job on both events, we create and configure the
-        // job here rather than in doInitialize which is only being called on system startup.
+        try {
+            final Duration schedulingDelay = configurableSchedulingDelay();
 
-        synchronized (configurationLock) {
-            for (final ScheduledJobs job: ScheduledJobs.values()) {
-                try {
-                    log.info("Configuring job {}/{} for updating API specifications.", JOB_GROUP, job.jobName); // the only one called on the config node change
+            scheduleJobsWithDelay(schedulingDelay);
 
-                    deactivatePreviousJobInstanceIfExist(job.jobName);
-
-                    if (jobShouldBeEnabled(moduleConfigNode, job)) {
-
-                        scheduleNewJob(moduleConfigNode, job);
-
-                    } else {
-                        log.warn("Job {}/{} is not configured to be enabled, therefore it will not be activated.", JOB_GROUP, job.jobName);
-                    }
-
-                } catch (final Exception e) {
-                    throw new RuntimeException(String.format("Failed to configure job %s/%s", JOB_GROUP, job.jobName), e);
-                }
-            }
+        } catch (final Exception e) {
+            log.error("Failed to schedule API Catalogue related jobs.", e);
         }
     }
 
-    @Override protected void doInitialize(final Session session) {
-        // no-op: all the work is done in doConfigure - see the comment in that method
+    private void scheduleJobsWithDelay(final Duration schedulingDelay) {
+
+        final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+
+        Arrays.stream(ScheduledJobs.values()).forEach(job -> {
+            log.info("Deferring scheduling of job " + job.jobName + " by " + schedulingDelay);
+
+            scheduledExecutorService.schedule(() -> scheduleInJcr(job), schedulingDelay.getSeconds(), SECONDS);
+        });
+
+        scheduledExecutorService.shutdown();
     }
 
-    @Override protected void doShutdown() {
+    private void scheduleInJcr(final ScheduledJobs job) {
+
+        try {
+            log.info("Configuring job {}/{} for updating API specifications.", JOB_GROUP, job.jobName);
+
+            deactivatePreviousJobInstanceIfExists(job.jobName);
+
+            if (shouldBeEnabled(job)) {
+
+                schedule(job);
+
+            } else {
+                log.warn("Job {}/{} is not configured to be enabled, therefore it will not be activated.", JOB_GROUP, job.jobName);
+            }
+
+        } catch (final Exception e) {
+            throw new ApiCatalogueJobException(format("Failed to schedule job %s/%s", JOB_GROUP, job.jobName), e);
+        }
+    }
+
+    @Override public void shutdown() {
         Arrays.stream(ScheduledJobs.values())
             .map(x -> x.jobName)
             .forEach(jobName -> {
                 try {
-                    deactivatePreviousJobInstanceIfExist(jobName);
+                    deactivatePreviousJobInstanceIfExists(jobName);
                 } catch (final Exception e) {
-                    throw new RuntimeException(String.format("Failed to cleanly shut down job %s/%s", JOB_GROUP, jobName), e);
+                    log.error(format("Failed to cleanly shut down job %s/%s", JOB_GROUP, jobName), e);
                 }
             });
     }
 
-    private void scheduleNewJob(
-        final Node moduleConfigNode,
-        final ScheduledJobs job
-    ) throws RepositoryException {
+    private Duration configurableSchedulingDelay() {
+
+        final String schedulingDelayRaw = Optional.ofNullable(System.getProperty(SCHEDULING_DELAY_PROPERTY_NAME))
+            .filter(StringUtils::isNotBlank)
+            .map(String::trim)
+            .orElse(SCHEDULING_DELAY_DEFAULT_VALUE);
+
+        try {
+            return Duration.parse(schedulingDelayRaw);
+
+        } catch (final Exception e) {
+            throw new IllegalArgumentException("Scheduling duration is not in a valid ISO-8601 format: " + schedulingDelayRaw, e);
+        }
+    }
+
+    private void schedule(final ScheduledJobs job) throws RepositoryException {
 
         final RepositoryJobInfo jobInfo = new RepositoryJobInfo(job.jobName, JOB_GROUP, job.jobClass);
 
-        final String cronExpression = cronExpression(moduleConfigNode, job);
+        final String cronExpression = cronExpression(job);
 
         final RepositoryJobCronTrigger trigger = new RepositoryJobCronTrigger(JOB_TRIGGER_NAME, cronExpression);
 
@@ -91,7 +123,7 @@ public class ApiSpecSyncFromApigeeModule extends AbstractReconfigurableDaemonMod
         log.info("Job {}/{} has been scheduled with cron expression: {}", JOB_GROUP, job.jobName, cronExpression);
     }
 
-    private void deactivatePreviousJobInstanceIfExist(final String jobName) throws RepositoryException {
+    private void deactivatePreviousJobInstanceIfExists(final String jobName) throws RepositoryException {
         if (scheduler().checkExists(jobName, JOB_GROUP)) {
             scheduler().deleteJob(jobName, JOB_GROUP);
             log.info("Job {}/{} has been deactivated.", JOB_GROUP, jobName);
@@ -102,25 +134,18 @@ public class ApiSpecSyncFromApigeeModule extends AbstractReconfigurableDaemonMod
         return HippoServiceRegistry.getService(RepositoryScheduler.class);
     }
 
-    private boolean jobShouldBeEnabled(final Node moduleConfigNode, final ScheduledJobs job) {
-
-        final Optional<String> cronExprFromJcr = JcrNodeUtils.getStringPropertyQuietly(moduleConfigNode, job.jcrPropertyName);
+    private boolean shouldBeEnabled(final ScheduledJobs job) {
 
         final Optional<String> cronExprFromSystemProperty = Optional.ofNullable(System.getProperty(job.systemPropertyName));
 
-        return Stream.of(cronExprFromJcr, cronExprFromSystemProperty).anyMatch(Optional::isPresent);
+        return cronExprFromSystemProperty.isPresent();
     }
 
-    private String cronExpression(final Node moduleConfigNode, final ScheduledJobs job) {
-
-        final Optional<String> cronExprFromJcr = JcrNodeUtils.getStringPropertyQuietly(moduleConfigNode, job.jcrPropertyName);
+    private String cronExpression(final ScheduledJobs job) {
 
         final Optional<String> cronExprFromSystemProperty = Optional.ofNullable(System.getProperty(job.systemPropertyName));
 
-        return Stream.of(cronExprFromJcr, cronExprFromSystemProperty)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .findFirst()
+        return cronExprFromSystemProperty
             .orElseThrow(() -> new RuntimeException("Cron expression has not been configured."));
     }
 
@@ -129,26 +154,22 @@ public class ApiSpecSyncFromApigeeModule extends AbstractReconfigurableDaemonMod
         DAILY(
             "apiSpecSyncFromApigee",
             ApiSpecSyncFromApigeeJob.class,
-            "devzone.apispec.sync.daily-cron-expression",
-            "cronExpression"
+            "devzone.apispec.sync.daily-cron-expression"
         ),
         NIGHTLY(
             "apiSpecRerender",
             ApiSpecRerenderJob.class,
-            "devzone.apispec.sync.nightly-cron-expression",
-            "cronExpression"
+            "devzone.apispec.sync.nightly-cron-expression"
         );
 
         private final String jobName;
         private final Class<? extends RepositoryJob> jobClass;
         private final String systemPropertyName;
-        private final String jcrPropertyName;
 
-        ScheduledJobs(final String jobName, final Class<? extends RepositoryJob> jobClass, final String systemPropertyName, final String jcrPropertyName) {
+        ScheduledJobs(final String jobName, final Class<? extends RepositoryJob> jobClass, final String systemPropertyName) {
             this.jobName = jobName;
             this.jobClass = jobClass;
             this.systemPropertyName = systemPropertyName;
-            this.jcrPropertyName = jcrPropertyName;
         }
     }
 }

--- a/cms/src/main/java/uk/nhs/digital/externalstorage/modules/S3ConnectorServiceRegistrationModule.java
+++ b/cms/src/main/java/uk/nhs/digital/externalstorage/modules/S3ConnectorServiceRegistrationModule.java
@@ -106,7 +106,7 @@ public class S3ConnectorServiceRegistrationModule extends AbstractReconfigurable
 
         if (HippoServiceRegistry.getService(PooledS3Connector.class) != null) {
 
-            HippoServiceRegistry.register(pooledS3Connector, PooledS3Connector.class);
+            HippoServiceRegistry.unregister(pooledS3Connector, PooledS3Connector.class);
 
             // null checks protect against failed doInitialize/doConfigure
             Optional.ofNullable(downloadExecutorService).ifPresent(ExecutorService::shutdown);

--- a/cms/src/test/java/uk/nhs/digital/apispecs/module/ApiSpecSyncFromApigeeModuleTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/module/ApiSpecSyncFromApigeeModuleTest.java
@@ -1,5 +1,7 @@
 package uk.nhs.digital.apispecs.module;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.with;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -11,28 +13,30 @@ import static org.mockito.Mockito.times;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.onehippo.cms7.services.HippoServiceRegistry;
-import org.onehippo.repository.mock.MockNode;
 import org.onehippo.repository.scheduling.RepositoryJobCronTrigger;
 import org.onehippo.repository.scheduling.RepositoryJobInfo;
 import org.onehippo.repository.scheduling.RepositoryJobTrigger;
 import org.onehippo.repository.scheduling.RepositoryScheduler;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import uk.nhs.digital.apispecs.jobs.ApiSpecRerenderJob;
 import uk.nhs.digital.apispecs.jobs.ApiSpecSyncFromApigeeJob;
 
 import java.util.List;
-import javax.jcr.Node;
 import javax.jcr.RepositoryException;
+import javax.jcr.Session;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({HippoServiceRegistry.class, ApiSpecSyncFromApigeeModule.class})
+@PrepareForTest({HippoServiceRegistry.class})
+@PowerMockIgnore({"org.awaitility.*", "java.util.concurrent.*"})
 public class ApiSpecSyncFromApigeeModuleTest {
 
     public static final String DAILY_JOB_NAME = "apiSpecSyncFromApigee";
@@ -41,11 +45,10 @@ public class ApiSpecSyncFromApigeeModuleTest {
     private static final String TRIGGER_NAME = "cronTrigger";
 
     @Mock private RepositoryScheduler scheduler;
+    @Mock private Session session;
 
     private ArgumentCaptor<RepositoryJobInfo> jobInfoArgCaptor = ArgumentCaptor.forClass(RepositoryJobInfo.class);
     private ArgumentCaptor<RepositoryJobTrigger> jobTriggerArgCaptor = ArgumentCaptor.forClass(RepositoryJobTrigger.class);
-
-    private Node moduleConfigNode;
 
     private final ApiSpecSyncFromApigeeModule apiSpecSyncFromApigeeModule = new ApiSpecSyncFromApigeeModule();
 
@@ -53,56 +56,120 @@ public class ApiSpecSyncFromApigeeModuleTest {
     public void setUp() {
         initMocks(this);
 
-        moduleConfigNode = new MockNode("api-specification-sync", "hippo:moduleconfig");
-
         mockStatic(HippoServiceRegistry.class);
         given(HippoServiceRegistry.getService(RepositoryScheduler.class)).willReturn(scheduler);
+
+    }
+
+    @After
+    public void tearDown() {
+        unsetSystemProperties();
     }
 
     @Test
-    public void doConfigure_schedulesNewJob_whenConfiguredAsEnabledAndWithCronExpression() throws RepositoryException {
+    public void initialize_schedulesNewJobs_whenConfiguredWithCronExpression() throws RepositoryException {
 
         // given
-        final String expectedCronExpression = "0 0/5 * ? * *";
+        final String expectedDailyCronExpression = "0 0/10 * ? * *";
+        final String expectedNightlyCronExpression = "0 10/10 * ? * *";
 
-        moduleConfigNode.setProperty("enabled", true);
-        moduleConfigNode.setProperty("cronExpression", expectedCronExpression);
+        System.setProperty("devzone.apispec.sync.daily-cron-expression", expectedDailyCronExpression);
+        System.setProperty("devzone.apispec.sync.nightly-cron-expression", expectedNightlyCronExpression);
+        System.setProperty("devzone.apispec.sync.schedule-delay-duration", "PT0.5S");
 
         // when
-        apiSpecSyncFromApigeeModule.doConfigure(moduleConfigNode);
+        apiSpecSyncFromApigeeModule.initialize(session);
 
         // then
+        with()
+            .pollDelay(1, SECONDS)
+            .await()
+            .atMost(5, SECONDS)
+            .untilAsserted(() ->
+                then(scheduler).should(times(2)).scheduleJob(any(), any())
+            );
+
         then(scheduler).should(times(2)).scheduleJob(
             jobInfoArgCaptor.capture(),
             jobTriggerArgCaptor.capture()
         );
 
         final List<RepositoryJobInfo> actualJobInfos = jobInfoArgCaptor.getAllValues();
+
         final RepositoryJobInfo dailyJobInfo = actualJobInfos.get(0);
         final RepositoryJobInfo nightlyJobInfo = actualJobInfos.get(1);
-        assertThat("Job is scheduled with correct group.", dailyJobInfo.getGroup(), is(JOB_GROUP_NAME));
-        assertThat("Job is scheduled with correct name.", dailyJobInfo.getName(), is(DAILY_JOB_NAME));
-        assertThat("Job is scheduled with correct class.", dailyJobInfo.getJobClass(), is(ApiSpecSyncFromApigeeJob.class));
+        assertThat("Daily job is scheduled with correct group.", dailyJobInfo.getGroup(), is(JOB_GROUP_NAME));
+        assertThat("Daily job is scheduled with correct name.", dailyJobInfo.getName(), is(DAILY_JOB_NAME));
+        assertThat("Daily job is scheduled with correct class.", dailyJobInfo.getJobClass(), is(ApiSpecSyncFromApigeeJob.class));
 
-        assertThat("Job is scheduled with correct group.", nightlyJobInfo.getGroup(), is(JOB_GROUP_NAME));
-        assertThat("Job is scheduled with correct name.", nightlyJobInfo.getName(), is(NIGHTLY_JOB_NAME));
-        assertThat("Job is scheduled with correct class.", nightlyJobInfo.getJobClass(), is(ApiSpecRerenderJob.class));
+        assertThat("Nightly job is scheduled with correct group.", nightlyJobInfo.getGroup(), is(JOB_GROUP_NAME));
+        assertThat("Nightly job is scheduled with correct name.", nightlyJobInfo.getName(), is(NIGHTLY_JOB_NAME));
+        assertThat("Nightly job is scheduled with correct class.", nightlyJobInfo.getJobClass(), is(ApiSpecRerenderJob.class));
 
         final List<RepositoryJobTrigger> actualJobTriggers = jobTriggerArgCaptor.getAllValues();
+
         final RepositoryJobTrigger dailyJobTrigger = actualJobTriggers.get(0);
-        assertThat("Job is scheduled as a cron job.", dailyJobTrigger, instanceOf(RepositoryJobCronTrigger.class));
-        assertThat("Job is scheduled with correct trigger name", dailyJobTrigger.getName(), is(TRIGGER_NAME));
-        assertThat("Job is scheduled with correct cron expression", ((RepositoryJobCronTrigger)dailyJobTrigger).getCronExpression(), is(expectedCronExpression));
+        assertThat("Daily job is scheduled as a cron job.", dailyJobTrigger, instanceOf(RepositoryJobCronTrigger.class));
+        assertThat("Daily job is scheduled with correct trigger name", dailyJobTrigger.getName(), is(TRIGGER_NAME));
+        assertThat("Daily job is scheduled with correct cron expression", ((RepositoryJobCronTrigger)dailyJobTrigger).getCronExpression(), is(expectedDailyCronExpression));
+
+        final RepositoryJobTrigger nightlyJobTrigger = actualJobTriggers.get(1);
+        assertThat("Nightly job is scheduled as a cron job.", nightlyJobTrigger, instanceOf(RepositoryJobCronTrigger.class));
+        assertThat("Nightly job is scheduled with correct trigger name", nightlyJobTrigger.getName(), is(TRIGGER_NAME));
+        assertThat("Nightly job is scheduled with correct cron expression", ((RepositoryJobCronTrigger)nightlyJobTrigger).getCronExpression(), is(expectedNightlyCronExpression));
     }
 
     @Test
-    public void doConfigure_deactivatesOldJob_whenPreviousJobInstanceExists() throws RepositoryException {
+    public void initialize_deactivatesOldJobs_whenPreviousJobInstancesExist() throws RepositoryException {
+
+        // given
+        given(scheduler.checkExists(any(), any())).willReturn(true);
+
+        System.setProperty("devzone.apispec.sync.schedule-delay-duration", "PT1S");
+
+        // when
+        apiSpecSyncFromApigeeModule.initialize(session);
+
+        // then
+        with()
+            .pollDelay(1, SECONDS)
+            .await()
+            .atMost(5, SECONDS)
+            .untilAsserted(() -> {
+                then(scheduler).should().checkExists(DAILY_JOB_NAME, JOB_GROUP_NAME);
+                then(scheduler).should().deleteJob(DAILY_JOB_NAME, JOB_GROUP_NAME);
+                then(scheduler).should().checkExists(NIGHTLY_JOB_NAME, JOB_GROUP_NAME);
+                then(scheduler).should().deleteJob(NIGHTLY_JOB_NAME, JOB_GROUP_NAME);
+            });
+    }
+
+    @Test
+    public void initialize_doesNotScheduleAnyJob_whenNoCronExpressionIsSet() throws RepositoryException {
+
+        // given
+        System.setProperty("devzone.apispec.sync.schedule-delay-duration", "PT0.5S");
+
+        // when
+        apiSpecSyncFromApigeeModule.initialize(session);
+
+        // then
+        with()
+            .pollDelay(1, SECONDS)
+            .await()
+            .atMost(2, SECONDS)
+            .untilAsserted(() ->
+                then(scheduler).should(never()).scheduleJob(any(), any())
+            );
+    }
+
+    @Test
+    public void shutdown_deletesScheduledJobs_whenMatchingJobsPreviouslyScheduled() throws RepositoryException {
 
         // given
         given(scheduler.checkExists(any(), any())).willReturn(true);
 
         // when
-        apiSpecSyncFromApigeeModule.doConfigure(moduleConfigNode);
+        apiSpecSyncFromApigeeModule.shutdown();
 
         // then
         then(scheduler).should().checkExists(DAILY_JOB_NAME, JOB_GROUP_NAME);
@@ -112,131 +179,21 @@ public class ApiSpecSyncFromApigeeModuleTest {
     }
 
     @Test
-    public void doConfigure_doesNotScheduleJob_whenCronExpressionNotSet() throws RepositoryException {
-
-        // given
-        mockStatic(System.class);
-
-        moduleConfigNode.setProperty("cronExpression", (String) null);
-
-        // when
-        apiSpecSyncFromApigeeModule.doConfigure(moduleConfigNode);
-
-        // then
-        then(scheduler).should(never()).scheduleJob(any(), any());
-    }
-
-    @Test
-    public void doConfigure_schedulesJob_whenCronExpressionSet() throws RepositoryException {
-
-        // given
-        mockStatic(System.class);
-
-        moduleConfigNode.setProperty("cronExpression", "0 0/5 * ? * *");
-
-        // when
-        apiSpecSyncFromApigeeModule.doConfigure(moduleConfigNode);
-
-        // then
-        then(scheduler).should(times(2)).scheduleJob(any(), any());
-    }
-
-    @Test
-    public void doConfigure_usesCronExpressionStatusFromJcrOverSystemProperty_whenBothSet() throws RepositoryException {
-
-        // given
-        final String cronExpressionFromSystemProperty = "0 0/1 * ? * *";
-        final String cronExpressionFromJcr = "0 0/5 * ? * *";
-
-        mockStatic(System.class);
-        given(System.getProperty("devzone.apispec.sync.cron-expression")).willReturn(cronExpressionFromSystemProperty);
-
-        moduleConfigNode.setProperty("cronExpression", cronExpressionFromJcr);
-
-        moduleConfigNode.setProperty("enabled", true);
-
-        // when
-        apiSpecSyncFromApigeeModule.doConfigure(moduleConfigNode);
-
-        // then
-        then(scheduler).should(times(2)).scheduleJob(
-            any(),
-            jobTriggerArgCaptor.capture()
-        );
-
-        final String actualCronExpression = ((RepositoryJobCronTrigger) jobTriggerArgCaptor.getAllValues().get(0)).getCronExpression();
-
-        assertThat(
-            "Job is scheduled with cron expression from JCR",
-            actualCronExpression,
-            is(cronExpressionFromJcr)
-        );
-    }
-
-    @Test
-    public void doConfigure_usesCronExpressionFromSystemPropertyIfAbsentInJcr() throws RepositoryException {
-
-        // given
-        final String dailyCronExpressionFromSystemProperty = "0 0/1 * ? * *";
-        final String nightlyCronExpressionFromSystemProperty = "0 0/2 * ? * *";
-
-        mockStatic(System.class);
-        given(System.getProperty("devzone.apispec.sync.daily-cron-expression")).willReturn(dailyCronExpressionFromSystemProperty);
-        given(System.getProperty("devzone.apispec.sync.nightly-cron-expression")).willReturn(nightlyCronExpressionFromSystemProperty);
-        // no cron expression property present in JCR
-
-        moduleConfigNode.setProperty("enabled", true);
-
-        // when
-        apiSpecSyncFromApigeeModule.doConfigure(moduleConfigNode);
-
-        // then
-        then(scheduler).should(times((2))).scheduleJob(
-            any(),
-            jobTriggerArgCaptor.capture()
-        );
-
-        final String actualDailyCronExpression = ((RepositoryJobCronTrigger) jobTriggerArgCaptor.getAllValues().get(0)).getCronExpression();
-        final String actualNightlyCronExpression = ((RepositoryJobCronTrigger) jobTriggerArgCaptor.getAllValues().get(1)).getCronExpression();
-
-        assertThat(
-            "Job is scheduled with cron expression from system property",
-            actualDailyCronExpression,
-            is(dailyCronExpressionFromSystemProperty)
-        );
-        assertThat(
-            "Job is scheduled with cron expression from system property",
-            actualNightlyCronExpression,
-            is(nightlyCronExpressionFromSystemProperty)
-        );
-    }
-
-    @Test
-    public void doShutdown_deletesScheduledJob_whenAMatchingJobPreviouslyScheduled() throws RepositoryException {
-
-        // given
-        given(scheduler.checkExists(any(), any())).willReturn(true);
-
-        // when
-        apiSpecSyncFromApigeeModule.doConfigure(moduleConfigNode);
-
-        // then
-        then(scheduler).should().checkExists(DAILY_JOB_NAME, JOB_GROUP_NAME);
-        then(scheduler).should().deleteJob(DAILY_JOB_NAME, JOB_GROUP_NAME);
-        then(scheduler).should().checkExists(NIGHTLY_JOB_NAME, JOB_GROUP_NAME);
-        then(scheduler).should().deleteJob(NIGHTLY_JOB_NAME, JOB_GROUP_NAME);
-    }
-
-    @Test
-    public void doShutdown_doesNothing_whenNoMatchingJobPreviouslyScheduled() throws RepositoryException {
+    public void shutdown_doesNothing_whenNoMatchingJobsPreviouslyScheduled() throws RepositoryException {
 
         // given
         given(scheduler.checkExists(DAILY_JOB_NAME, JOB_GROUP_NAME)).willReturn(false);
 
         // when
-        apiSpecSyncFromApigeeModule.doConfigure(moduleConfigNode);
+        apiSpecSyncFromApigeeModule.shutdown();
 
         // then
         then(scheduler).should(never()).deleteJob(any(), any());
+    }
+
+    private void unsetSystemProperties() {
+        System.getProperties().remove("devzone.apispec.sync.daily-cron-expression");
+        System.getProperties().remove("devzone.apispec.sync.nightly-cron-expression");
+        System.getProperties().remove("devzone.apispec.sync.schedule-delay-duration");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <devzone.apigee.resources.specs.all.url></devzone.apigee.resources.specs.all.url>
         <devzone.apigee.resources.specs.individual.url ></devzone.apigee.resources.specs.individual.url>
         <!-- Apigee API specifications sync schedule properties -->
-        <devzone.apispec.sync.enabled></devzone.apispec.sync.enabled>
+        <devzone.apispec.sync.schedule-delay-duration></devzone.apispec.sync.schedule-delay-duration>
         <devzone.apispec.sync.daily-cron-expression></devzone.apispec.sync.daily-cron-expression>
         <devzone.apispec.sync.nightly-cron-expression></devzone.apispec.sync.nightly-cron-expression>
 
@@ -288,6 +288,13 @@
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-library</artifactId>
                 <version>2.1</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>4.0.3</version>
                 <scope>test</scope>
             </dependency>
 
@@ -961,7 +968,7 @@
                                     <devzone.apigee.resources.specs.all.url>${devzone.apigee.resources.specs.all.url}</devzone.apigee.resources.specs.all.url>
                                     <devzone.apigee.resources.specs.individual.url>${devzone.apigee.resources.specs.individual.url}</devzone.apigee.resources.specs.individual.url>
                                     <!-- Apigee API specifications sync schedule properties -->
-                                    <devzone.apispec.sync.enabled>${devzone.apispec.sync.enabled}</devzone.apispec.sync.enabled>
+                                    <devzone.apispec.sync.schedule-delay-duration>${devzone.apispec.sync.schedule-delay-duration}</devzone.apispec.sync.schedule-delay-duration>
                                     <devzone.apispec.sync.daily-cron-expression>${devzone.apispec.sync.daily-cron-expression}</devzone.apispec.sync.daily-cron-expression>
                                     <devzone.apispec.sync.nightly-cron-expression>${devzone.apispec.sync.nightly-cron-expression}</devzone.apispec.sync.nightly-cron-expression>
 

--- a/vars.mk
+++ b/vars.mk
@@ -37,6 +37,7 @@ REPO_PATH ?=
 
 APIGEE_SYNC_CRON ?=
 APIGEE_RERENDER_CRON ?=
+APIGEE_SYNC_SCHEDULE_DELAY ?= PT90S
 APIGEE_TOKEN_URL ?= https://login.apigee.com/oauth/token
 APIGEE_SPECS_ALL_URL ?= https://apigee.com/dapi/api/organizations/nhsd-nonprod/specs/folder/home
 APIGEE_SPECS_ONE_URL ?= https://apigee.com/dapi/api/organizations/nhsd-nonprod/specs/doc/{specificationId}/content
@@ -54,6 +55,7 @@ MVN_VARS = -Dexternalstorage.aws.bucket=$(S3_BUCKET) \
 	-Dspring.profiles.active=local \
     "-Ddevzone.apispec.sync.daily-cron-expression=$(APIGEE_SYNC_CRON)" \
     "-Ddevzone.apispec.sync.nightly-cron-expression=$(APIGEE_RERENDER_CRON)" \
+    -Ddevzone.apispec.sync.schedule-delay-duration=$(APIGEE_SYNC_SCHEDULE_DELAY) \
     -Ddevzone.apigee.resources.specs.all.url=$(APIGEE_SPECS_ALL_URL) \
     -Ddevzone.apigee.resources.specs.individual.url=$(APIGEE_SPECS_ONE_URL) \
 	-Ddevzone.apigee.oauth.token.url=$(APIGEE_TOKEN_URL)


### PR DESCRIPTION
Also:
* Fixes the `Error while shutting down daemon module
  org.onehippo.cms7.services.HippoServiceException:
  A service of type uk.nhs.digital.externalstorage
  .s3.PooledS3Connector is already registered.`,
  where the service was attempted to be registered,
  rather than unregistered on module/system shutdown,
  by mistake.