### PR TITLE
[ADZ-322] Automatic try-it-out trigger

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/modules/diagnostics.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/modules/diagnostics.yaml
@@ -1,0 +1,7 @@
+---
+definitions:
+  config:
+    /hippo:configuration/hippo:modules/diagnostics/hippo:moduleconfig:
+      enabled: true
+      thresholdMillisec: 2000
+      unitThresholdMillisec: 5

--- a/repository-data/site/src/main/resources/hcm-config/hst/hosts.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/hosts.yaml
@@ -40,7 +40,9 @@ definitions:
           jcr:primaryType: hst:virtualhost
         hst:defaultport: 8080
         jcr:primaryType: hst:virtualhostgroup
-      hst:diagnosticsenabled: false
+      hst:diagnosticsenabled: true
+      hst:diagnosticsthresholdmillisec: 1000
+      hst:diagnosticsunitthresholdmillisec: 5
       hst:homepage: root
       hst:scheme: https
       hst:showcontextpath: false

--- a/repository-data/webfiles/package-lock.json
+++ b/repository-data/webfiles/package-lock.json
@@ -5655,9 +5655,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true
     },
     "hsl-regex": {

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/api-try-it-now.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/api-try-it-now.ftl
@@ -170,17 +170,34 @@
 
                         window.onload = function () {
 
+                            const AlwaysEnableTryItOutPlugin = function(system) {
+                                const OperationContainer = system.getComponents("OperationContainer");
+                                return {
+                                    components: {
+                                        TryItOutButton: () => null,
+                                        OperationContainer: class CustomOperationContainer extends OperationContainer {
+                                            constructor(...args) {
+                                                super(...args);
+                                                this.state.tryItOutEnabled = true;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
                             const ui = SwaggerUIBundle({
                                 spec: specification,
 
                                 dom_id: '#content',
                                 deepLinking: true,
+
                                 presets: [
                                     SwaggerUIBundle.presets.apis,
                                     SwaggerUIStandalonePreset
                                 ],
                                 plugins: [
-                                    SwaggerUIBundle.plugins.DownloadUrl
+                                    SwaggerUIBundle.plugins.DownloadUrl,
+                                    AlwaysEnableTryItOutPlugin
                                 ],
                                 layout: "StandaloneLayout",
 


### PR DESCRIPTION
Override swagger-ui configuration allows us to hide the try-it-now configurations and enable all input fields for params. 
