### PR TITLE
ADZ-895 indicate level of nesting in schema with tree diagram

### DIFF
--- a/cms/src/main/java/uk/nhs/digital/apispecs/handlebars/BorderHelper.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/handlebars/BorderHelper.java
@@ -1,0 +1,239 @@
+package uk.nhs.digital.apispecs.handlebars;
+
+
+import com.github.jknack.handlebars.Handlebars.SafeString;
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import uk.nhs.digital.apispecs.handlebars.schema.ContextModelsStack;
+
+import java.util.*;
+
+public class BorderHelper implements Helper<Object> {
+    public static final String NAME = "borders";
+    private static final String INDENTATIONS_TO_IGNORE = "indentationsToIgnore";
+    private static final Schema EMPTY_SCHEMA = new Schema();
+
+    private ContextModelsStack.Factory contextStackFactory;
+
+    public BorderHelper(final ContextModelsStack.Factory contextStackFactory) {
+        this.contextStackFactory = contextStackFactory;
+    }
+
+    public static BorderHelper with(final ContextModelsStack.Factory contextStackFactory) {
+        return new BorderHelper(contextStackFactory);
+    }
+
+    @Override
+    public CharSequence apply(
+        final Object model,
+        final Options options) {
+
+        try {
+            final ContextModelsStack contextModelsStack = contextStackFactory.from(options.context);
+
+            final int indentationLevel = contextModelsStack.ancestorModelsCount();
+            final boolean hasChildren = currentModelHasChildren(contextModelsStack);
+
+            final StringBuilder htmlWriter = new StringBuilder();
+
+            // get child border
+            if (hasChildren) {
+                htmlWriter.append(
+                    getChildBorder(indentationLevel)
+                );
+            }
+            // if object has no parents, return here
+            if (!contextModelsStack.parentModel().isPresent()) {
+                return new SafeString(htmlWriter);
+            }
+
+            final ArrayList<Integer> indentationsToIgnore = getIndentationsToIgnore(options, indentationLevel);
+            final boolean isLastPropertyOfLevel = currentModelIsLastPropertyOfParent(contextModelsStack);
+
+            htmlWriter.append(
+                getHorizontalBorder(indentationLevel, hasChildren)
+            );
+            htmlWriter.append(
+                getVerticalBorders(isLastPropertyOfLevel, indentationLevel, indentationsToIgnore)
+            );
+
+            if (hasChildren && isLastPropertyOfLevel) {
+                indentationsToIgnore.add(indentationLevel);
+            }
+            options.context.data(INDENTATIONS_TO_IGNORE, indentationsToIgnore);
+
+            return new SafeString(htmlWriter);
+
+        } catch (final Exception e) {
+            throw new TemplateRenderingException("Failed to render schema borders.", e);
+        }
+
+    }
+
+    private ArrayList<Integer> getIndentationsToIgnore(final Options options, final int indentationLevel) {
+        ArrayList<Integer> indentationsToIgnore = options.context.data(INDENTATIONS_TO_IGNORE);
+        if (indentationsToIgnore == null) {
+            indentationsToIgnore = new ArrayList<>();
+        }
+        indentationsToIgnore.removeIf(n -> n >= indentationLevel);
+        return indentationsToIgnore;
+    }
+
+
+    private String getChildBorder(int indentationLevel) {
+        return String.format(
+            "<span class=\"child-schema-border\" style=\"--border-padding: 1.25em; --border-lightness: %.1f%%\"></span>",
+            getLightness(indentationLevel + 1)
+        );
+    }
+
+    // horizontal border connects element to first vertical border
+    private String getHorizontalBorder(final int indentationLevel, final boolean hasChildren) {
+        return String.format(
+            "<span class=\"%shorizontal-schema-border\" style=\"--border-padding: -0.25em; --border-lightness: %.1f%%\"></span>",
+            hasChildren ? "short-" : "",
+            getLightness(indentationLevel)
+        );
+    }
+
+    private String getVerticalBorders(
+        final boolean isLastPropertyOfLevel,
+        final int indentationLevel,
+        final ArrayList<Integer> indentationsToIgnore
+    ) {
+        final StringBuilder htmlWriter = new StringBuilder();
+
+        final String firstBorder = String.format(
+            "<span class=\"%svertical-schema-border\" style=\"--border-padding: -0.25em; --border-lightness: %.1f%%\"></span>",
+            isLastPropertyOfLevel ? "short-" : "",
+            getLightness(indentationLevel)
+        );
+
+        htmlWriter.append(firstBorder);
+
+        for (int i = 2; i <= indentationLevel; i++) {
+            if (indentationsToIgnore.contains(indentationLevel + 1 - i)) {
+                continue;
+            }
+            final String borderHtml = String.format(
+                "<span class=\"vertical-schema-border\" style=\"--border-padding: %sem; --border-lightness: %.1f%%\"></span>",
+                1.25 - (1.5 * i),
+                getLightness(indentationLevel + 1 - i)
+            );
+            htmlWriter.append(borderHtml);
+        }
+
+        return htmlWriter.toString();
+    }
+
+    private boolean currentModelHasChildren(ContextModelsStack contextModelsStack) {
+        if (contextModelsStack.currentModel().orElse(EMPTY_SCHEMA) instanceof ArrayList) {
+            return !((ArrayList) contextModelsStack.currentModel().get()).isEmpty();
+        }
+
+        final Schema<?> currentModel = asSchema(contextModelsStack.currentModel());
+
+        if (currentModel == null) {
+            return false;
+        }
+
+        if (currentModel instanceof ComposedSchema) {
+            return ((ComposedSchema) currentModel).getAllOf() != null
+                || ((ComposedSchema) currentModel).getAnyOf() != null
+                || ((ComposedSchema) currentModel).getOneOf() != null;
+        } else if (currentModel instanceof ArraySchema) {
+            return ((ArraySchema) currentModel).getItems() != null;
+        } else {
+            return currentModel.getProperties() != null;
+        }
+    }
+
+    private double getLightness(int indentationLevel) {
+        // Lightness is calculated as an exponential function, starting at (0, 25) and tending to (infinity, 40).
+        // Weighting (any positive value) affects how quickly the lighting scales.
+        double maximum = 40;
+        double minimum = 25;
+        double weighting = 2;
+
+        double weightedVariable = weighting * indentationLevel;
+        double offsetConstant = 1 / Math.log(minimum / maximum);
+        double exponent = -1 / ( weightedVariable - offsetConstant);
+        return maximum * Math.exp(exponent);
+    }
+
+    private boolean currentModelIsLastPropertyOfParent(final ContextModelsStack contextModelsStack) {
+        final Object currentModel = contextModelsStack.currentModel().orElse(null);
+        final Object parentModel = contextModelsStack.parentModel().orElse(null);
+
+        if (parentModel == null || currentModel == null) {
+            return true;
+        }
+
+        Object lastParentProperty;
+        if (parentModel instanceof ArrayList) {
+            lastParentProperty = getLastArrayListProperty((ArrayList) parentModel);
+        } else if (parentModel instanceof ComposedSchema) {
+            lastParentProperty = getLastXofProperty((ComposedSchema) parentModel);
+            if (! (currentModel instanceof ArrayList)) {
+                lastParentProperty = getLastArrayListProperty((ArrayList) lastParentProperty);
+            }
+        } else if (parentModel instanceof ArraySchema) {
+            lastParentProperty = getLastArrayProperty((ArraySchema) parentModel);
+        } else if (parentModel instanceof Schema) {
+            lastParentProperty = getLastProperty((Schema) parentModel);
+        } else {
+            lastParentProperty = EMPTY_SCHEMA;
+        }
+
+        return currentModel.equals(lastParentProperty);
+
+    }
+
+    private Schema getLastProperty(final Schema parentModel) {
+        final ArrayList<Schema> parentProperties = new ArrayList<Schema>(
+            Optional.ofNullable(parentModel.getProperties()).map(Map::values).orElse(Collections.emptyList())
+        );
+        final Schema lastPropertyOfParent = parentProperties.isEmpty() ? EMPTY_SCHEMA : parentProperties.get(parentProperties.size() - 1);
+        return lastPropertyOfParent;
+    }
+
+    private Schema getLastArrayProperty(final ArraySchema schema) {
+        return Optional.ofNullable(schema.getItems()).orElse(EMPTY_SCHEMA);
+    }
+
+    private Object getLastXofProperty(final ComposedSchema schema) {
+        List<Schema> xofProperties = Optional.ofNullable(
+            schema.getAllOf()
+        ).orElse(
+            Optional.ofNullable(
+                schema.getAnyOf()
+            ).orElse(
+                Optional.ofNullable(
+                    schema.getOneOf()
+                ).orElse(Collections.emptyList())
+            )
+        );
+
+        return xofProperties.isEmpty() ? EMPTY_SCHEMA : xofProperties;
+    }
+
+    private Object getLastArrayListProperty(final ArrayList schema) {
+        return schema.isEmpty() ? null : schema.get(schema.size() - 1);
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private Schema<?> asSchema(final Optional<?> schemaCandidate) {
+        if (!schemaCandidate.isPresent()) {
+            return null;
+        }
+
+        return schemaCandidate
+            .filter(model -> model instanceof Schema)
+            .map(model -> (Schema<?>) model)
+            .orElse(null);
+    }
+
+}

--- a/cms/src/main/java/uk/nhs/digital/apispecs/handlebars/UuidHelper.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/handlebars/UuidHelper.java
@@ -1,8 +1,12 @@
 package uk.nhs.digital.apispecs.handlebars;
 
+import com.github.jknack.handlebars.Helper;
+import com.github.jknack.handlebars.Options;
+
 import java.util.UUID;
 
-public class UuidHelper {
+public class UuidHelper implements Helper<Object> {
+    public static final String NAME = "uuid";
 
     public static final UuidHelper INSTANCE = new UuidHelper();
 
@@ -10,7 +14,8 @@ public class UuidHelper {
         // private to encourage use of INSTANCE
     }
 
-    public CharSequence uuid() {
+    @Override
+    public CharSequence apply(Object model, Options options) {
         return UUID.randomUUID().toString();
     }
 }

--- a/cms/src/main/java/uk/nhs/digital/apispecs/handlebars/schema/SchemaHelper.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/handlebars/schema/SchemaHelper.java
@@ -81,9 +81,8 @@ public class SchemaHelper implements Helper<Schema<?>> {
             .registerHelper(TypeAnySanitisingHelper.NAME, TypeAnySanitisingHelper.INSTANCE)
             .registerHelper(AssignHelper.NAME, AssignHelper.INSTANCE)
             .registerHelper(VariableValueHelper.NAME, VariableValueHelper.INSTANCE)
-            // below helper is registered as a HelperSource as it takes no parameters.
-            // see https://github.com/jknack/handlebars.java#using-a-helpersource for further info
-            .registerHelpers(UuidHelper.INSTANCE)
+            .registerHelper(BorderHelper.NAME, new BorderHelper(contextStackFactory))
+            .registerHelper(UuidHelper.NAME, UuidHelper.INSTANCE)
             ;
     }
 }

--- a/cms/src/main/resources/api-specification/codegen-templates/schema.mustache
+++ b/cms/src/main/resources/api-specification/codegen-templates/schema.mustache
@@ -1,6 +1,6 @@
 <table data-disablesort="true">
     <thead>
-    <th colspan="2">Name</th>
+    <th>Name</th>
     <th>Description</th>
     </thead>
 

--- a/cms/src/main/resources/api-specification/codegen-templates/schema_object.mustache
+++ b/cms/src/main/resources/api-specification/codegen-templates/schema_object.mustache
@@ -1,8 +1,17 @@
 {{! For model's reference see io.swagger.v3.oas.models.media.Schema and extending classes}}
 {{#assign "schemaUUID"}}{{uuid}}{{/assign}}
 <tr class="expanded" data-schema-uuid="{{variable "schemaUUID"}}" data-indentation="{{indentation}}" colspan="2">
+
     {{! 'Name' column (values that don't require labels) }}
-    <td style="padding-left: {{indentation}}em;" class="name_column">
+    <td style="padding-left: {{indentation weighting=1.5}}em;" class="name_column">
+        {{#or properties anyOf oneOf allOf}}
+            <button class="collapser js" data-schema-uuid="{{variable "schemaUUID"}}" onclick="collapseChildren('{{variable "schemaUUID"}}')"></button>
+        {{else}}
+            {{#eq type 'array'}}
+                <button class="collapser js" data-schema-uuid="{{variable "schemaUUID"}}" onclick="collapseChildren('{{variable "schemaUUID"}}')"></button>
+            {{/eq}}
+        {{/or}}
+        {{borders}}
         {{#block "propertyName"}}{{/block}}
 
         {{#or type format}}
@@ -18,16 +27,6 @@
         {{#readOnly}}<div><code class="readonly">read-only</code></div>{{/readOnly}}
         {{#writeOnly}}<div><code class="writeonly">write-only</code></div>{{/writeOnly}}
         {{#ifRequired}}<div><code class="required">required</code></div>{{/ifRequired}}
-    </td>
-
-    <td class="button_column">
-        {{#or properties anyOf oneOf allOf}}
-            <button class="collapser js" data-schema-uuid="{{variable "schemaUUID"}}" onclick="collapseChildren('{{variable "schemaUUID"}}')"></button>
-        {{else}}
-            {{#eq type 'array'}}
-                <button class="collapser js" data-schema-uuid="{{variable "schemaUUID"}}" onclick="collapseChildren('{{variable "schemaUUID"}}')"></button>
-            {{/eq}}
-        {{/or}}
     </td>
 
     {{! 'Description' column (actual description + values that do require labels) }}

--- a/cms/src/main/resources/api-specification/codegen-templates/schema_xof_if.mustache
+++ b/cms/src/main/resources/api-specification/codegen-templates/schema_xof_if.mustache
@@ -1,11 +1,10 @@
 {{#assign "schemaUUID"}}{{uuid}}{{/assign}}
 {{#if anyOf}}
     <tr class="expanded" data-schema-uuid="{{variable "schemaUUID"}}" data-indentation="{{indentation}}">
-        <td style="padding-left: {{indentation}}em;">
+        <td class="name_column" style="padding-left: {{indentation weighting=1.5}}em;">
+            <button class="collapser js" data-schema-uuid="{{variable "schemaUUID"}}" onclick="collapseChildren('{{variable "schemaUUID"}}')"></button>
+            {{borders}}
             <div><code class="anyOf">anyOf</code></div>
-        </td>
-        <td class="button_column">
-            <div><button class="collapser js" data-schema-uuid="{{variable "schemaUUID"}}" onclick="collapseChildren('{{variable "schemaUUID"}}')"></button></div>
         </td>
         <td class="description_column"></td>
     </tr>
@@ -16,11 +15,10 @@
 {{/each}}
 {{#if oneOf}}
     <tr class="expanded" data-schema-uuid="{{variable "schemaUUID"}}" data-indentation="{{indentation}}">
-        <td style="padding-left: {{indentation}}em;">
+        <td class="name_column" style="padding-left: {{indentation weighting=1.5}}em;">
+            <button class="collapser js" data-schema-uuid="{{variable "schemaUUID"}}" onclick="collapseChildren('{{variable "schemaUUID"}}')"></button>
+            {{borders}}
             <div><code class="oneOf">oneOf</code></div>
-        </td>
-        <td class="button_column">
-            <div><button class="collapser js" data-schema-uuid="{{variable "schemaUUID"}}" onclick="collapseChildren('{{variable "schemaUUID"}}')"></button></div>
         </td>
         <td class="description_column"></td>
     </tr>
@@ -31,11 +29,10 @@
 {{/each}}
 {{#if allOf}}
     <tr class="expanded" data-schema-uuid="{{variable "schemaUUID"}}" data-indentation="{{indentation}}">
-        <td style="padding-left: {{indentation}}em;">
+        <td class="name_column" style="padding-left: {{indentation weighting=1.5}}em;">
+            <button class="collapser js" data-schema-uuid="{{variable "schemaUUID"}}" onclick="collapseChildren('{{variable "schemaUUID"}}')"></button>
+            {{borders}}
             <div><code class="allOf">allOf</code></div>
-        </td>
-        <td class="button_column">
-            <div><button class="collapser js" data-schema-uuid="{{variable "schemaUUID"}}" onclick="collapseChildren('{{variable "schemaUUID"}}')"></button></div>
         </td>
         <td class="description_column"></td>
     </tr>

--- a/cms/src/main/resources/api-specification/codegen-templates/schema_xof_with.mustache
+++ b/cms/src/main/resources/api-specification/codegen-templates/schema_xof_with.mustache
@@ -1,11 +1,10 @@
 {{#assign "schemaUUID"}}{{uuid}}{{/assign}}
 {{#with anyOf}}
     <tr class="expanded" data-schema-uuid="{{variable "schemaUUID"}}" data-indentation="{{indentation}}">
-        <td style="padding-left: {{indentation}}em;">
+        <td class="name_column" style="padding-left: {{indentation weighting=1.5}}em;">
+            <button class="collapser js" data-schema-uuid="{{variable "schemaUUID"}}" onclick="collapseChildren('{{variable "schemaUUID"}}')"></button>
+            {{borders}}
             <div><code class="anyOf">anyOf</code></div>
-        </td>
-        <td class="button_column">
-            <div><button class="collapser js" data-schema-uuid="{{variable "schemaUUID"}}" onclick="collapseChildren('{{variable "schemaUUID"}}')"></button></div>
         </td>
         <td class="description_column"></td>
     </tr>
@@ -16,11 +15,10 @@
 {{/with}}
 {{#with oneOf}}
     <tr class="expanded" data-schema-uuid="{{variable "schemaUUID"}}" data-indentation="{{indentation}}">
-        <td style="padding-left: {{indentation}}em;">
+        <td class="name_column" style="padding-left: {{indentation weighting=1.5}}em;">
+            <button class="collapser js" data-schema-uuid="{{variable "schemaUUID"}}" onclick="collapseChildren('{{variable "schemaUUID"}}')"></button>
+            {{borders}}
             <div><code class="oneOf">oneOf</code></div>
-        </td>
-        <td class="button_column">
-            <div><button class="collapser js" data-schema-uuid="{{variable "schemaUUID"}}" onclick="collapseChildren('{{variable "schemaUUID"}}')"></button></div>
         </td>
         <td class="description_column"></td>
     </tr>
@@ -31,11 +29,10 @@
 {{/with}}
 {{#with allOf}}
     <tr class="expanded" data-schema-uuid="{{variable "schemaUUID"}}" data-indentation="{{indentation}}">
-        <td style="padding-left: {{indentation}}em;">
+        <td class="name_column" style="padding-left: {{indentation weighting=1.5}}em;">
+            <button class="collapser js" data-schema-uuid="{{variable "schemaUUID"}}" onclick="collapseChildren('{{variable "schemaUUID"}}')"></button>
+            {{borders}}
             <div><code class="allOf">allOf</code></div>
-        </td>
-        <td class="button_column">
-            <div><button class="collapser js" data-schema-uuid="{{variable "schemaUUID"}}" onclick="collapseChildren('{{variable "schemaUUID"}}')"></button></div>
         </td>
         <td class="description_column"></td>
     </tr>

--- a/cms/src/test/java/uk/nhs/digital/apispecs/handlebars/OptionsStub.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/handlebars/OptionsStub.java
@@ -35,6 +35,10 @@ public class OptionsStub extends Options {
         return new OptionsStub(null, null, null, null, null, null, null, null, hash, emptyList());
     }
 
+    public static OptionsStub with(final Context context, final Hash hash) {
+        return new OptionsStub(null, null, null, null, context, null, null, null, hash, emptyList());
+    }
+
     public static OptionsStub with(final Buffer buffer, final Hash hash) {
         return new OptionsStub(buffer, null, null, null, null, null, null, null, hash, emptyList());
     }

--- a/cms/src/test/java/uk/nhs/digital/apispecs/handlebars/schema/BorderHelperTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/handlebars/schema/BorderHelperTest.java
@@ -1,0 +1,284 @@
+package uk.nhs.digital.apispecs.handlebars.schema;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.BDDMockito.given;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+import com.github.jknack.handlebars.Context;
+import com.github.jknack.handlebars.Options;
+import com.google.common.collect.ImmutableMap;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import io.swagger.v3.oas.models.media.ArraySchema;
+import io.swagger.v3.oas.models.media.ComposedSchema;
+import io.swagger.v3.oas.models.media.Schema;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.nhs.digital.apispecs.handlebars.BorderHelper;
+import uk.nhs.digital.apispecs.handlebars.OptionsStub;
+
+import java.util.ArrayList;
+
+
+@RunWith(DataProviderRunner.class)
+public class BorderHelperTest {
+    private BorderHelper borderHelper = new BorderHelper(new ContextModelsStack.Factory(new UniqueModelStackExtractor()));
+    private static final String[] lightnessLevels = new String[]{"31.4%", "34.0%"};
+
+    @Test
+    public void doesNotReturnParentBorder_whenElementHasNone() {
+        // given
+        final Context context = Context.newContext(new Object());
+
+        final Schema currentModel = new Schema().properties(
+            ImmutableMap.of("child_1", new Schema())
+        );
+
+        final ContextModelsStack contextModelsStack = new ContextModelsStack(asList(currentModel));
+
+        final ContextModelsStack.Factory contextStackFactory = mock(ContextModelsStack.Factory.class);
+        given(contextStackFactory.from(context)).willReturn(contextModelsStack);
+        borderHelper = BorderHelper.with(contextStackFactory);
+
+        final Options options = OptionsStub.with(context);
+
+        // when
+        final CharSequence expectedBorders = getBorder(SchemaBorder.CHILD,  0);
+        final CharSequence actualBorders = borderHelper.apply(null, options).toString();
+
+        // then
+        assertThat("Helper returns HTML for child element's border and does not return any other vertical borders",
+            actualBorders,
+            is(expectedBorders)
+        );
+    }
+
+
+    @Test
+    public void returnsHorizontalBorder_whenElementHasParent() {
+        // given
+        final Context context = Context.newContext(new Object());
+
+        final Schema currentModel = new Schema();
+        final Schema parentModel = new Schema();
+
+        final ContextModelsStack contextModelsStack = new ContextModelsStack(
+            asList(currentModel, parentModel)
+        );
+
+        final ContextModelsStack.Factory contextStackFactory = mock(ContextModelsStack.Factory.class);
+        given(contextStackFactory.from(context)).willReturn(contextModelsStack);
+        borderHelper = BorderHelper.with(contextStackFactory);
+
+        final Options options = OptionsStub.with(context);
+
+        // when
+        final CharSequence expectedBorders = getBorder(SchemaBorder.HORIZONTAL, 1, 0)
+             + getBorder(SchemaBorder.SHORT_VERTICAL, 1, 0);
+        final CharSequence actualBorders = borderHelper.apply(null, options).toString();
+
+        // then
+        assertThat("Helper returns HTML with one vertical border for each ancestor model, and a horizontal border",
+            actualBorders,
+            is(expectedBorders)
+        );
+    }
+
+    @Test
+    public void returnsParentBorder_forEachIndentationLevel() {
+        // given
+        final Context context = Context.newContext(new Object());
+
+        final Schema currentModel = new Schema();
+        final Schema parentModel = new Schema();
+        final Schema grandparentModel = new Schema();
+
+        final ContextModelsStack contextModelsStack = new ContextModelsStack(
+            asList(currentModel, parentModel, grandparentModel)
+        );
+
+        final ContextModelsStack.Factory contextStackFactory = mock(ContextModelsStack.Factory.class);
+        given(contextStackFactory.from(context)).willReturn(contextModelsStack);
+        borderHelper = BorderHelper.with(contextStackFactory);
+
+        final Options options = OptionsStub.with(context);
+
+        // when
+        final CharSequence expectedBorders = getBorder(SchemaBorder.HORIZONTAL, 1, 1)
+            + getBorder(SchemaBorder.SHORT_VERTICAL, 1, 1)
+            + getBorder(SchemaBorder.VERTICAL, 2, 0);
+        final CharSequence actualBorders = borderHelper.apply(null, options).toString();
+
+        // then
+        assertThat("Helper returns HTML with one vertical border for each ancestor model, and a horizontal border",
+            actualBorders,
+            is(expectedBorders)
+        );
+    }
+
+    @Test
+    @UseDataProvider("lastChildModels")
+    public void returnsShortVerticalBorder_whenElementIsLastPropertyOfParent(
+        final Schema currentModel,
+        final Schema parentModel,
+        final String expectedBorders
+    ) {
+        // given
+        final Context context = Context.newContext(new Object());
+
+        final ContextModelsStack contextModelsStack = new ContextModelsStack(
+            asList(currentModel, parentModel)
+        );
+
+        final ContextModelsStack.Factory contextStackFactory = mock(ContextModelsStack.Factory.class);
+        given(contextStackFactory.from(context)).willReturn(contextModelsStack);
+        borderHelper = BorderHelper.with(contextStackFactory);
+
+        final Options options = OptionsStub.with(context);
+
+        // when
+        final CharSequence actualBorders = borderHelper.apply(null, options).toString();
+
+        // then
+        assertThat("Helper returns HTML with one short vertical border",
+            actualBorders,
+            is(expectedBorders)
+        );
+    }
+
+    @Test
+    @UseDataProvider("modelsWithChildren")
+    public void returnsChildBorder_whenElementHasChildren(
+        final Schema currentModel,
+        final String expectedBorders
+    ) {
+        // given
+        final Context context = Context.newContext(new Object());
+
+        final ContextModelsStack contextModelsStack = new ContextModelsStack(
+            asList(currentModel)
+        );
+
+        final ContextModelsStack.Factory contextStackFactory = mock(ContextModelsStack.Factory.class);
+        given(contextStackFactory.from(context)).willReturn(contextModelsStack);
+        borderHelper = BorderHelper.with(contextStackFactory);
+
+        final Options options = OptionsStub.with(context);
+
+        // when
+        final CharSequence actualBorders = borderHelper.apply(null, options).toString();
+
+        // then
+        assertThat("Helper returns HTML with a child border",
+            actualBorders,
+            is(expectedBorders)
+        );
+    }
+
+    @DataProvider
+    public static Object[][] lastChildModels() {
+        final String expectedBorder = getBorder(SchemaBorder.HORIZONTAL, 1, 0) + getBorder(SchemaBorder.SHORT_VERTICAL, 1, 0);
+        final Schema currentModel = new Schema();
+        return new Object[][] {
+            // "properties" child
+            {
+                currentModel,
+                new Schema().properties(ImmutableMap.of("child", currentModel)),
+                expectedBorder
+            },
+            // "allOf" child
+            {
+                currentModel,
+                new ComposedSchema().allOf(new ArrayList<>(asList(currentModel))),
+                expectedBorder
+            },
+            // "anyOf" child
+            {
+                currentModel,
+                new ComposedSchema().anyOf(new ArrayList<>(asList(currentModel))),
+                expectedBorder
+            },
+            // "oneOf" child
+            {
+                currentModel,
+                new ComposedSchema().oneOf(new ArrayList<>(asList(currentModel))),
+                expectedBorder
+            },
+            // "array" -> "items" child
+            {
+                currentModel,
+                new ArraySchema().items(currentModel),
+                expectedBorder
+            }
+        };
+    }
+
+    @DataProvider
+    public static Object[][] modelsWithChildren() {
+        final String childBorder = getBorder(SchemaBorder.CHILD, 0);
+        return new Object[][] {
+            // "properties" child
+            {
+                new Schema().properties(ImmutableMap.of("child", new Schema())),
+                childBorder
+            },
+            // "allOf" child
+            {
+                new ComposedSchema().allOf(asList(new Schema())),
+                childBorder
+            },
+            // "anyOf" child
+            {
+                new ComposedSchema().anyOf(asList(new Schema())),
+                childBorder
+            },
+            // "oneOf" child
+            {
+                new ComposedSchema().oneOf(asList(new Schema())),
+                childBorder
+            },
+            // "array" -> "items" child
+            {
+                new ArraySchema().items(new Schema<>()),
+                childBorder
+            }
+        };
+    }
+
+    private static String getBorder(SchemaBorder type, int lightnessLevel) {
+        return String.format(
+            "<span class=\"%s-schema-border\" style=\"--border-padding: 1.25em; --border-lightness: %s\"></span>",
+            type.getString(), lightnessLevels[lightnessLevel]
+        );
+    }
+
+    private static String getBorder(SchemaBorder type, int paddingLevel, int lightnessLevel) {
+        if (type == SchemaBorder.CHILD) {
+            return getBorder(type, lightnessLevel);
+        }
+        return String.format(
+            "<span class=\"%s-schema-border\" style=\"--border-padding: %sem; --border-lightness: %s\"></span>",
+            type.getString(), 1.25 - (1.5 * paddingLevel), lightnessLevels[lightnessLevel]
+        );
+    }
+
+    enum SchemaBorder {
+        CHILD("child"),
+        HORIZONTAL("horizontal"),
+        VERTICAL("vertical"),
+        SHORT_VERTICAL("short-vertical");
+
+        private final String cssString;
+
+        SchemaBorder(String cssString) {
+            this.cssString = cssString;
+        }
+
+        public String getString() {
+            return this.cssString;
+        }
+    }
+}

--- a/cms/src/test/java/uk/nhs/digital/apispecs/handlebars/schema/SchemaHelperTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/handlebars/schema/SchemaHelperTest.java
@@ -39,6 +39,7 @@ import uk.nhs.digital.test.util.TestFileUtils;
 
 import java.io.File;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -353,13 +354,13 @@ public class SchemaHelperTest {
         assertThat("HTML contains '" + propertyName + "' element.",
             ignoringWhiteSpacesIn(actualSchemaHtml),
             stringContainsInOrder(
-                "padding-left: 0em;",           // root
-                "padding-left: 1em;",           //   non-items
-                "padding-left: 2em;",           //     oneOf
+                "padding-left: 0.0em;",           // root
+                "padding-left: 1.5em;",           //   non-items
+                "padding-left: 3.0em;",           //     oneOf
                 ">" + propertyName + "<",       //
-                "padding-left: 3em;",           //       A
+                "padding-left: 4.5em;",           //       A
                 ">" + propertyName + " - A<",   //
-                "padding-left: 3em;",           //       B
+                "padding-left: 4.5em;",           //       B
                 ">" + propertyName + " - B<"
             )
         );
@@ -379,13 +380,13 @@ public class SchemaHelperTest {
         assertThat("HTML contains '" + propertyName + "' element.",
             ignoringWhiteSpacesIn(actualSchemaHtml),
             stringContainsInOrder(
-                "padding-left: 0em;",           // root
-                "padding-left: 1em;",           //   array-schema
-                "padding-left: 2em;",           //     oneOf
+                "padding-left: 0.0em;",           // root
+                "padding-left: 1.5em;",           //   array-schema
+                "padding-left: 3.0em;",           //     oneOf
                 ">" + propertyName + "<",       //
-                "padding-left: 3em;",           //       A
+                "padding-left: 4.5em;",           //       A
                 ">" + propertyName + " - A<",   //
-                "padding-left: 3em;",           //       B
+                "padding-left: 4.5em;",           //       B
                 ">" + propertyName + " - B<"
             )
         );
@@ -627,10 +628,10 @@ public class SchemaHelperTest {
         final ComposedSchema notItemSchemaObject = new ComposedSchema();
         notItemSchemaObject.title("not-items schema object");
 
-        setField(notItemSchemaObject, propertyName, asList(
+        setField(notItemSchemaObject, propertyName, new ArrayList<>(asList(
             new ObjectSchema().title(propertyName + " - A"),
             new ObjectSchema().title(propertyName + " - B")
-        ));
+        )));
 
         return new ObjectSchema()
             .title("root schema object")
@@ -644,10 +645,10 @@ public class SchemaHelperTest {
         final ComposedSchema items = new ComposedSchema();
         items.title("items object");
 
-        setField(items, propertyName, asList(
+        setField(items, propertyName, new ArrayList<>(asList(
             new ObjectSchema().title(propertyName + " - A"),
             new ObjectSchema().title(propertyName + " - B")
-        ));
+        )));
 
         return new ObjectSchema()
             .title("root object")

--- a/cms/src/test/resources/test-data/api-specifications/ApiSpecSyncFromApigeeJobIntegrationTest/oasV3_complete.html
+++ b/cms/src/test/resources/test-data/api-specifications/ApiSpecSyncFromApigeeJobIntegrationTest/oasV3_complete.html
@@ -1,16 +1,16 @@
 <div class="column column--one-third page-block--sticky-nav page-block--sidebar article-section-nav-outer-wrapper apispecification">
-<!-- start sticky-nav -->
-<div id="sticky-nav">
-    <div class="article-section-nav-wrapper">
-        <div class="article-section-nav">
-            <h2 class="article-section-nav__title">Page contents</h2>
-            <div class="scrollable-component">
-                <nav>
-                    <ol class="article-section-nav__list">
-                        <li>
-                            <a href="#top" aria-label="Scroll to 'Top of page'"
-                               title="Scroll to 'Top of page'">Top of page</a>
-                        </li>
+    <!-- start sticky-nav -->
+    <div id="sticky-nav">
+        <div class="article-section-nav-wrapper">
+            <div class="article-section-nav">
+                <h2 class="article-section-nav__title">Page contents</h2>
+                <div class="scrollable-component">
+                    <nav>
+                        <ol class="article-section-nav__list">
+                            <li>
+                                <a href="#top" aria-label="Scroll to 'Top of page'"
+                                   title="Scroll to 'Top of page'">Top of page</a>
+                            </li>
                             <li>
                                 <a href="#api-description__overview"
                                    aria-label="Scroll to 'Overview'"
@@ -21,2462 +21,1186 @@
                                    aria-label="Scroll to 'Legal use'"
                                    title="Scroll to 'Legal use'">Legal use</a>
                             </li>
-
-                                        <li>
-                                            <a href="#api-Patients"
-                                               aria-label="Endpoints: Patients"
-                                               title="Endpoints: Patients">Endpoints: Patients</a>
-                                        </li>
-                                        <li class="section-numbered">
-                                            <a href="#api-Patients-get-patient"
-                                               aria-label="get-patient"
-                                               title="get-patient">Retrieve a patient's resource</a>
-                                        </li>
-                                        <li class="section-numbered">
-                                            <a href="#api-Patients-search-patient"
-                                               aria-label="search-patient"
-                                               title="search-patient">Search for patient</a>
-                                        </li>
-                                        <li class="section-numbered">
-                                            <a href="#api-Patients-update-patient-partial"
-                                               aria-label="update-patient-partial"
-                                               title="update-patient-partial">Update a patient's resource</a>
-                                        </li>
-                                        <li>
-                                            <a href="#api-Polling"
-                                               aria-label="Endpoints: Polling"
-                                               title="Endpoints: Polling">Endpoints: Polling</a>
-                                        </li>
-                                        <li class="section-numbered">
-                                            <a href="#api-Polling-polling"
-                                               aria-label="polling"
-                                               title="polling">Retrieve the outcome of the accepted update.</a>
-                                        </li>
-                    </ol>
-                </nav>
+                            <li>
+                                <a href="#api-Patients"
+                                   aria-label="Endpoints: Patients"
+                                   title="Endpoints: Patients">Endpoints: Patients</a>
+                            </li>
+                            <li class="section-numbered">
+                                <a href="#api-Patients-get-patient"
+                                   aria-label="get-patient"
+                                   title="get-patient">Retrieve a patient's resource</a>
+                            </li>
+                            <li class="section-numbered">
+                                <a href="#api-Patients-search-patient"
+                                   aria-label="search-patient"
+                                   title="search-patient">Search for patient</a>
+                            </li>
+                            <li class="section-numbered">
+                                <a href="#api-Patients-update-patient-partial"
+                                   aria-label="update-patient-partial"
+                                   title="update-patient-partial">Update a patient's resource</a>
+                            </li>
+                            <li>
+                                <a href="#api-Polling"
+                                   aria-label="Endpoints: Polling"
+                                   title="Endpoints: Polling">Endpoints: Polling</a>
+                            </li>
+                            <li class="section-numbered">
+                                <a href="#api-Polling-polling"
+                                   aria-label="polling"
+                                   title="polling">Retrieve the outcome of the accepted update.</a>
+                            </li>
+                        </ol>
+                    </nav>
+                </div>
             </div>
         </div>
     </div>
+    <!-- end sticky-nav -->
 </div>
-<!-- end sticky-nav -->
-</div>
-
 <div id="content" class="column column--two-thirds page-block page-block--main apispecification" aria-label="Document content">
-
     <!-- API Title: Personal Demographics Service (FHIR) API -->
-
     <div id="api-description" class="article-section">
         <h2 id="api-description__overview">Overview</h2>
-<p>Use this API to access the <a href="https://digital.nhs.uk/services/demographics">Personal Demographics Service (PDS)</a></p>
-<h2 id="api-description__legal-use">Legal use</h2>
-<p>This API can only be used where there is a legal basis.
+        <p>Use this API to access the <a href="https://digital.nhs.uk/services/demographics">Personal Demographics Service (PDS)</a></p>
+        <h2 id="api-description__legal-use">Legal use</h2>
+        <p>This API can only be used where there is a legal basis.
     </div>
-
-                    <div id="api-Patients" class="article-section">
-                        <h2>Endpoints: Patients</h2>
-                    </div>
-                                    <div id="api-Patients-get-patient" class="article-section-with-sub-heading">
-                                        <article id="api-Patients-get-patient-0">
-                                            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-                                            <h3>Retrieve a patient's resource</h3>
-                                            <div class="endpoint_path">
-                                                <div class="method">get</div>
-                                                <div class="pre"><pre>/Patient/{id}</pre></div>
-
-                                                        <div class="try"><a onclick="tryEndpointNow('/Patients/get-patient')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
-                                            </div>
-
-                                            <p><h4 id="overview">Overview</h4>
-<p>Use this endpoint to get patient details from PDS for a given NHS Number.</p>
-
-                                                <h4>Request</h4>
-
-                                                <div class="httpparams">
-                                                    <h5>Path parameters</h5>
-                                                    <table data-disablesort="true">
-                                                        <tr>
-                                                            <th>Name</th>
-                                                            <th>Description</th>
-                                                        </tr>
-                                                            <tr><td class="httpparams__name">id</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                <div>The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales.</div>
-
-
-
-                                                                                <div>Example: <code class="codeinline">9000000009</code></div>
-
-                                                                        </div>
-                                                                            <div class="httpparams__required">
-                                                                                Required
-                                                                            </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                    </table>
-                                                </div>
-
-
-                                                <div class="httpparams">
-                                                    <h5>Headers</h5>
-                                                    <table data-disablesort="true">
-                                                        <tr>
-                                                            <th>Name</th>
-                                                            <th>Description</th>
-                                                        </tr>
-                                                            <tr><td class="httpparams__name">NHSD-Session-URID</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>).</div>
-
-                                                                                <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
-
-
-                                                                                <div>Example: <code class="codeinline">555021935107</code></div>
-
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                    </table>
-                                                </div>
-
-
-
-                                                    <h4>Response</h4>
-
-                                                <h5>HTTP status: 200</h5>
-                                                <div>Information successfully returned.</div>
-
-                                                    <div class="httpparams">
-                                                        <h6>Headers</h6>
-                                                        <table data-disablesort="true">
-                                                            <tr>
-                                                                <th>Name</th>
-                                                                <th>Description</th>
-                                                            </tr>
-                                                                <tr><td class="httpparams__name">ETag</td>
-                                                                <td>
-                                                                    <div>
-                                                                        <div class="httpparams__description">
-                                                                            <div>
-                                                                                <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                    <div>Record version identifier enclosed in quotes and preceded by 'W/'. For example, <code class="codeinline">W/&quot;2&quot;</code>.</div>
-
-                                                                                    <div>Pattern: <code class="codeinline">/^W\/"[0-9]+"$/</code></div>
-
-
-                                                                                    <div>Example: <code class="codeinline">W/"2"</code></div>
-
-                                                                            </div>
-                                                                        </div>
-                                                                    </div>
-                                                                </td>
-                                                                </tr>
-                                                        </table>
-                                                    </div>
-
-                                                        <h6>Body</h6>
-
-
-                                                            <div class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/fhir+json</span>
-                                                            </div>
-
-                                                                <div class="body__example__header">Example</div>
-                                                                <div><pre><code>{
-  "address" : [ {
-    "id" : "456",
-    "line" : [ "1 Trevelyan Square", "Boar Lane", "City Centre", "Leeds", "West Yorkshire" ],
-    "postalCode" : "LS1 6AE",
-    "use" : "home"
-  } ],
-  "birthDate" : "2010-10-22"
-}</code></pre></div>
-
-
-
-
-                                                                <div class="body__schema__header">Schema
-                                                                    <span class="schema__header__buttons">
-                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('e81ea218-50ec-493a-9db1-8817bea495aa')">Collapse all</button>
-                                                                        <button class='schemaButton js expandAll' onclick="expandAll('e81ea218-50ec-493a-9db1-8817bea495aa')">Expand all</button>
-                                                                    </span>
-                                                                </div>
-                                                                <div class="body__schema" data-schema-uuid="e81ea218-50ec-493a-9db1-8817bea495aa">
-                                                                    <table data-disablesort="true">
-                                                                        <thead>
-                                                                        <th colspan="2">Name</th>
-                                                                        <th>Description</th>
-                                                                        </thead>
-
-
-<tr class="expanded" data-schema-uuid="0f19ee9b-2831-456a-973f-35985ee17d74" data-indentation="0" colspan="2">
-    <td style="padding-left: 0em;" class="name_column">
-
-        <div>
-            <code class="type">object</code>
-
-        </div>
-
-
-
-
-
-
-
-    </td>
-
-    <td class="button_column">
-            <button class="collapser js" data-schema-uuid="0f19ee9b-2831-456a-973f-35985ee17d74" onclick="collapseChildren('0f19ee9b-2831-456a-973f-35985ee17d74')"></button>
-    </td>
-
-    <td class="description_column">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    </td>
-</tr>
-
-
-    <tr class="expanded" data-schema-uuid="a12ddc9b-1f4a-4b60-b318-f5bf3d21b86e" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">resourceType</code></div>
-
-            <div>
-                <code class="type">string</code>
-
-            </div>
-
-
-
-
-            <div><code class="readonly">read-only</code></div>
-
-
-        </td>
-
-        <td class="button_column">
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">FHIR resource type.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                <div>Default: <code class="codeinline default">Patient</code></div>
-
-        </td>
-    </tr>
-
-
-
-
-
-    <tr class="expanded" data-schema-uuid="23fb31ac-17c5-4cde-aaa1-ddae7ec8382e" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">id</code></div>
-
-            <div>
-                <code class="type">string</code>
-
-            </div>
-
-
-
-
-
-
-            <div><code class="required">required</code></div>
-        </td>
-
-        <td class="button_column">
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales. Always 10 digits and must be a <a href="https://www.datadictionary.nhs.uk/data_dictionary/attributes/n/nhs/nhs_number_de.asp">valid NHS Number</a>.</div>
-
-            <div>Pattern: <code class="codeinline pattern">^\d{10}$</code></div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                <div>Example: <code class="codeinline example">9000000009</code></div>
-        </td>
-    </tr>
-
-
-
-
-
-
-
-
-
-                                                                    </table>
-                                                                </div>
-
-
-
-                                                <h5>HTTP status: 400</h5>
-                                                <div>Invalid NHS number supplied.</div>
-
-
-                                                        <h6>Body</h6>
-
-
-                                                            <div class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/fhir+json</span>
-                                                            </div>
-
-                                                                <div class="body__example__header">Example</div>
-                                                                <div><pre><code>{
-  "resourceType" : "OperationOutcome",
-  "issue" : [ {
-    "severity" : "error",
-    "code" : "value",
-    "details" : {
-      "coding" : [ {
-        "system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
-        "version" : "1",
-        "code" : "INVALID_RESOURCE_ID",
-        "display" : "Resource Id is invalid"
-      } ]
-    }
-  } ]
-}</code></pre></div>
-
-
-
-
-                                                                <div class="body__schema__header">Schema
-                                                                    <span class="schema__header__buttons">
-                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('374f4d90-5cbf-46b7-80a5-3d8706318ac8')">Collapse all</button>
-                                                                        <button class='schemaButton js expandAll' onclick="expandAll('374f4d90-5cbf-46b7-80a5-3d8706318ac8')">Expand all</button>
-                                                                    </span>
-                                                                </div>
-                                                                <div class="body__schema" data-schema-uuid="374f4d90-5cbf-46b7-80a5-3d8706318ac8">
-                                                                    <table data-disablesort="true">
-                                                                        <thead>
-                                                                        <th colspan="2">Name</th>
-                                                                        <th>Description</th>
-                                                                        </thead>
-
-
-<tr class="expanded" data-schema-uuid="b85d66d0-8eb3-461b-8d71-9890ad059c96" data-indentation="0" colspan="2">
-    <td style="padding-left: 0em;" class="name_column">
-
-        <div>
-            <code class="type">object</code>
-
-        </div>
-
-
-
-
-
-
-
-    </td>
-
-    <td class="button_column">
-            <button class="collapser js" data-schema-uuid="b85d66d0-8eb3-461b-8d71-9890ad059c96" onclick="collapseChildren('b85d66d0-8eb3-461b-8d71-9890ad059c96')"></button>
-    </td>
-
-    <td class="description_column">
-
-
-        <div class="description">Outcome of an operation that does not result in a resource or bundle being returned (e.g. error, async/batch submission).</p>
-<p>Search outcomes:</p>
-<table data-disablesort="true">
-<thead>
-<tr>
-<th>Code</th>
-<th>Response Code</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>INVALID_SEARCH_DATA</td>
-<td>400</td>
-<td>The search parameters are invalid. A description of what exactly is at fault will be added to the display.</td>
-</tr>
-<tr>
-<td>TOO_MANY_MATCHES</td>
-<td>200</td>
-<td>Too many matches were found - user should be told to refine their search parameters.</td>
-</tr>
-</tbody>
-</table></div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    </td>
-</tr>
-
-
-    <tr class="expanded" data-schema-uuid="7e0e1a8f-9607-4215-a6f5-0c0aa0e0f156" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">resourceType</code></div>
-
-            <div>
-                <code class="type">string</code>
-
-            </div>
-
-
-
-
-            <div><code class="readonly">read-only</code></div>
-
-
-        </td>
-
-        <td class="button_column">
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">FHIR Resource Type.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                <div>Default: <code class="codeinline default">OperationOutcome</code></div>
-
-        </td>
-    </tr>
-
-
-
-
-
-    <tr class="expanded" data-schema-uuid="2dd81e85-039e-4093-bda6-4b57cc5a9848" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">issue</code></div>
-
-            <div>
-                <code class="type">array</code>
-
-            </div>
-
-
-
-
-
-
-
-        </td>
-
-        <td class="button_column">
-                    <button class="collapser js" data-schema-uuid="2dd81e85-039e-4093-bda6-4b57cc5a9848" onclick="collapseChildren('2dd81e85-039e-4093-bda6-4b57cc5a9848')"></button>
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">List of issues that have occurred.</div>
-
-
-
-
-
-
-
-
-
-
-
-            <div>Min items: <code class="codeinline minitems">1</code></div>
-
-
-
-
-
-
-
-        </td>
-    </tr>
-
-
-
-            <tr class="expanded" data-schema-uuid="80da859f-9764-4202-95c0-8140a168c427" data-indentation="2" colspan="2">
-                <td style="padding-left: 2em;" class="name_column">
-
-                    <div>
-                        <code class="type">object</code>
-
-                    </div>
-
-
-
-
-
-
-
-                </td>
-
-                <td class="button_column">
-                </td>
-
-                <td class="description_column">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                </td>
-            </tr>
-
-
-
-
-
-
-
-
-
-
-
-                                                                    </table>
-                                                                </div>
-
-
-                                        </article>
-                                    </div>
-                                    <div id="api-Patients-search-patient" class="article-section-with-sub-heading">
-                                        <article id="api-Patients-search-patient-0">
-                                            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-                                            <h3>Search for patient</h3>
-                                            <div class="endpoint_path">
-                                                <div class="method">get</div>
-                                                <div class="pre"><pre>/Patient</pre></div>
-
-                                                        <div class="try"><a onclick="tryEndpointNow('/Patients/search-patient')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
-                                            </div>
-
-                                            <p><h4 id="endpoint">Endpoint</h4>
-<p>Use this endpoint to search for a patient in PDS.</p>
-
-                                                <h4>Request</h4>
-
-
-                                                <div class="httpparams">
-                                                    <h5>Query parameters</h5>
-                                                    <table data-disablesort="true">
-                                                        <tr>
-                                                            <th>Name</th>
-                                                            <th>Description</th>
-                                                        </tr>
-                                                            <tr><td class="httpparams__name">_exact-match</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">Boolean</span>
-
-
-                                                                                <div>Default value: <code class="codeinline">false</code></div>
-
-                                                                                <div>The search only returns results where the <code class="codeinline">score</code> field is 1.0.</div>
-
-
-
-                                                                                <div>Example: <code class="codeinline">true</code></div>
-
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                            <tr><td class="httpparams__name">_history</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">Boolean</span>
-
-
-                                                                                <div>Default value: <code class="codeinline">false</code></div>
-
-                                                                                <div>The search looks for matches in historic information such as previous names and addresses.</div>
-
-
-
-                                                                                <div>Example: <code class="codeinline">true</code></div>
-
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                    </table>
-                                                </div>
-
-                                                <div class="httpparams">
-                                                    <h5>Headers</h5>
-                                                    <table data-disablesort="true">
-                                                        <tr>
-                                                            <th>Name</th>
-                                                            <th>Description</th>
-                                                        </tr>
-                                                            <tr><td class="httpparams__name">NHSD-Session-URID</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>), specifies the role the user is acting in.</div>
-
-                                                                                <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
-
-
-                                                                                <div>Example: <code class="codeinline">555021935107</code></div>
-
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                            <tr><td class="httpparams__name">Authorization</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">String</span>
-
-                                                                                <code class="codeinline">(^Bearer\ [[:ascii:]]+$)</code>
-
-
-                                                                                <div>An OAuthV2 access token presented in Bearer format.</p>
-<p>Note: This parameter is required unless interacting with the Sandbox.</div>
-
-
-
-                                                                                <div>Example: <code class="codeinline">Bearer g1112R_ccQ1Ebbb4gtHBP1aaaNM</code></div>
-
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                    </table>
-                                                </div>
-
-
-
-                                                    <h4>Response</h4>
-
-                                                <h5>HTTP status: 200</h5>
-                                                <div>A completed search, containing zero, one, or many matching patients.</div>
-
-
-                                                        <h6>Body</h6>
-
-
-                                                            <div class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/fhir+json</span>
-                                                            </div>
-
-                                                                <div class="body__example__header">Example</div>
-                                                                <div><pre><code>{
-  "resourceType" : "Bundle",
-  "type" : "searchset",
-  "timestamp" : "2019-12-25T12:00:00+00:00",
-  "total" : 1,
-  "entry" : [ {
-    "fullUrl" : "https://beta.api.digital.nhs.uk/personal-demographics/Patient/9000000009",
-    "search" : {
-      "score" : 1
-    }
-  } ]
-}</code></pre></div>
-
-
-
-
-                                                                <div class="body__schema__header">Schema
-                                                                    <span class="schema__header__buttons">
-                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('0f300798-fa95-4cc9-871c-996908042029')">Collapse all</button>
-                                                                        <button class='schemaButton js expandAll' onclick="expandAll('0f300798-fa95-4cc9-871c-996908042029')">Expand all</button>
-                                                                    </span>
-                                                                </div>
-                                                                <div class="body__schema" data-schema-uuid="0f300798-fa95-4cc9-871c-996908042029">
-                                                                    <table data-disablesort="true">
-                                                                        <thead>
-                                                                        <th colspan="2">Name</th>
-                                                                        <th>Description</th>
-                                                                        </thead>
-
-
-<tr class="expanded" data-schema-uuid="79eabd5d-9800-4aa6-8201-9ff591d7efdf" data-indentation="0" colspan="2">
-    <td style="padding-left: 0em;" class="name_column">
-
-        <div>
-            <code class="type">object</code>
-
-        </div>
-
-
-
-
-
-
-
-    </td>
-
-    <td class="button_column">
-            <button class="collapser js" data-schema-uuid="79eabd5d-9800-4aa6-8201-9ff591d7efdf" onclick="collapseChildren('79eabd5d-9800-4aa6-8201-9ff591d7efdf')"></button>
-    </td>
-
-    <td class="description_column">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    </td>
-</tr>
-
-
-    <tr class="expanded" data-schema-uuid="c62709c2-3a91-4d84-ae27-52873c12ea8c" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">resourceType</code></div>
-
-            <div>
-                <code class="type">string</code>
-
-            </div>
-
-
-
-
-
-
-
-        </td>
-
-        <td class="button_column">
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">FHIR Resource Type.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                <div>Default: <code class="codeinline default">Bundle</code></div>
-
-        </td>
-    </tr>
-
-
-
-
-
-    <tr class="expanded" data-schema-uuid="d26a2e42-0790-41d2-b8d6-30b759f7cb80" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">type</code></div>
-
-            <div>
-                <code class="type">string</code>
-
-            </div>
-
-
-
-
-
-
-
-        </td>
-
-        <td class="button_column">
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">FHIR Bundle Type.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                <div>Default: <code class="codeinline default">searchset</code></div>
-
-        </td>
-    </tr>
-
-
-
-
-
-
-
-
-
-                                                                    </table>
-                                                                </div>
-
-
-
-                                                <h5>HTTP status: 400</h5>
-                                                <div>Invalid search paramaters supplied.</div>
-
-
-                                                        <h6>Body</h6>
-
-
-                                                            <div class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/fhir+json</span>
-                                                            </div>
-
-
-
-                                                                        <div class="body__example__header">Examples</div>
-
-                                                                <div class="body__example__summary">too few search params</div>
-
-
-                                                                <div><pre><code>{
-  "resourceType" : "OperationOutcome",
-  "issue" : [ {
-    "severity" : "error",
-    "code" : "value"
-  } ]
-}</code></pre></div>
-
-                                                                <div class="body__example__summary">Invalid combination of search parameters</div>
-
-
-                                                                <div><pre><code>{
-  "resourceType" : "OperationOutcome",
-  "issue" : [ {
-    "severity" : "error",
-    "code" : "value"
-  } ]
-}</code></pre></div>
-
-
-                                                                <div class="body__schema__header">Schema
-                                                                    <span class="schema__header__buttons">
-                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('e1c55b08-17f8-4ff3-9c33-1a4d77b69863')">Collapse all</button>
-                                                                        <button class='schemaButton js expandAll' onclick="expandAll('e1c55b08-17f8-4ff3-9c33-1a4d77b69863')">Expand all</button>
-                                                                    </span>
-                                                                </div>
-                                                                <div class="body__schema" data-schema-uuid="e1c55b08-17f8-4ff3-9c33-1a4d77b69863">
-                                                                    <table data-disablesort="true">
-                                                                        <thead>
-                                                                        <th colspan="2">Name</th>
-                                                                        <th>Description</th>
-                                                                        </thead>
-
-
-<tr class="expanded" data-schema-uuid="5d847097-e8af-4ff5-8ff1-f18ebd060b56" data-indentation="0" colspan="2">
-    <td style="padding-left: 0em;" class="name_column">
-
-        <div>
-            <code class="type">object</code>
-            <code class="format">int(32)</code>
-        </div>
-
-        <div><code class="deprecated">deprecated</code></div>
-        <div><code class="uniqueitems">unique items</code></div>
-        <div><code class="nullable">nullable</code></div>
-        <div><code class="readonly">read-only</code></div>
-        <div><code class="writeonly">write-only</code></div>
-
-    </td>
-
-    <td class="button_column">
-    </td>
-
-    <td class="description_column">
-        <div class="title">Response Schema with all simple fields.</div>
-
-        <div class="description">Response Test Schema Object description in <code class="codeinline">Markdown</code>.</div>
-
-        <div>Pattern: <code class="codeinline pattern">^(?:[0-9]{4}-[0-9]{2}-[0-9]{2})?(?:[ T][0-9]{2}:[0-9]{2}:[0-9]{2})?(?:[.,][0-9]{3})?</code></div>
-
-        <div>Multiple of: <code class="codeinline multipleof">1.2</code><div>
-
-        <div>Maximum: <code class="codeinline maximum">2.2</code>
-            <code class="codeinline exclusivemaximum">(exclusive)</code>
-        </div>
-
-        <div>Minimum: <code class="codeinline minimum">-2.3</code>
-            <code class="codeinline exclusiveminimum">(exclusive)</code>
-        </div>
-
-        <div>Max length: <code class="codeinline maxlength">22</code></div>
-        <div>Min length: <code class="codeinline minlength">11</code></div>
-
-        <div>Max items: <code class="codeinline maxitems">44</code></div>
-        <div>Min items: <code class="codeinline minitems">33</code></div>
-
-        <div>Max properties: <code class="codeinline maxproperties">5</code></div>
-        <div>Min properties: <code class="codeinline minproperties">3</code></div>
-
-
-
-
-    </td>
-</tr>
-
-
-
-
-
-
-                                                                    </table>
-                                                                </div>
-
-
-                                        </article>
-                                    </div>
-                                    <div id="api-Patients-update-patient-partial" class="article-section-with-sub-heading">
-                                        <article id="api-Patients-update-patient-partial-0">
-                                            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-                                            <h3>Update a patient's resource</h3>
-                                            <div class="endpoint_path">
-                                                <div class="method">patch</div>
-                                                <div class="pre"><pre>/Patient/{id}</pre></div>
-
-                                                        <div class="try"><a onclick="tryEndpointNow('/Patients/update-patient-partial')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
-                                            </div>
-
-                                            <p><h4 id="overview">Overview</h4>
-<p>Use this endpoint to update patient details in PDS.</p>
-
-                                                <h4>Request</h4>
-
-                                                <div class="httpparams">
-                                                    <h5>Path parameters</h5>
-                                                    <table data-disablesort="true">
-                                                        <tr>
-                                                            <th>Name</th>
-                                                            <th>Description</th>
-                                                        </tr>
-                                                            <tr><td class="httpparams__name">id</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                <div>The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales.</div>
-
-
-
-                                                                                <div>Example: <code class="codeinline">9000000009</code></div>
-
-                                                                        </div>
-                                                                            <div class="httpparams__required">
-                                                                                Required
-                                                                            </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                    </table>
-                                                </div>
-
-
-                                                <div class="httpparams">
-                                                    <h5>Headers</h5>
-                                                    <table data-disablesort="true">
-                                                        <tr>
-                                                            <th>Name</th>
-                                                            <th>Description</th>
-                                                        </tr>
-                                                            <tr><td class="httpparams__name">NHSD-Session-URID</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>).</div>
-
-                                                                                <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
-
-
-                                                                                <div>Example: <code class="codeinline">555021935107</code></div>
-
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                            <tr><td class="httpparams__name">If-Match</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                <div>Latest known version identifier enclosed in quotes preceded by <code class="codeinline">W/</code>.</p>
-<p>Send the value of this resource's <code class="codeinline">ETag</code> response header (or <code class="codeinline">meta.versionId</code> property) as received.</div>
-
-                                                                                <div>Pattern: <code class="codeinline">/^W\/"[0-9]+"$/</code></div>
-
-
-                                                                                <div>Example: <code class="codeinline">W/"2"</code></div>
-
-                                                                        </div>
-                                                                            <div class="httpparams__required">
-                                                                                Required
-                                                                            </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                    </table>
-                                                </div>
-
-
-                                                <div class="httpparams">
-                                                    <h5>Body</h5>
-                                                        <div class="httpparams__required">Required</div>
-
-
-
-                                                                    <div class="body__contenttype">
-                                                                        <span class="body__contenttype__label">Content type: </span>
-                                                                        <span class="body__contenttype__value">application/json</span>
-                                                                    </div>
-
-
-
-                                                                                <div class="body__example__header">Examples</div>
-
-                                                                        <div class="body__example__summary">Add a new single item (deceasedDateTime) to the patient</div>
-
-
-                                                                        <div><pre><code>{
-  "patches" : [ {
-    "op" : "add",
-    "path" : "/deceasedDateTime",
-    "value" : "2010-10-22T00:00:00+00:00"
-  } ]
-}</code></pre></div>
-
-                                                                        <div class="body__example__summary">Update the simple item (gender)</div>
-
-
-                                                                        <div><pre><code>{
-  "patches" : [ {
-    "op" : "replace",
-    "path" : "/gender",
-    "value" : "male"
-  } ]
-}</code></pre></div>
-
-
-                                                                        <div class="body__schema__header">Schema
-                                                                            <span class="schema__header__buttons">
-                                                                                <button class='schemaButton js collapseAll' onclick="collapseAll('e054bcee-cb82-4544-a4f0-e46b06bd9be6')">Collapse all</button>
-                                                                                <button class='schemaButton js expandAll' onclick="expandAll('e054bcee-cb82-4544-a4f0-e46b06bd9be6')">Expand all</button>
-                                                                            </span>
-                                                                        </div>
-                                                                        <div class="body__schema" data-schema-uuid="e054bcee-cb82-4544-a4f0-e46b06bd9be6">
-                                                                            <table data-disablesort="true">
-                                                                                <thead>
-                                                                                <th colspan="2">Name</th>
-                                                                                <th>Description</th>
-                                                                                </thead>
-
-
-<tr class="expanded" data-schema-uuid="99ca5016-1726-46a8-8259-77f6f2b0a479" data-indentation="0" colspan="2">
-    <td style="padding-left: 0em;" class="name_column">
-
-        <div>
-            <code class="type">object</code>
-            <code class="format">int(32)</code>
-        </div>
-
-        <div><code class="deprecated">deprecated</code></div>
-        <div><code class="uniqueitems">unique items</code></div>
-        <div><code class="nullable">nullable</code></div>
-        <div><code class="readonly">read-only</code></div>
-        <div><code class="writeonly">write-only</code></div>
-
-    </td>
-
-    <td class="button_column">
-    </td>
-
-    <td class="description_column">
-        <div class="title">Request Schema with all simple fields.</div>
-
-        <div class="description">Request Test Schema Object description in <code class="codeinline">Markdown</code>.</div>
-
-        <div>Pattern: <code class="codeinline pattern">^(?:[0-9]{4}-[0-9]{2}-[0-9]{2})?(?:[ T][0-9]{2}:[0-9]{2}:[0-9]{2})?(?:[.,][0-9]{3})?</code></div>
-
-        <div>Multiple of: <code class="codeinline multipleof">1.2</code><div>
-
-        <div>Maximum: <code class="codeinline maximum">2.2</code>
-            <code class="codeinline exclusivemaximum">(exclusive)</code>
-        </div>
-
-        <div>Minimum: <code class="codeinline minimum">-2.3</code>
-            <code class="codeinline exclusiveminimum">(exclusive)</code>
-        </div>
-
-        <div>Max length: <code class="codeinline maxlength">22</code></div>
-        <div>Min length: <code class="codeinline minlength">11</code></div>
-
-        <div>Max items: <code class="codeinline maxitems">44</code></div>
-        <div>Min items: <code class="codeinline minitems">33</code></div>
-
-        <div>Max properties: <code class="codeinline maxproperties">5</code></div>
-        <div>Min properties: <code class="codeinline minproperties">3</code></div>
-
-
-
-
-    </td>
-</tr>
-
-
-
-
-
-
-                                                                            </table>
-                                                                        </div>
-
-
-                                                </div>
-
-                                                    <h4>Response</h4>
-
-                                                <h5>HTTP status: 202</h5>
-                                                <div>The patch was syntactically correct and was accepted.</div>
-
-                                                    <div class="httpparams">
-                                                        <h6>Headers</h6>
-                                                        <table data-disablesort="true">
-                                                            <tr>
-                                                                <th>Name</th>
-                                                                <th>Description</th>
-                                                            </tr>
-                                                                <tr><td class="httpparams__name">Content-Location</td>
-                                                                <td>
-                                                                    <div>
-                                                                        <div class="httpparams__description">
-                                                                            <div>
-                                                                                <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                    <div>Polling location of the update</div>
-
-
-
-                                                                                    <div>Example: <code class="codeinline">/Polling/20200522091633363041_461139_1524772598</code></div>
-
-                                                                            </div>
-                                                                        </div>
-                                                                    </div>
-                                                                </td>
-                                                                </tr>
-                                                                <tr><td class="httpparams__name">Retry-After</td>
-                                                                <td>
-                                                                    <div>
-                                                                        <div class="httpparams__description">
-                                                                            <div>
-                                                                                <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                    <div>Time to wait between polls in milliseconds</div>
-
-
-
-                                                                                    <div>Example: <code class="codeinline">100</code></div>
-
-                                                                            </div>
-                                                                        </div>
-                                                                    </div>
-                                                                </td>
-                                                                </tr>
-                                                        </table>
-                                                    </div>
-
-
-
-
-                                                <h5>HTTP status: 400</h5>
-                                                <div>Client error.</div>
-
-
-                                                        <h6>Body</h6>
-
-
-                                                            <div class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/fhir+json</span>
-                                                            </div>
-
-
-
-                                                                        <div class="body__example__header">Examples</div>
-
-                                                                <div class="body__example__summary">Invalid NHS number supplied</div>
-
-
-                                                                <div><pre><code>{
-  "resourceType" : "OperationOutcome",
-  "issue" : [ {
-    "severity" : "error",
-    "code" : "value",
-    "details" : {
-      "coding" : [ {
-        "system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
-        "version" : "1",
-        "code" : "INVALID_RESOURCE_ID",
-        "display" : "Resource Id is invalid"
-      } ]
-    }
-  } ]
-}</code></pre></div>
-
-                                                                <div class="body__example__summary">No patches submitted</div>
-
-
-                                                                <div><pre><code>{
-  "resourceType" : "OperationOutcome",
-  "issue" : [ {
-    "severity" : "error",
-    "code" : "required",
-    "details" : {
-      "coding" : [ {
-        "system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
-        "version" : "1",
-        "code" : "MISSING_VALUE",
-        "display" : "Missing value - patches"
-      } ]
-    }
-  } ]
-}</code></pre></div>
-
-
-                                                                <div class="body__schema__header">Schema
-                                                                    <span class="schema__header__buttons">
-                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('f31f9536-abac-4a8c-b8b0-ded9c3e12f48')">Collapse all</button>
-                                                                        <button class='schemaButton js expandAll' onclick="expandAll('f31f9536-abac-4a8c-b8b0-ded9c3e12f48')">Expand all</button>
-                                                                    </span>
-                                                                </div>
-                                                                <div class="body__schema" data-schema-uuid="f31f9536-abac-4a8c-b8b0-ded9c3e12f48">
-                                                                    <table data-disablesort="true">
-                                                                        <thead>
-                                                                        <th colspan="2">Name</th>
-                                                                        <th>Description</th>
-                                                                        </thead>
-
-
-<tr class="expanded" data-schema-uuid="fdfb6b48-06f0-4db7-8102-6c79dd31ab2f" data-indentation="0" colspan="2">
-    <td style="padding-left: 0em;" class="name_column">
-
-        <div>
-            <code class="type">object</code>
-
-        </div>
-
-
-
-
-
-
-
-    </td>
-
-    <td class="button_column">
-            <button class="collapser js" data-schema-uuid="fdfb6b48-06f0-4db7-8102-6c79dd31ab2f" onclick="collapseChildren('fdfb6b48-06f0-4db7-8102-6c79dd31ab2f')"></button>
-    </td>
-
-    <td class="description_column">
-
-
-        <div class="description">Outcome of an operation that does not result in a resource or bundle being returned (e.g. error, async/batch submission).</p>
-<p>Search outcomes:</p>
-<table data-disablesort="true">
-<thead>
-<tr>
-<th>Code</th>
-<th>Response Code</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>INVALID_SEARCH_DATA</td>
-<td>400</td>
-<td>The search parameters are invalid. A description of what exactly is at fault will be added to the display.</td>
-</tr>
-<tr>
-<td>TOO_MANY_MATCHES</td>
-<td>200</td>
-<td>Too many matches were found - user should be told to refine their search parameters.</td>
-</tr>
-</tbody>
-</table></div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    </td>
-</tr>
-
-
-    <tr class="expanded" data-schema-uuid="8b41dfb7-b585-4998-b021-526604811801" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">resourceType</code></div>
-
-            <div>
-                <code class="type">string</code>
-
-            </div>
-
-
-
-
-            <div><code class="readonly">read-only</code></div>
-
-
-        </td>
-
-        <td class="button_column">
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">FHIR Resource Type.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                <div>Default: <code class="codeinline default">OperationOutcome</code></div>
-
-        </td>
-    </tr>
-
-
-
-
-
-    <tr class="expanded" data-schema-uuid="7fa70c88-5989-4de7-b040-2bd9872d9f54" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">issue</code></div>
-
-            <div>
-                <code class="type">array</code>
-
-            </div>
-
-
-
-
-
-
-
-        </td>
-
-        <td class="button_column">
-                    <button class="collapser js" data-schema-uuid="7fa70c88-5989-4de7-b040-2bd9872d9f54" onclick="collapseChildren('7fa70c88-5989-4de7-b040-2bd9872d9f54')"></button>
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">List of issues that have occurred.</div>
-
-
-
-
-
-
-
-
-
-
-
-            <div>Min items: <code class="codeinline minitems">1</code></div>
-
-
-
-
-
-
-
-        </td>
-    </tr>
-
-
-
-            <tr class="expanded" data-schema-uuid="ca588ce3-c8d6-436c-a59d-49fc78776ca0" data-indentation="2" colspan="2">
-                <td style="padding-left: 2em;" class="name_column">
-
-                    <div>
-                        <code class="type">object</code>
-
-                    </div>
-
-
-
-
-
-
-
-                </td>
-
-                <td class="button_column">
-                        <button class="collapser js" data-schema-uuid="ca588ce3-c8d6-436c-a59d-49fc78776ca0" onclick="collapseChildren('ca588ce3-c8d6-436c-a59d-49fc78776ca0')"></button>
-                </td>
-
-                <td class="description_column">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                </td>
-            </tr>
-
-
-                <tr class="expanded" data-schema-uuid="0106017a-f5dd-4aaa-8c68-1a133a86a841" data-indentation="3" colspan="2">
-                    <td style="padding-left: 3em;" class="name_column">
-                    <div><code class="propertyName">severity</code></div>
-
-                        <div>
-                            <code class="type">string</code>
-
-                        </div>
-
-
-
-
-
-
-                        <div><code class="required">required</code></div>
-                    </td>
-
-                    <td class="button_column">
-                    </td>
-
-                    <td class="description_column">
-
-
-                        <div class="description">Severity of the error.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                        <div>Allowed values: <code class="codeinline">fatal</code>, <code class="codeinline">error</code>, <code class="codeinline">warning</code>, <code class="codeinline">information</code></div>
-
-
-                            <div>Example: <code class="codeinline example">error</code></div>
-                    </td>
-                </tr>
-
-
-
-
-
-                <tr class="expanded" data-schema-uuid="4a4db968-4fff-4d69-aff3-45c45e4834ce" data-indentation="3" colspan="2">
-                    <td style="padding-left: 3em;" class="name_column">
-                    <div><code class="propertyName">code</code></div>
-
-                        <div>
-                            <code class="type">string</code>
-
-                        </div>
-
-
-
-
-
-
-                        <div><code class="required">required</code></div>
-                    </td>
-
-                    <td class="button_column">
-                    </td>
-
-                    <td class="description_column">
-
-
-                        <div class="description">FHIR error code.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                        <div>Allowed values: <code class="codeinline">incomplete</code>, <code class="codeinline">throttled</code>, <code class="codeinline">informational</code></div>
-
-
-                            <div>Example: <code class="codeinline example">invalid</code></div>
-                    </td>
-                </tr>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                                                                    </table>
-                                                                </div>
-
-
-                                        </article>
-                                    </div>
-
-                    <div id="api-Polling" class="article-section">
-                        <h2>Endpoints: Polling</h2>
-                    </div>
-                                    <div id="api-Polling-polling" class="article-section-with-sub-heading">
-                                        <article id="api-Polling-polling-0">
-                                            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-                                            <h3>Retrieve the outcome of the accepted update.</h3>
-                                            <div class="endpoint_path">
-                                                <div class="method">get</div>
-                                                <div class="pre"><pre>/Polling/{message_id}</pre></div>
-
-                                                        <div class="try"><a onclick="tryEndpointNow('/Polling/polling')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
-                                            </div>
-
-                                            <p><h4 id="overview">Overview</h4>
-<p>Use this endpoint to poll for the outcome of an updated patient record.</p>
-
-                                                <h4>Request</h4>
-
-                                                <div class="httpparams">
-                                                    <h5>Path parameters</h5>
-                                                    <table data-disablesort="true">
-                                                        <tr>
-                                                            <th>Name</th>
-                                                            <th>Description</th>
-                                                        </tr>
-                                                            <tr><td class="httpparams__name">message_id</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                <div>The message ID of the accepted update that needs to be submitted to confirm the resource a successfully updated.</div>
-
-
-
-                                                                                <div>Example: <code class="codeinline">20200522091633363041000001</code></div>
-
-                                                                        </div>
-                                                                            <div class="httpparams__required">
-                                                                                Required
-                                                                            </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                    </table>
-                                                </div>
-
-
-                                                <div class="httpparams">
-                                                    <h5>Headers</h5>
-                                                    <table data-disablesort="true">
-                                                        <tr>
-                                                            <th>Name</th>
-                                                            <th>Description</th>
-                                                        </tr>
-                                                            <tr><td class="httpparams__name">NHSD-Session-URID</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>).</div>
-
-                                                                                <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
-
-
-                                                                                <div>Example: <code class="codeinline">555021935107</code></div>
-
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                    </table>
-                                                </div>
-
-
-
-                                                    <h4>Response</h4>
-
-                                                <h5>HTTP status: 200</h5>
-                                                <div>Patient updated.</div>
-
-                                                    <div class="httpparams">
-                                                        <h6>Headers</h6>
-                                                        <table data-disablesort="true">
-                                                            <tr>
-                                                                <th>Name</th>
-                                                                <th>Description</th>
-                                                            </tr>
-                                                                <tr><td class="httpparams__name">ETag</td>
-                                                                <td>
-                                                                    <div>
-                                                                        <div class="httpparams__description">
-                                                                            <div>
-                                                                                <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                    <div>Record version identifier enclosed in quotes and preceded by 'W/'. For example, <code class="codeinline">W/&quot;2&quot;</code>.</p>
-<p>Corresponds to <code class="codeinline">meta.versionId</code> attribute in the patient resource body.</div>
-
-                                                                                    <div>Pattern: <code class="codeinline">/^W\/"[0-9]+"$/</code></div>
-
-
-                                                                                    <div>Example: <code class="codeinline">W/"2"</code></div>
-
-                                                                            </div>
-                                                                        </div>
-                                                                    </div>
-                                                                </td>
-                                                                </tr>
-                                                        </table>
-                                                    </div>
-
-                                                        <h6>Body</h6>
-
-
-                                                            <div class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/fhir+json</span>
-                                                            </div>
-
-
-
-
-
-                                                                <div class="body__schema__header">Schema
-                                                                    <span class="schema__header__buttons">
-                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('6282c580-f255-4590-a54e-3fddcaea0593')">Collapse all</button>
-                                                                        <button class='schemaButton js expandAll' onclick="expandAll('6282c580-f255-4590-a54e-3fddcaea0593')">Expand all</button>
-                                                                    </span>
-                                                                </div>
-                                                                <div class="body__schema" data-schema-uuid="6282c580-f255-4590-a54e-3fddcaea0593">
-                                                                    <table data-disablesort="true">
-                                                                        <thead>
-                                                                        <th colspan="2">Name</th>
-                                                                        <th>Description</th>
-                                                                        </thead>
-
-
-<tr class="expanded" data-schema-uuid="59e5c20b-b091-4340-a9c8-66727873c509" data-indentation="0" colspan="2">
-    <td style="padding-left: 0em;" class="name_column">
-
-        <div>
-            <code class="type">object</code>
-
-        </div>
-
-
-
-
-
-
-
-    </td>
-
-    <td class="button_column">
-            <button class="collapser js" data-schema-uuid="59e5c20b-b091-4340-a9c8-66727873c509" onclick="collapseChildren('59e5c20b-b091-4340-a9c8-66727873c509')"></button>
-    </td>
-
-    <td class="description_column">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    </td>
-</tr>
-
-
-    <tr class="expanded" data-schema-uuid="6cf643ea-8b4d-4aca-a120-91b34ce40055" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">resourceType</code></div>
-
-            <div>
-                <code class="type">string</code>
-
-            </div>
-
-
-
-
-            <div><code class="readonly">read-only</code></div>
-
-
-        </td>
-
-        <td class="button_column">
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">FHIR resource type.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                <div>Default: <code class="codeinline default">Patient</code></div>
-
-        </td>
-    </tr>
-
-
-
-
-
-    <tr class="expanded" data-schema-uuid="d334ec92-1ed5-4972-afd6-ebee894b88ff" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">id</code></div>
-
-            <div>
-                <code class="type">string</code>
-
-            </div>
-
-
-
-
-
-
-            <div><code class="required">required</code></div>
-        </td>
-
-        <td class="button_column">
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales. Always 10 digits and must be a <a href="https://www.datadictionary.nhs.uk/data_dictionary/attributes/n/nhs/nhs_number_de.asp">valid NHS Number</a>.</div>
-
-            <div>Pattern: <code class="codeinline pattern">^\d{10}$</code></div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                <div>Example: <code class="codeinline example">9000000009</code></div>
-        </td>
-    </tr>
-
-
-
-
-
-
-
-
-
-                                                                    </table>
-                                                                </div>
-
-
-
-                                                <h5>HTTP status: 400</h5>
-                                                <div>Client error after the patch was accepted and patient was not updated.</div>
-
-
-                                                        <h6>Body</h6>
-
-
-                                                            <div class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/fhir+json</span>
-                                                            </div>
-
-
-
-                                                                        <div class="body__example__header">Example</div>
-
-                                                                <div class="body__example__summary">Business rule failure; start date was after the end date.</div>
-
-
-                                                                <div><pre><code>{
-  "resourceType" : "OperationOutcome",
-  "issue" : [ {
-    "severity" : "error",
-    "code" : "structure",
-    "details" : {
-      "coding" : [ {
-        "system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
-        "version" : "1",
-        "code" : "INVALID_UPDATE",
-        "display" : "Invalid update with error - business effective start date is after the end date"
-      } ]
-    }
-  } ]
-}</code></pre></div>
-
-
-                                                                <div class="body__schema__header">Schema
-                                                                    <span class="schema__header__buttons">
-                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('53ee0b10-4b9f-4a68-b010-6099408f357a')">Collapse all</button>
-                                                                        <button class='schemaButton js expandAll' onclick="expandAll('53ee0b10-4b9f-4a68-b010-6099408f357a')">Expand all</button>
-                                                                    </span>
-                                                                </div>
-                                                                <div class="body__schema" data-schema-uuid="53ee0b10-4b9f-4a68-b010-6099408f357a">
-                                                                    <table data-disablesort="true">
-                                                                        <thead>
-                                                                        <th colspan="2">Name</th>
-                                                                        <th>Description</th>
-                                                                        </thead>
-
-
-<tr class="expanded" data-schema-uuid="69a8b19b-75a0-4089-b85b-a8ed87a1e8c7" data-indentation="0" colspan="2">
-    <td style="padding-left: 0em;" class="name_column">
-
-        <div>
-            <code class="type">object</code>
-
-        </div>
-
-
-
-
-
-
-
-    </td>
-
-    <td class="button_column">
-            <button class="collapser js" data-schema-uuid="69a8b19b-75a0-4089-b85b-a8ed87a1e8c7" onclick="collapseChildren('69a8b19b-75a0-4089-b85b-a8ed87a1e8c7')"></button>
-    </td>
-
-    <td class="description_column">
-
-
-        <div class="description">Outcome of an operation that does not result in a resource or bundle being returned (e.g. error, async/batch submission).</p>
-<p>Search outcomes:</p>
-<table data-disablesort="true">
-<thead>
-<tr>
-<th>Code</th>
-<th>Response Code</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>INVALID_SEARCH_DATA</td>
-<td>400</td>
-<td>The search parameters are invalid. A description of what exactly is at fault will be added to the display.</td>
-</tr>
-<tr>
-<td>TOO_MANY_MATCHES</td>
-<td>200</td>
-<td>Too many matches were found - user should be told to refine their search parameters.</td>
-</tr>
-</tbody>
-</table></div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    </td>
-</tr>
-
-
-    <tr class="expanded" data-schema-uuid="4cf84597-4fa6-4d29-a82d-634d95f3aa24" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">resourceType</code></div>
-
-            <div>
-                <code class="type">string</code>
-
-            </div>
-
-
-
-
-            <div><code class="readonly">read-only</code></div>
-
-
-        </td>
-
-        <td class="button_column">
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">FHIR Resource Type.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                <div>Default: <code class="codeinline default">OperationOutcome</code></div>
-
-        </td>
-    </tr>
-
-
-
-
-
-    <tr class="expanded" data-schema-uuid="3696ab57-f5eb-4832-9795-f931cedd0c26" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">issue</code></div>
-
-            <div>
-                <code class="type">array</code>
-
-            </div>
-
-
-
-
-
-
-
-        </td>
-
-        <td class="button_column">
-                    <button class="collapser js" data-schema-uuid="3696ab57-f5eb-4832-9795-f931cedd0c26" onclick="collapseChildren('3696ab57-f5eb-4832-9795-f931cedd0c26')"></button>
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">List of issues that have occurred.</div>
-
-
-
-
-
-
-
-
-
-
-
-            <div>Min items: <code class="codeinline minitems">1</code></div>
-
-
-
-
-
-
-
-        </td>
-    </tr>
-
-
-
-            <tr class="expanded" data-schema-uuid="0810ddb6-572f-4c11-a39f-8640c2824045" data-indentation="2" colspan="2">
-                <td style="padding-left: 2em;" class="name_column">
-
-                    <div>
-                        <code class="type">object</code>
-
-                    </div>
-
-
-
-
-
-
-
-                </td>
-
-                <td class="button_column">
-                        <button class="collapser js" data-schema-uuid="0810ddb6-572f-4c11-a39f-8640c2824045" onclick="collapseChildren('0810ddb6-572f-4c11-a39f-8640c2824045')"></button>
-                </td>
-
-                <td class="description_column">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                </td>
-            </tr>
-
-
-                <tr class="expanded" data-schema-uuid="13eae277-a586-4507-9414-c3d8e6c41603" data-indentation="3" colspan="2">
-                    <td style="padding-left: 3em;" class="name_column">
-                    <div><code class="propertyName">severity</code></div>
-
-                        <div>
-                            <code class="type">string</code>
-
-                        </div>
-
-
-
-
-
-
-                        <div><code class="required">required</code></div>
-                    </td>
-
-                    <td class="button_column">
-                    </td>
-
-                    <td class="description_column">
-
-
-                        <div class="description">Severity of the error.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                        <div>Allowed values: <code class="codeinline">fatal</code>, <code class="codeinline">error</code>, <code class="codeinline">warning</code>, <code class="codeinline">information</code></div>
-
-
-                            <div>Example: <code class="codeinline example">error</code></div>
-                    </td>
-                </tr>
-
-
-
-
-
-                <tr class="expanded" data-schema-uuid="862beb1d-8147-4cbd-a929-01f8d98875f5" data-indentation="3" colspan="2">
-                    <td style="padding-left: 3em;" class="name_column">
-                    <div><code class="propertyName">code</code></div>
-
-                        <div>
-                            <code class="type">string</code>
-
-                        </div>
-
-
-
-
-
-
-                        <div><code class="required">required</code></div>
-                    </td>
-
-                    <td class="button_column">
-                    </td>
-
-                    <td class="description_column">
-
-
-                        <div class="description">FHIR error code.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                        <div>Allowed values: <code class="codeinline">invalid</code>, <code class="codeinline">structure</code>, <code class="codeinline">required</code>, <code class="codeinline">value</code></div>
-
-
-                            <div>Example: <code class="codeinline example">invalid</code></div>
-                    </td>
-                </tr>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                                                                    </table>
-                                                                </div>
-
-
-                                        </article>
-                                    </div>
-
+    <div id="api-Patients" class="article-section">
+        <h2>Endpoints: Patients</h2>
     </div>
+    <div id="api-Patients-get-patient" class="article-section-with-sub-heading">
+        <article id="api-Patients-get-patient-0">
+            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+            <h3>Retrieve a patient's resource</h3>
+            <div class="endpoint_path">
+                <div class="method">get</div>
+                <div class="pre"><pre>/Patient/{id}</pre></div>
+                <div class="try"><a onclick="tryEndpointNow('/Patients/get-patient')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
+            </div>
+            <p><h4 id="overview">Overview</h4>
+            <p>Use this endpoint to get patient details from PDS for a given NHS Number.</p>
+            <h4>Request</h4>
+            <div class="httpparams">
+                <h5>Path parameters</h5>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">id</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales.</div>
+                                        <div>Example: <code class="codeinline">9000000009</code></div>
+                                    </div>
+                                    <div class="httpparams__required">
+                                        Required
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <div class="httpparams">
+                <h5>Headers</h5>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">NHSD-Session-URID</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>).</div>
+                                        <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
+                                        <div>Example: <code class="codeinline">555021935107</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <h4>Response</h4>
+            <h5>HTTP status: 200</h5>
+            <div>Information successfully returned.</div>
+            <div class="httpparams">
+                <h6>Headers</h6>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">ETag</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>Record version identifier enclosed in quotes and preceded by 'W/'. For example, <code class="codeinline">W/&quot;2&quot;</code>.</div>
+                                        <div>Pattern: <code class="codeinline">/^W\/"[0-9]+"$/</code></div>
+                                        <div>Example: <code class="codeinline">W/"2"</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <h6>Body</h6>
+            <div class="body__contenttype">
+                <span class="body__contenttype__label">Content type: </span>
+                <span class="body__contenttype__value">application/fhir+json</span>
+            </div>
+            <div class="body__example__header">Example</div>
+            <div><pre><code>{
+"address" : [ {
+"id" : "456",
+"line" : [ "1 Trevelyan Square", "Boar Lane", "City Centre", "Leeds", "West Yorkshire" ],
+"postalCode" : "LS1 6AE",
+"use" : "home"
+} ],
+"birthDate" : "2010-10-22"
+}</code></pre></div>
+            <div class="body__schema__header">Schema
+                <span class="schema__header__buttons">
+<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+</span>
+            </div>
+            <div class="body__schema" data-schema-uuid="">
+                <table data-disablesort="true">
+                    <thead>
+                    <th>Name</th>
+                    <th>Description</th>
+                    </thead>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+                        <td style="padding-left: 0.0em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+                            <div>
+                                <code class="type">object</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">resourceType</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="readonly">read-only</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">FHIR resource type.</div>
+                            <div>Default: <code class="codeinline default">Patient</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">id</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="required">required</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales. Always 10 digits and must be a <a href="https://www.datadictionary.nhs.uk/data_dictionary/attributes/n/nhs/nhs_number_de.asp">valid NHS Number</a>.</div>
+                            <div>Pattern: <code class="codeinline pattern">^\d{10}$</code></div>
+                            <div>Example: <code class="codeinline example">9000000009</code></div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <h5>HTTP status: 400</h5>
+            <div>Invalid NHS number supplied.</div>
+            <h6>Body</h6>
+            <div class="body__contenttype">
+                <span class="body__contenttype__label">Content type: </span>
+                <span class="body__contenttype__value">application/fhir+json</span>
+            </div>
+            <div class="body__example__header">Example</div>
+            <div><pre><code>{
+"resourceType" : "OperationOutcome",
+"issue" : [ {
+"severity" : "error",
+"code" : "value",
+"details" : {
+"coding" : [ {
+"system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
+"version" : "1",
+"code" : "INVALID_RESOURCE_ID",
+"display" : "Resource Id is invalid"
+} ]
+}
+} ]
+}</code></pre></div>
+            <div class="body__schema__header">Schema
+                <span class="schema__header__buttons">
+<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+</span>
+            </div>
+            <div class="body__schema" data-schema-uuid="">
+                <table data-disablesort="true">
+                    <thead>
+                    <th>Name</th>
+                    <th>Description</th>
+                    </thead>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+                        <td style="padding-left: 0.0em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+                            <div>
+                                <code class="type">object</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">Outcome of an operation that does not result in a resource or bundle being returned (e.g. error, async/batch submission).</p>
+                                <p>Search outcomes:</p>
+                                <table data-disablesort="true">
+                                    <thead>
+                                    <tr>
+                                        <th>Code</th>
+                                        <th>Response Code</th>
+                                        <th>Description</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td>INVALID_SEARCH_DATA</td>
+                                        <td>400</td>
+                                        <td>The search parameters are invalid. A description of what exactly is at fault will be added to the display.</td>
+                                    </tr>
+                                    <tr>
+                                        <td>TOO_MANY_MATCHES</td>
+                                        <td>200</td>
+                                        <td>Too many matches were found - user should be told to refine their search parameters.</td>
+                                    </tr>
+                                    </tbody>
+                                </table></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">resourceType</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="readonly">read-only</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">FHIR Resource Type.</div>
+                            <div>Default: <code class="codeinline default">OperationOutcome</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">issue</code></div>
+                            <div>
+                                <code class="type">array</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">List of issues that have occurred.</div>
+                            <div>Min items: <code class="codeinline minitems">1</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="2" colspan="2">
+                        <td style="padding-left: 3.0em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span>
+                            <div>
+                                <code class="type">object</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </article>
+    </div>
+    <div id="api-Patients-search-patient" class="article-section-with-sub-heading">
+        <article id="api-Patients-search-patient-0">
+            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+            <h3>Search for patient</h3>
+            <div class="endpoint_path">
+                <div class="method">get</div>
+                <div class="pre"><pre>/Patient</pre></div>
+                <div class="try"><a onclick="tryEndpointNow('/Patients/search-patient')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
+            </div>
+            <p><h4 id="endpoint">Endpoint</h4>
+            <p>Use this endpoint to search for a patient in PDS.</p>
+            <h4>Request</h4>
+            <div class="httpparams">
+                <h5>Query parameters</h5>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">_exact-match</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">Boolean</span>
+                                        <div>Default value: <code class="codeinline">false</code></div>
+                                        <div>The search only returns results where the <code class="codeinline">score</code> field is 1.0.</div>
+                                        <div>Example: <code class="codeinline">true</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr><td class="httpparams__name">_history</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">Boolean</span>
+                                        <div>Default value: <code class="codeinline">false</code></div>
+                                        <div>The search looks for matches in historic information such as previous names and addresses.</div>
+                                        <div>Example: <code class="codeinline">true</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <div class="httpparams">
+                <h5>Headers</h5>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">NHSD-Session-URID</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>), specifies the role the user is acting in.</div>
+                                        <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
+                                        <div>Example: <code class="codeinline">555021935107</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr><td class="httpparams__name">Authorization</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <code class="codeinline">(^Bearer\ [[:ascii:]]+$)</code>
+                                        <div>An OAuthV2 access token presented in Bearer format.</p>
+                                            <p>Note: This parameter is required unless interacting with the Sandbox.</div>
+                                        <div>Example: <code class="codeinline">Bearer g1112R_ccQ1Ebbb4gtHBP1aaaNM</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <h4>Response</h4>
+            <h5>HTTP status: 200</h5>
+            <div>A completed search, containing zero, one, or many matching patients.</div>
+            <h6>Body</h6>
+            <div class="body__contenttype">
+                <span class="body__contenttype__label">Content type: </span>
+                <span class="body__contenttype__value">application/fhir+json</span>
+            </div>
+            <div class="body__example__header">Example</div>
+            <div><pre><code>{
+"resourceType" : "Bundle",
+"type" : "searchset",
+"timestamp" : "2019-12-25T12:00:00+00:00",
+"total" : 1,
+"entry" : [ {
+"fullUrl" : "https://beta.api.digital.nhs.uk/personal-demographics/Patient/9000000009",
+"search" : {
+"score" : 1
+}
+} ]
+}</code></pre></div>
+            <div class="body__schema__header">Schema
+                <span class="schema__header__buttons">
+<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+</span>
+            </div>
+            <div class="body__schema" data-schema-uuid="">
+                <table data-disablesort="true">
+                    <thead>
+                    <th>Name</th>
+                    <th>Description</th>
+                    </thead>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+                        <td style="padding-left: 0.0em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+                            <div>
+                                <code class="type">object</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">resourceType</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">FHIR Resource Type.</div>
+                            <div>Default: <code class="codeinline default">Bundle</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">type</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">FHIR Bundle Type.</div>
+                            <div>Default: <code class="codeinline default">searchset</code></div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <h5>HTTP status: 400</h5>
+            <div>Invalid search paramaters supplied.</div>
+            <h6>Body</h6>
+            <div class="body__contenttype">
+                <span class="body__contenttype__label">Content type: </span>
+                <span class="body__contenttype__value">application/fhir+json</span>
+            </div>
+            <div class="body__example__header">Examples</div>
+            <div class="body__example__summary">too few search params</div>
+            <div><pre><code>{
+"resourceType" : "OperationOutcome",
+"issue" : [ {
+"severity" : "error",
+"code" : "value"
+} ]
+}</code></pre></div>
+            <div class="body__example__summary">Invalid combination of search parameters</div>
+            <div><pre><code>{
+"resourceType" : "OperationOutcome",
+"issue" : [ {
+"severity" : "error",
+"code" : "value"
+} ]
+}</code></pre></div>
+            <div class="body__schema__header">Schema
+                <span class="schema__header__buttons">
+<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+</span>
+            </div>
+            <div class="body__schema" data-schema-uuid="">
+                <table data-disablesort="true">
+                    <thead>
+                    <th>Name</th>
+                    <th>Description</th>
+                    </thead>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+                        <td style="padding-left: 0.0em;" class="name_column">
+                            <div>
+                                <code class="type">object</code>
+                                <code class="format">int(32)</code>
+                            </div>
+                            <div><code class="deprecated">deprecated</code></div>
+                            <div><code class="uniqueitems">unique items</code></div>
+                            <div><code class="nullable">nullable</code></div>
+                            <div><code class="readonly">read-only</code></div>
+                            <div><code class="writeonly">write-only</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="title">Response Schema with all simple fields.</div>
+                            <div class="description">Response Test Schema Object description in <code class="codeinline">Markdown</code>.</div>
+                            <div>Pattern: <code class="codeinline pattern">^(?:[0-9]{4}-[0-9]{2}-[0-9]{2})?(?:[ T][0-9]{2}:[0-9]{2}:[0-9]{2})?(?:[.,][0-9]{3})?</code></div>
+                            <div>Multiple of: <code class="codeinline multipleof">1.2</code><div>
+                                <div>Maximum: <code class="codeinline maximum">2.2</code>
+                                    <code class="codeinline exclusivemaximum">(exclusive)</code>
+                                </div>
+                                <div>Minimum: <code class="codeinline minimum">-2.3</code>
+                                    <code class="codeinline exclusiveminimum">(exclusive)</code>
+                                </div>
+                                <div>Max length: <code class="codeinline maxlength">22</code></div>
+                                <div>Min length: <code class="codeinline minlength">11</code></div>
+                                <div>Max items: <code class="codeinline maxitems">44</code></div>
+                                <div>Min items: <code class="codeinline minitems">33</code></div>
+                                <div>Max properties: <code class="codeinline maxproperties">5</code></div>
+                                <div>Min properties: <code class="codeinline minproperties">3</code></div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </article>
+    </div>
+    <div id="api-Patients-update-patient-partial" class="article-section-with-sub-heading">
+        <article id="api-Patients-update-patient-partial-0">
+            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+            <h3>Update a patient's resource</h3>
+            <div class="endpoint_path">
+                <div class="method">patch</div>
+                <div class="pre"><pre>/Patient/{id}</pre></div>
+                <div class="try"><a onclick="tryEndpointNow('/Patients/update-patient-partial')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
+            </div>
+            <p><h4 id="overview">Overview</h4>
+            <p>Use this endpoint to update patient details in PDS.</p>
+            <h4>Request</h4>
+            <div class="httpparams">
+                <h5>Path parameters</h5>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">id</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales.</div>
+                                        <div>Example: <code class="codeinline">9000000009</code></div>
+                                    </div>
+                                    <div class="httpparams__required">
+                                        Required
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <div class="httpparams">
+                <h5>Headers</h5>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">NHSD-Session-URID</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>).</div>
+                                        <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
+                                        <div>Example: <code class="codeinline">555021935107</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr><td class="httpparams__name">If-Match</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>Latest known version identifier enclosed in quotes preceded by <code class="codeinline">W/</code>.</p>
+                                            <p>Send the value of this resource's <code class="codeinline">ETag</code> response header (or <code class="codeinline">meta.versionId</code> property) as received.</div>
+                                        <div>Pattern: <code class="codeinline">/^W\/"[0-9]+"$/</code></div>
+                                        <div>Example: <code class="codeinline">W/"2"</code></div>
+                                    </div>
+                                    <div class="httpparams__required">
+                                        Required
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <div class="httpparams">
+                <h5>Body</h5>
+                <div class="httpparams__required">Required</div>
+                <div class="body__contenttype">
+                    <span class="body__contenttype__label">Content type: </span>
+                    <span class="body__contenttype__value">application/json</span>
+                </div>
+                <div class="body__example__header">Examples</div>
+                <div class="body__example__summary">Add a new single item (deceasedDateTime) to the patient</div>
+                <div><pre><code>{
+"patches" : [ {
+"op" : "add",
+"path" : "/deceasedDateTime",
+"value" : "2010-10-22T00:00:00+00:00"
+} ]
+}</code></pre></div>
+                <div class="body__example__summary">Update the simple item (gender)</div>
+                <div><pre><code>{
+"patches" : [ {
+"op" : "replace",
+"path" : "/gender",
+"value" : "male"
+} ]
+}</code></pre></div>
+                <div class="body__schema__header">Schema
+                    <span class="schema__header__buttons">
+<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+</span>
+                </div>
+                <div class="body__schema" data-schema-uuid="">
+                    <table data-disablesort="true">
+                        <thead>
+                        <th>Name</th>
+                        <th>Description</th>
+                        </thead>
+                        <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+                            <td style="padding-left: 0.0em;" class="name_column">
+                                <div>
+                                    <code class="type">object</code>
+                                    <code class="format">int(32)</code>
+                                </div>
+                                <div><code class="deprecated">deprecated</code></div>
+                                <div><code class="uniqueitems">unique items</code></div>
+                                <div><code class="nullable">nullable</code></div>
+                                <div><code class="readonly">read-only</code></div>
+                                <div><code class="writeonly">write-only</code></div>
+                            </td>
+                            <td class="description_column">
+                                <div class="title">Request Schema with all simple fields.</div>
+                                <div class="description">Request Test Schema Object description in <code class="codeinline">Markdown</code>.</div>
+                                <div>Pattern: <code class="codeinline pattern">^(?:[0-9]{4}-[0-9]{2}-[0-9]{2})?(?:[ T][0-9]{2}:[0-9]{2}:[0-9]{2})?(?:[.,][0-9]{3})?</code></div>
+                                <div>Multiple of: <code class="codeinline multipleof">1.2</code><div>
+                                    <div>Maximum: <code class="codeinline maximum">2.2</code>
+                                        <code class="codeinline exclusivemaximum">(exclusive)</code>
+                                    </div>
+                                    <div>Minimum: <code class="codeinline minimum">-2.3</code>
+                                        <code class="codeinline exclusiveminimum">(exclusive)</code>
+                                    </div>
+                                    <div>Max length: <code class="codeinline maxlength">22</code></div>
+                                    <div>Min length: <code class="codeinline minlength">11</code></div>
+                                    <div>Max items: <code class="codeinline maxitems">44</code></div>
+                                    <div>Min items: <code class="codeinline minitems">33</code></div>
+                                    <div>Max properties: <code class="codeinline maxproperties">5</code></div>
+                                    <div>Min properties: <code class="codeinline minproperties">3</code></div>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+            <h4>Response</h4>
+            <h5>HTTP status: 202</h5>
+            <div>The patch was syntactically correct and was accepted.</div>
+            <div class="httpparams">
+                <h6>Headers</h6>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">Content-Location</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>Polling location of the update</div>
+                                        <div>Example: <code class="codeinline">/Polling/20200522091633363041_461139_1524772598</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr><td class="httpparams__name">Retry-After</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>Time to wait between polls in milliseconds</div>
+                                        <div>Example: <code class="codeinline">100</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <h5>HTTP status: 400</h5>
+            <div>Client error.</div>
+            <h6>Body</h6>
+            <div class="body__contenttype">
+                <span class="body__contenttype__label">Content type: </span>
+                <span class="body__contenttype__value">application/fhir+json</span>
+            </div>
+            <div class="body__example__header">Examples</div>
+            <div class="body__example__summary">Invalid NHS number supplied</div>
+            <div><pre><code>{
+"resourceType" : "OperationOutcome",
+"issue" : [ {
+"severity" : "error",
+"code" : "value",
+"details" : {
+"coding" : [ {
+"system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
+"version" : "1",
+"code" : "INVALID_RESOURCE_ID",
+"display" : "Resource Id is invalid"
+} ]
+}
+} ]
+}</code></pre></div>
+            <div class="body__example__summary">No patches submitted</div>
+            <div><pre><code>{
+"resourceType" : "OperationOutcome",
+"issue" : [ {
+"severity" : "error",
+"code" : "required",
+"details" : {
+"coding" : [ {
+"system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
+"version" : "1",
+"code" : "MISSING_VALUE",
+"display" : "Missing value - patches"
+} ]
+}
+} ]
+}</code></pre></div>
+            <div class="body__schema__header">Schema
+                <span class="schema__header__buttons">
+<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+</span>
+            </div>
+            <div class="body__schema" data-schema-uuid="">
+                <table data-disablesort="true">
+                    <thead>
+                    <th>Name</th>
+                    <th>Description</th>
+                    </thead>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+                        <td style="padding-left: 0.0em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+                            <div>
+                                <code class="type">object</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">Outcome of an operation that does not result in a resource or bundle being returned (e.g. error, async/batch submission).</p>
+                                <p>Search outcomes:</p>
+                                <table data-disablesort="true">
+                                    <thead>
+                                    <tr>
+                                        <th>Code</th>
+                                        <th>Response Code</th>
+                                        <th>Description</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td>INVALID_SEARCH_DATA</td>
+                                        <td>400</td>
+                                        <td>The search parameters are invalid. A description of what exactly is at fault will be added to the display.</td>
+                                    </tr>
+                                    <tr>
+                                        <td>TOO_MANY_MATCHES</td>
+                                        <td>200</td>
+                                        <td>Too many matches were found - user should be told to refine their search parameters.</td>
+                                    </tr>
+                                    </tbody>
+                                </table></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">resourceType</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="readonly">read-only</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">FHIR Resource Type.</div>
+                            <div>Default: <code class="codeinline default">OperationOutcome</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">issue</code></div>
+                            <div>
+                                <code class="type">array</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">List of issues that have occurred.</div>
+                            <div>Min items: <code class="codeinline minitems">1</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="2" colspan="2">
+                        <td style="padding-left: 3.0em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 35.4%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span>
+                            <div>
+                                <code class="type">object</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
+                        <td style="padding-left: 4.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
+                            <div><code class="propertyName">severity</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="required">required</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">Severity of the error.</div>
+                            <div>Allowed values: <code class="codeinline">fatal</code>, <code class="codeinline">error</code>, <code class="codeinline">warning</code>, <code class="codeinline">information</code></div>
+                            <div>Example: <code class="codeinline example">error</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
+                        <td style="padding-left: 4.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
+                            <div><code class="propertyName">code</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="required">required</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">FHIR error code.</div>
+                            <div>Allowed values: <code class="codeinline">incomplete</code>, <code class="codeinline">throttled</code>, <code class="codeinline">informational</code></div>
+                            <div>Example: <code class="codeinline example">invalid</code></div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </article>
+    </div>
+    <div id="api-Polling" class="article-section">
+        <h2>Endpoints: Polling</h2>
+    </div>
+    <div id="api-Polling-polling" class="article-section-with-sub-heading">
+        <article id="api-Polling-polling-0">
+            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+            <h3>Retrieve the outcome of the accepted update.</h3>
+            <div class="endpoint_path">
+                <div class="method">get</div>
+                <div class="pre"><pre>/Polling/{message_id}</pre></div>
+                <div class="try"><a onclick="tryEndpointNow('/Polling/polling')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
+            </div>
+            <p><h4 id="overview">Overview</h4>
+            <p>Use this endpoint to poll for the outcome of an updated patient record.</p>
+            <h4>Request</h4>
+            <div class="httpparams">
+                <h5>Path parameters</h5>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">message_id</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>The message ID of the accepted update that needs to be submitted to confirm the resource a successfully updated.</div>
+                                        <div>Example: <code class="codeinline">20200522091633363041000001</code></div>
+                                    </div>
+                                    <div class="httpparams__required">
+                                        Required
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <div class="httpparams">
+                <h5>Headers</h5>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">NHSD-Session-URID</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>).</div>
+                                        <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
+                                        <div>Example: <code class="codeinline">555021935107</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <h4>Response</h4>
+            <h5>HTTP status: 200</h5>
+            <div>Patient updated.</div>
+            <div class="httpparams">
+                <h6>Headers</h6>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">ETag</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>Record version identifier enclosed in quotes and preceded by 'W/'. For example, <code class="codeinline">W/&quot;2&quot;</code>.</p>
+                                            <p>Corresponds to <code class="codeinline">meta.versionId</code> attribute in the patient resource body.</div>
+                                        <div>Pattern: <code class="codeinline">/^W\/"[0-9]+"$/</code></div>
+                                        <div>Example: <code class="codeinline">W/"2"</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <h6>Body</h6>
+            <div class="body__contenttype">
+                <span class="body__contenttype__label">Content type: </span>
+                <span class="body__contenttype__value">application/fhir+json</span>
+            </div>
+            <div class="body__schema__header">Schema
+                <span class="schema__header__buttons">
+<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+</span>
+            </div>
+            <div class="body__schema" data-schema-uuid="">
+                <table data-disablesort="true">
+                    <thead>
+                    <th>Name</th>
+                    <th>Description</th>
+                    </thead>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+                        <td style="padding-left: 0.0em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+                            <div>
+                                <code class="type">object</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">resourceType</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="readonly">read-only</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">FHIR resource type.</div>
+                            <div>Default: <code class="codeinline default">Patient</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">id</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="required">required</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales. Always 10 digits and must be a <a href="https://www.datadictionary.nhs.uk/data_dictionary/attributes/n/nhs/nhs_number_de.asp">valid NHS Number</a>.</div>
+                            <div>Pattern: <code class="codeinline pattern">^\d{10}$</code></div>
+                            <div>Example: <code class="codeinline example">9000000009</code></div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <h5>HTTP status: 400</h5>
+            <div>Client error after the patch was accepted and patient was not updated.</div>
+            <h6>Body</h6>
+            <div class="body__contenttype">
+                <span class="body__contenttype__label">Content type: </span>
+                <span class="body__contenttype__value">application/fhir+json</span>
+            </div>
+            <div class="body__example__header">Example</div>
+            <div class="body__example__summary">Business rule failure; start date was after the end date.</div>
+            <div><pre><code>{
+"resourceType" : "OperationOutcome",
+"issue" : [ {
+"severity" : "error",
+"code" : "structure",
+"details" : {
+"coding" : [ {
+"system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
+"version" : "1",
+"code" : "INVALID_UPDATE",
+"display" : "Invalid update with error - business effective start date is after the end date"
+} ]
+}
+} ]
+}</code></pre></div>
+            <div class="body__schema__header">Schema
+                <span class="schema__header__buttons">
+<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+</span>
+            </div>
+            <div class="body__schema" data-schema-uuid="">
+                <table data-disablesort="true">
+                    <thead>
+                    <th>Name</th>
+                    <th>Description</th>
+                    </thead>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+                        <td style="padding-left: 0.0em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+                            <div>
+                                <code class="type">object</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">Outcome of an operation that does not result in a resource or bundle being returned (e.g. error, async/batch submission).</p>
+                                <p>Search outcomes:</p>
+                                <table data-disablesort="true">
+                                    <thead>
+                                    <tr>
+                                        <th>Code</th>
+                                        <th>Response Code</th>
+                                        <th>Description</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td>INVALID_SEARCH_DATA</td>
+                                        <td>400</td>
+                                        <td>The search parameters are invalid. A description of what exactly is at fault will be added to the display.</td>
+                                    </tr>
+                                    <tr>
+                                        <td>TOO_MANY_MATCHES</td>
+                                        <td>200</td>
+                                        <td>Too many matches were found - user should be told to refine their search parameters.</td>
+                                    </tr>
+                                    </tbody>
+                                </table></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">resourceType</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="readonly">read-only</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">FHIR Resource Type.</div>
+                            <div>Default: <code class="codeinline default">OperationOutcome</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">issue</code></div>
+                            <div>
+                                <code class="type">array</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">List of issues that have occurred.</div>
+                            <div>Min items: <code class="codeinline minitems">1</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="2" colspan="2">
+                        <td style="padding-left: 3.0em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 35.4%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span>
+                            <div>
+                                <code class="type">object</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
+                        <td style="padding-left: 4.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
+                            <div><code class="propertyName">severity</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="required">required</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">Severity of the error.</div>
+                            <div>Allowed values: <code class="codeinline">fatal</code>, <code class="codeinline">error</code>, <code class="codeinline">warning</code>, <code class="codeinline">information</code></div>
+                            <div>Example: <code class="codeinline example">error</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
+                        <td style="padding-left: 4.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
+                            <div><code class="propertyName">code</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="required">required</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">FHIR error code.</div>
+                            <div>Allowed values: <code class="codeinline">invalid</code>, <code class="codeinline">structure</code>, <code class="codeinline">required</code>, <code class="codeinline">value</code></div>
+                            <div>Example: <code class="codeinline example">invalid</code></div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </article>
+    </div>
+</div>

--- a/cms/src/test/resources/test-data/api-specifications/SchemaHelperTest/schemaObject-empty.html
+++ b/cms/src/test/resources/test-data/api-specifications/SchemaHelperTest/schemaObject-empty.html
@@ -1,11 +1,8 @@
 <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
-    <td style="padding-left: 0em;" class="name_column">
+    <td style="padding-left: 0.0em;" class="name_column">
         <div>
             <code class="type">object</code>
         </div>
-    </td>
-    <td class="button_column">
-
     </td>
     <td class="description_column">
 

--- a/cms/src/test/resources/test-data/api-specifications/SchemaHelperTest/schemaObjectCompleteTopLevel-simpleFields.html
+++ b/cms/src/test/resources/test-data/api-specifications/SchemaHelperTest/schemaObjectCompleteTopLevel-simpleFields.html
@@ -1,5 +1,5 @@
 <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
-    <td style="padding-left: 0em;" class="name_column">
+    <td style="padding-left: 0.0em;" class="name_column">
     <div>
         <code class="type">object</code>
         <code class="format">int(32)</code>
@@ -9,9 +9,6 @@
     <div><code class="nullable">nullable</code></div>
     <div><code class="readonly">read-only</code></div>
     <div><code class="writeonly">write-only</code></div>
-    </td>
-    <td class="button_column">
-
     </td>
     <td class="description_column">
         <div class="title">Test Schema Title</div>

--- a/cms/src/test/resources/test-data/api-specifications/SchemaHelperTest/schemaObjectsMultiLevelHierarchy-items.html
+++ b/cms/src/test/resources/test-data/api-specifications/SchemaHelperTest/schemaObjectsMultiLevelHierarchy-items.html
@@ -1,71 +1,65 @@
 <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
-    <td style="padding-left: 0em;" class="name_column">
-        <div>
-            <code class="type">object</code>
-        </div>
-    </td>
-    <td class="button_column">
-        <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+    <td style="padding-left: 0.0em;" class="name_column">
+    <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+    <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+    <div>
+        <code class="type">object</code>
+    </div>
     </td>
     <td class="description_column">
         <div class="title">object 1 - top-level schema</div>
     </td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
-    <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">property-1.1.1</code></div>
-        <div>
-            <code class="type">array</code>
-        </div>
-    </td>
-    <td class="button_column">
-        <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+    <td style="padding-left: 1.5em;" class="name_column">
+    <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+    <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+    <div><code class="propertyName">property-1.1.1</code></div>
+    <div>
+        <code class="type">array</code>
+    </div>
     </td>
     <td class="description_column">
 
     </td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="2" colspan="2">
-    <td style="padding-left: 2em;" class="name_column">
-        <div>
-            <code class="type">object</code>
-        </div>
-    </td>
-    <td class="button_column">
-        <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+    <td style="padding-left: 3.0em;" class="name_column">
+    <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+    <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 35.4%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="vertical-schema-border" style="--border-padding: -1.75em; --border-lightness: 31.4%"></span>
+    <div>
+        <code class="type">object</code>
+    </div>
     </td>
     <td class="description_column">
         <div class="title">object 1.1.1.1 - items</div>
     </td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
-    <td style="padding-left: 3em;" class="name_column">
-        <div><code class="propertyName">item-1.1.1.1.1.1</code></div>
-        <div>
-            <code class="type">array</code>
-        </div>
-    </td>
-    <td class="button_column">
-        <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+    <td style="padding-left: 4.5em;" class="name_column">
+    <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+    <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 36.2%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -3.25em; --border-lightness: 31.4%"></span>
+    <div><code class="propertyName">item-1.1.1.1.1.1</code></div>
+    <div>
+        <code class="type">array</code>
+    </div>
     </td>
     <td class="description_column">
         <div class="title">object 1.1.1.1.1.1 - item</div>
     </td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="4" colspan="2">
-    <td style="padding-left: 4em;" class="name_column">
-        <div>
-            <code class="type">object</code>
-            <code class="format">int(32)</code>
-        </div>
-        <div><code class="deprecated">deprecated</code></div>
-        <div><code class="uniqueitems">unique items</code></div>
-        <div><code class="nullable">nullable</code></div>
-        <div><code class="readonly">read-only</code></div>
-        <div><code class="writeonly">write-only</code></div>
-    </td>
-    <td class="button_column">
-
+    <td style="padding-left: 6.0em;" class="name_column">
+    <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 36.2%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 36.2%"></span><span class="vertical-schema-border" style="--border-padding: -1.75em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -4.75em; --border-lightness: 31.4%"></span>
+    <div>
+        <code class="type">object</code>
+        <code class="format">int(32)</code>
+    </div>
+    <div><code class="deprecated">deprecated</code></div>
+    <div><code class="uniqueitems">unique items</code></div>
+    <div><code class="nullable">nullable</code></div>
+    <div><code class="readonly">read-only</code></div>
+    <div><code class="writeonly">write-only</code></div>
     </td>
     <td class="description_column">
         <div class="title">object 1.1.1.1.1.1.1 - items</div>
@@ -94,28 +88,24 @@
     </td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
-    <td style="padding-left: 3em;" class="name_column">
-        <div><code class="propertyName">item-1.1.1.1.1.2</code></div>
-        <div>
-            <code class="type">object</code>
-        </div>
-    </td>
-    <td class="button_column">
-
+    <td style="padding-left: 4.5em;" class="name_column">
+    <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -3.25em; --border-lightness: 31.4%"></span>
+    <div><code class="propertyName">item-1.1.1.1.1.2</code></div>
+    <div>
+        <code class="type">object</code>
+    </div>
     </td>
     <td class="description_column">
         <div class="title">object 1.1.1.1.1.2 - item</div>
     </td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
-    <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">property-1.1.2</code></div>
-        <div>
-            <code class="type">object</code>
-        </div>
-    </td>
-    <td class="button_column">
-
+    <td style="padding-left: 1.5em;" class="name_column">
+    <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+    <div><code class="propertyName">property-1.1.2</code></div>
+    <div>
+        <code class="type">object</code>
+    </div>
     </td>
     <td class="description_column">
         <div class="title">object 1.1.2 - property</div>

--- a/cms/src/test/resources/test-data/api-specifications/SchemaHelperTest/schemaObjectsMultiLevelHierarchy-xOf.html
+++ b/cms/src/test/resources/test-data/api-specifications/SchemaHelperTest/schemaObjectsMultiLevelHierarchy-xOf.html
@@ -1,53 +1,49 @@
 <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
-    <td style="padding-left: 0em;" class="name_column">
-    <div>
-        <code class="type">object</code>
-    </div>
-    </td>
-    <td class="button_column">
+    <td style="padding-left: 0.0em;" class="name_column">
         <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+        <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+        <div>
+            <code class="type">object</code>
+        </div>
     </td>
     <td class="description_column">
         <div class="title">object 1 - top-level schema</div>
     </td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
-    <td style="padding-left: 1em;" class="name_column">
-    <div><code class="propertyName">property-1.1.1</code></div>
-    <div>
-        <code class="type">array</code>
-    </div>
-    </td>
-    <td class="button_column">
+    <td style="padding-left: 1.5em;" class="name_column">
         <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+        <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+        <div><code class="propertyName">property-1.1.1</code></div>
+        <div>
+            <code class="type">array</code>
+        </div>
     </td>
     <td class="description_column">
         <div class="title">1.1.1 - object with &#x27;items&#x27;</div>
     </td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="2">
-    <td style="padding-left: 2em;">
-    <div><code class="xOfPropertyPlaceholder">xOfPropertyPlaceholder</code></div>
-    </td>
-    <td class="button_column">
-        <div><button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button></div>
+    <td class="name_column" style="padding-left: 3.0em;">
+        <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+        <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 35.4%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="vertical-schema-border" style="--border-padding: -1.75em; --border-lightness: 31.4%"></span>
+        <div><code class="xOfPropertyPlaceholder">xOfPropertyPlaceholder</code></div>
     </td>
     <td class="description_column"></td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
-    <td style="padding-left: 3em;" class="name_column">
-    <div>
-        <code class="type">object</code>
-        <code class="format">int</code>
-    </div>
-    <div><code class="deprecated">deprecated</code></div>
-    <div><code class="uniqueitems">unique items</code></div>
-    <div><code class="nullable">nullable</code></div>
-    <div><code class="readonly">read-only</code></div>
-    <div><code class="writeonly">write-only</code></div>
-    </td>
-    <td class="button_column">
+    <td style="padding-left: 4.5em;" class="name_column">
         <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+        <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 36.2%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -3.25em; --border-lightness: 31.4%"></span>
+        <div>
+            <code class="type">object</code>
+            <code class="format">int</code>
+        </div>
+        <div><code class="deprecated">deprecated</code></div>
+        <div><code class="uniqueitems">unique items</code></div>
+        <div><code class="nullable">nullable</code></div>
+        <div><code class="readonly">read-only</code></div>
+        <div><code class="writeonly">write-only</code></div>
     </td>
     <td class="description_column">
         <div class="title">1.1.1.1.1 - &#x27;xOfPropertyPlaceholder&#x27; within &#x27;items&#x27;</div>
@@ -68,193 +64,170 @@
             <div>Min properties: <code class="codeinline minproperties">3</code></div>
             <div>Allowed values: <code class="codeinline">enum-a</code>, <code class="codeinline">enum-b</code></div>
             <div>Default: <pre><code>{
-                &quot;property&quot; : &quot;default value&quot;
-                }</code></pre></div>
+&quot;property&quot; : &quot;default value&quot;
+}</code></pre></div>
             <div>Example: <pre><code>{
-                &quot;property&quot; : &quot;example value&quot;
-                }</code></pre></div>
+&quot;property&quot; : &quot;example value&quot;
+}</code></pre></div>
     </td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="4" colspan="2">
-    <td style="padding-left: 4em;" class="name_column">
-    <div><code class="propertyName">property-1.1.1.1.1.1.1</code></div>
-    <div>
-        <code class="type">array</code>
-    </div>
-    </td>
-    <td class="button_column">
+    <td style="padding-left: 6.0em;" class="name_column">
         <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+        <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 36.8%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 36.2%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 36.2%"></span><span class="vertical-schema-border" style="--border-padding: -1.75em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -4.75em; --border-lightness: 31.4%"></span>
+        <div><code class="propertyName">property-1.1.1.1.1.1.1</code></div>
+        <div>
+            <code class="type">array</code>
+        </div>
     </td>
     <td class="description_column">
         <div class="title">1.1.1.1.1.1.1 - object within &#x27;xOfPropertyPlaceholder&#x27;</div>
     </td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="5">
-    <td style="padding-left: 5em;">
-    <div><code class="xOfPropertyPlaceholder">xOfPropertyPlaceholder</code></div>
-    </td>
-    <td class="button_column">
-        <div><button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button></div>
+    <td class="name_column" style="padding-left: 7.5em;">
+        <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+        <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 37.3%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 36.8%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 36.8%"></span><span class="vertical-schema-border" style="--border-padding: -1.75em; --border-lightness: 36.2%"></span><span class="vertical-schema-border" style="--border-padding: -3.25em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -6.25em; --border-lightness: 31.4%"></span>
+        <div><code class="xOfPropertyPlaceholder">xOfPropertyPlaceholder</code></div>
     </td>
     <td class="description_column"></td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="6" colspan="2">
-    <td style="padding-left: 6em;" class="name_column">
-    <div>
-        <code class="type">object</code>
-    </div>
-    </td>
-    <td class="button_column">
-
+    <td style="padding-left: 9.0em;" class="name_column">
+        <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 37.3%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 37.3%"></span><span class="vertical-schema-border" style="--border-padding: -3.25em; --border-lightness: 36.2%"></span><span class="vertical-schema-border" style="--border-padding: -4.75em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -7.75em; --border-lightness: 31.4%"></span>
+        <div>
+            <code class="type">object</code>
+        </div>
     </td>
     <td class="description_column">
         <div class="title">1.1.1.1.1.1.1.1.1 - object within &#x27;xOfPropertyPlaceholder&#x27;</div>
     </td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="6" colspan="2">
-    <td style="padding-left: 6em;" class="name_column">
-    <div>
-        <code class="type">object</code>
-    </div>
-    </td>
-    <td class="button_column">
-
+    <td style="padding-left: 9.0em;" class="name_column">
+        <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 37.3%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 37.3%"></span><span class="vertical-schema-border" style="--border-padding: -3.25em; --border-lightness: 36.2%"></span><span class="vertical-schema-border" style="--border-padding: -4.75em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -7.75em; --border-lightness: 31.4%"></span>
+        <div>
+            <code class="type">object</code>
+        </div>
     </td>
     <td class="description_column">
         <div class="title">1.1.1.1.1.1.1.1.2 - object within &#x27;xOfPropertyPlaceholder&#x27;</div>
     </td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="4" colspan="2">
-    <td style="padding-left: 4em;" class="name_column">
-    <div><code class="propertyName">property-1.1.1.1.1.1.2</code></div>
-    <div>
-        <code class="type">object</code>
-    </div>
-    </td>
-    <td class="button_column">
-
+    <td style="padding-left: 6.0em;" class="name_column">
+        <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 36.2%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 36.2%"></span><span class="vertical-schema-border" style="--border-padding: -1.75em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -4.75em; --border-lightness: 31.4%"></span>
+        <div><code class="propertyName">property-1.1.1.1.1.1.2</code></div>
+        <div>
+            <code class="type">object</code>
+        </div>
     </td>
     <td class="description_column">
         <div class="title">1.1.1.1.1.1.2 - object within &#x27;xOfPropertyPlaceholder&#x27;</div>
     </td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
-    <td style="padding-left: 3em;" class="name_column">
-    <div>
-        <code class="type">object</code>
-    </div>
-    </td>
-    <td class="button_column">
-
+    <td style="padding-left: 4.5em;" class="name_column">
+        <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -3.25em; --border-lightness: 31.4%"></span>
+        <div>
+            <code class="type">object</code>
+        </div>
     </td>
     <td class="description_column">
         <div class="title">1.1.1.1.2 - &#x27;xOfPropertyPlaceholder&#x27; within &#x27;items&#x27;</div>
     </td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
-    <td style="padding-left: 1em;" class="name_column">
-    <div><code class="propertyName">property-1.1.2</code></div>
-    <div>
-        <code class="type">object</code>
-    </div>
-    </td>
-    <td class="button_column">
+    <td style="padding-left: 1.5em;" class="name_column">
         <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+        <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+        <div><code class="propertyName">property-1.1.2</code></div>
+        <div>
+            <code class="type">object</code>
+        </div>
     </td>
     <td class="description_column">
         <div class="title">1.1.2 - object with &#x27;xOfPropertyPlaceholder&#x27;</div>
     </td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="2">
-    <td style="padding-left: 2em;">
-    <div><code class="xOfPropertyPlaceholder">xOfPropertyPlaceholder</code></div>
-    </td>
-    <td class="button_column">
-        <div><button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button></div>
+    <td class="name_column" style="padding-left: 3.0em;">
+        <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+        <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 35.4%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span>
+        <div><code class="xOfPropertyPlaceholder">xOfPropertyPlaceholder</code></div>
     </td>
     <td class="description_column"></td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
-    <td style="padding-left: 3em;" class="name_column">
-    <div>
-        <code class="type">object</code>
-    </div>
-    </td>
-    <td class="button_column">
+    <td style="padding-left: 4.5em;" class="name_column">
         <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+        <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 36.2%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
+        <div>
+            <code class="type">object</code>
+        </div>
     </td>
     <td class="description_column">
         <div class="title">1.1.2.1 - &#x27;xOfPropertyPlaceholder&#x27;</div>
     </td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="4" colspan="2">
-    <td style="padding-left: 4em;" class="name_column">
-    <div><code class="propertyName">property-1.1.2.1.1.1</code></div>
-    </td>
-    <td class="button_column">
+    <td style="padding-left: 6.0em;" class="name_column">
         <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+        <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 36.8%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 36.2%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 36.2%"></span><span class="vertical-schema-border" style="--border-padding: -1.75em; --border-lightness: 35.4%"></span>
+        <div><code class="propertyName">property-1.1.2.1.1.1</code></div>
     </td>
     <td class="description_column">
         <div class="title">1.1.2.1.1.1 - object within &#x27;xOfPropertyPlaceholder&#x27;</div>
     </td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="5">
-    <td style="padding-left: 5em;">
-    <div><code class="xOfPropertyPlaceholder">xOfPropertyPlaceholder</code></div>
-    </td>
-    <td class="button_column">
-        <div><button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button></div>
+    <td class="name_column" style="padding-left: 7.5em;">
+        <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+        <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 37.3%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 36.8%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 36.8%"></span><span class="vertical-schema-border" style="--border-padding: -1.75em; --border-lightness: 36.2%"></span><span class="vertical-schema-border" style="--border-padding: -3.25em; --border-lightness: 35.4%"></span>
+        <div><code class="xOfPropertyPlaceholder">xOfPropertyPlaceholder</code></div>
     </td>
     <td class="description_column"></td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="6" colspan="2">
-    <td style="padding-left: 6em;" class="name_column">
-    <div>
-        <code class="type">object</code>
-    </div>
-    </td>
-    <td class="button_column">
-
+    <td style="padding-left: 9.0em;" class="name_column">
+        <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 37.3%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 37.3%"></span><span class="vertical-schema-border" style="--border-padding: -3.25em; --border-lightness: 36.2%"></span><span class="vertical-schema-border" style="--border-padding: -4.75em; --border-lightness: 35.4%"></span>
+        <div>
+            <code class="type">object</code>
+        </div>
     </td>
     <td class="description_column">
         <div class="title">1.1.2.1.1.1.1 - object within &#x27;xOfPropertyPlaceholder&#x27;</div>
     </td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="6" colspan="2">
-    <td style="padding-left: 6em;" class="name_column">
-    <div>
-        <code class="type">object</code>
-    </div>
-    </td>
-    <td class="button_column">
-
+    <td style="padding-left: 9.0em;" class="name_column">
+        <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 37.3%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 37.3%"></span><span class="vertical-schema-border" style="--border-padding: -3.25em; --border-lightness: 36.2%"></span><span class="vertical-schema-border" style="--border-padding: -4.75em; --border-lightness: 35.4%"></span>
+        <div>
+            <code class="type">object</code>
+        </div>
     </td>
     <td class="description_column">
         <div class="title">1.1.2.1.1.1.2 - object within &#x27;xOfPropertyPlaceholder&#x27;</div>
     </td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="4" colspan="2">
-    <td style="padding-left: 4em;" class="name_column">
-    <div><code class="propertyName">property-1.1.2.1.1.2</code></div>
-    <div>
-        <code class="type">object</code>
-    </div>
-    </td>
-    <td class="button_column">
-
+    <td style="padding-left: 6.0em;" class="name_column">
+        <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 36.2%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 36.2%"></span><span class="vertical-schema-border" style="--border-padding: -1.75em; --border-lightness: 35.4%"></span>
+        <div><code class="propertyName">property-1.1.2.1.1.2</code></div>
+        <div>
+            <code class="type">object</code>
+        </div>
     </td>
     <td class="description_column">
         <div class="title">1.1.2.1.1.2 - object within &#x27;xOfPropertyPlaceholder&#x27;</div>
     </td>
 </tr>
 <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
-    <td style="padding-left: 3em;" class="name_column">
-    <div>
-        <code class="type">object</code>
-    </div>
-    </td>
-    <td class="button_column">
-
+    <td style="padding-left: 4.5em;" class="name_column">
+        <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
+        <div>
+            <code class="type">object</code>
+        </div>
     </td>
     <td class="description_column">
         <div class="title">1.1.2.2 - &#x27;xOfPropertyPlaceholder&#x27;</div>

--- a/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/oasV3_complete.html
+++ b/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/oasV3_complete.html
@@ -1,16 +1,16 @@
 <div class="column column--one-third page-block--sticky-nav page-block--sidebar article-section-nav-outer-wrapper apispecification">
-<!-- start sticky-nav -->
-<div id="sticky-nav">
-    <div class="article-section-nav-wrapper">
-        <div class="article-section-nav">
-            <h2 class="article-section-nav__title">Page contents</h2>
-            <div class="scrollable-component">
-                <nav>
-                    <ol class="article-section-nav__list">
-                        <li>
-                            <a href="#top" aria-label="Scroll to 'Top of page'"
-                               title="Scroll to 'Top of page'">Top of page</a>
-                        </li>
+    <!-- start sticky-nav -->
+    <div id="sticky-nav">
+        <div class="article-section-nav-wrapper">
+            <div class="article-section-nav">
+                <h2 class="article-section-nav__title">Page contents</h2>
+                <div class="scrollable-component">
+                    <nav>
+                        <ol class="article-section-nav__list">
+                            <li>
+                                <a href="#top" aria-label="Scroll to 'Top of page'"
+                                   title="Scroll to 'Top of page'">Top of page</a>
+                            </li>
                             <li>
                                 <a href="#api-description__overview"
                                    aria-label="Scroll to 'Overview'"
@@ -21,2462 +21,1186 @@
                                    aria-label="Scroll to 'Legal use'"
                                    title="Scroll to 'Legal use'">Legal use</a>
                             </li>
-
-                                        <li>
-                                            <a href="#api-Patients"
-                                               aria-label="Endpoints: Patients"
-                                               title="Endpoints: Patients">Endpoints: Patients</a>
-                                        </li>
-                                        <li class="section-numbered">
-                                            <a href="#api-Patients-get-patient"
-                                               aria-label="get-patient"
-                                               title="get-patient">Retrieve a patient's resource</a>
-                                        </li>
-                                        <li class="section-numbered">
-                                            <a href="#api-Patients-search-patient"
-                                               aria-label="search-patient"
-                                               title="search-patient">Search for patient</a>
-                                        </li>
-                                        <li class="section-numbered">
-                                            <a href="#api-Patients-update-patient-partial"
-                                               aria-label="update-patient-partial"
-                                               title="update-patient-partial">Update a patient's resource</a>
-                                        </li>
-                                        <li>
-                                            <a href="#api-Polling"
-                                               aria-label="Endpoints: Polling"
-                                               title="Endpoints: Polling">Endpoints: Polling</a>
-                                        </li>
-                                        <li class="section-numbered">
-                                            <a href="#api-Polling-polling"
-                                               aria-label="polling"
-                                               title="polling">Retrieve the outcome of the accepted update.</a>
-                                        </li>
-                    </ol>
-                </nav>
+                            <li>
+                                <a href="#api-Patients"
+                                   aria-label="Endpoints: Patients"
+                                   title="Endpoints: Patients">Endpoints: Patients</a>
+                            </li>
+                            <li class="section-numbered">
+                                <a href="#api-Patients-get-patient"
+                                   aria-label="get-patient"
+                                   title="get-patient">Retrieve a patient's resource</a>
+                            </li>
+                            <li class="section-numbered">
+                                <a href="#api-Patients-search-patient"
+                                   aria-label="search-patient"
+                                   title="search-patient">Search for patient</a>
+                            </li>
+                            <li class="section-numbered">
+                                <a href="#api-Patients-update-patient-partial"
+                                   aria-label="update-patient-partial"
+                                   title="update-patient-partial">Update a patient's resource</a>
+                            </li>
+                            <li>
+                                <a href="#api-Polling"
+                                   aria-label="Endpoints: Polling"
+                                   title="Endpoints: Polling">Endpoints: Polling</a>
+                            </li>
+                            <li class="section-numbered">
+                                <a href="#api-Polling-polling"
+                                   aria-label="polling"
+                                   title="polling">Retrieve the outcome of the accepted update.</a>
+                            </li>
+                        </ol>
+                    </nav>
+                </div>
             </div>
         </div>
     </div>
+    <!-- end sticky-nav -->
 </div>
-<!-- end sticky-nav -->
-</div>
-
 <div id="content" class="column column--two-thirds page-block page-block--main apispecification" aria-label="Document content">
-
     <!-- API Title: Personal Demographics Service (FHIR) API -->
-
     <div id="api-description" class="article-section">
         <h2 id="api-description__overview">Overview</h2>
-<p>Use this API to access the <a href="https://digital.nhs.uk/services/demographics">Personal Demographics Service (PDS)</a></p>
-<h2 id="api-description__legal-use">Legal use</h2>
-<p>This API can only be used where there is a legal basis.
+        <p>Use this API to access the <a href="https://digital.nhs.uk/services/demographics">Personal Demographics Service (PDS)</a></p>
+        <h2 id="api-description__legal-use">Legal use</h2>
+        <p>This API can only be used where there is a legal basis.
     </div>
-
-                    <div id="api-Patients" class="article-section">
-                        <h2>Endpoints: Patients</h2>
-                    </div>
-                                    <div id="api-Patients-get-patient" class="article-section-with-sub-heading">
-                                        <article id="api-Patients-get-patient-0">
-                                            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-                                            <h3>Retrieve a patient's resource</h3>
-                                            <div class="endpoint_path">
-                                                <div class="method">get</div>
-                                                <div class="pre"><pre>/Patient/{id}</pre></div>
-
-                                                        <div class="try"><a onclick="tryEndpointNow('/Patients/get-patient')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
-                                            </div>
-
-                                            <p><h4 id="overview">Overview</h4>
-<p>Use this endpoint to get patient details from PDS for a given NHS Number.</p>
-
-                                                <h4>Request</h4>
-
-                                                <div class="httpparams">
-                                                    <h5>Path parameters</h5>
-                                                    <table data-disablesort="true">
-                                                        <tr>
-                                                            <th>Name</th>
-                                                            <th>Description</th>
-                                                        </tr>
-                                                            <tr><td class="httpparams__name">id</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                <div>The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales.</div>
-
-
-
-                                                                                <div>Example: <code class="codeinline">9000000009</code></div>
-
-                                                                        </div>
-                                                                            <div class="httpparams__required">
-                                                                                Required
-                                                                            </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                    </table>
-                                                </div>
-
-
-                                                <div class="httpparams">
-                                                    <h5>Headers</h5>
-                                                    <table data-disablesort="true">
-                                                        <tr>
-                                                            <th>Name</th>
-                                                            <th>Description</th>
-                                                        </tr>
-                                                            <tr><td class="httpparams__name">NHSD-Session-URID</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>).</div>
-
-                                                                                <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
-
-
-                                                                                <div>Example: <code class="codeinline">555021935107</code></div>
-
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                    </table>
-                                                </div>
-
-
-
-                                                    <h4>Response</h4>
-
-                                                <h5>HTTP status: 200</h5>
-                                                <div>Information successfully returned.</div>
-
-                                                    <div class="httpparams">
-                                                        <h6>Headers</h6>
-                                                        <table data-disablesort="true">
-                                                            <tr>
-                                                                <th>Name</th>
-                                                                <th>Description</th>
-                                                            </tr>
-                                                                <tr><td class="httpparams__name">ETag</td>
-                                                                <td>
-                                                                    <div>
-                                                                        <div class="httpparams__description">
-                                                                            <div>
-                                                                                <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                    <div>Record version identifier enclosed in quotes and preceded by 'W/'. For example, <code class="codeinline">W/&quot;2&quot;</code>.</div>
-
-                                                                                    <div>Pattern: <code class="codeinline">/^W\/"[0-9]+"$/</code></div>
-
-
-                                                                                    <div>Example: <code class="codeinline">W/"2"</code></div>
-
-                                                                            </div>
-                                                                        </div>
-                                                                    </div>
-                                                                </td>
-                                                                </tr>
-                                                        </table>
-                                                    </div>
-
-                                                        <h6>Body</h6>
-
-
-                                                            <div class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/fhir+json</span>
-                                                            </div>
-
-                                                                <div class="body__example__header">Example</div>
-                                                                <div><pre><code>{
-  "address" : [ {
-    "id" : "456",
-    "line" : [ "1 Trevelyan Square", "Boar Lane", "City Centre", "Leeds", "West Yorkshire" ],
-    "postalCode" : "LS1 6AE",
-    "use" : "home"
-  } ],
-  "birthDate" : "2010-10-22"
-}</code></pre></div>
-
-
-
-
-                                                                <div class="body__schema__header">Schema
-                                                                    <span class="schema__header__buttons">
-                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('e81ea218-50ec-493a-9db1-8817bea495aa')">Collapse all</button>
-                                                                        <button class='schemaButton js expandAll' onclick="expandAll('e81ea218-50ec-493a-9db1-8817bea495aa')">Expand all</button>
-                                                                    </span>
-                                                                </div>
-                                                                <div class="body__schema" data-schema-uuid="e81ea218-50ec-493a-9db1-8817bea495aa">
-                                                                    <table data-disablesort="true">
-                                                                        <thead>
-                                                                        <th colspan="2">Name</th>
-                                                                        <th>Description</th>
-                                                                        </thead>
-
-
-<tr class="expanded" data-schema-uuid="0f19ee9b-2831-456a-973f-35985ee17d74" data-indentation="0" colspan="2">
-    <td style="padding-left: 0em;" class="name_column">
-
-        <div>
-            <code class="type">object</code>
-
-        </div>
-
-
-
-
-
-
-
-    </td>
-
-    <td class="button_column">
-            <button class="collapser js" data-schema-uuid="0f19ee9b-2831-456a-973f-35985ee17d74" onclick="collapseChildren('0f19ee9b-2831-456a-973f-35985ee17d74')"></button>
-    </td>
-
-    <td class="description_column">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    </td>
-</tr>
-
-
-    <tr class="expanded" data-schema-uuid="a12ddc9b-1f4a-4b60-b318-f5bf3d21b86e" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">resourceType</code></div>
-
-            <div>
-                <code class="type">string</code>
-
-            </div>
-
-
-
-
-            <div><code class="readonly">read-only</code></div>
-
-
-        </td>
-
-        <td class="button_column">
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">FHIR resource type.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                <div>Default: <code class="codeinline default">Patient</code></div>
-
-        </td>
-    </tr>
-
-
-
-
-
-    <tr class="expanded" data-schema-uuid="23fb31ac-17c5-4cde-aaa1-ddae7ec8382e" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">id</code></div>
-
-            <div>
-                <code class="type">string</code>
-
-            </div>
-
-
-
-
-
-
-            <div><code class="required">required</code></div>
-        </td>
-
-        <td class="button_column">
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales. Always 10 digits and must be a <a href="https://www.datadictionary.nhs.uk/data_dictionary/attributes/n/nhs/nhs_number_de.asp">valid NHS Number</a>.</div>
-
-            <div>Pattern: <code class="codeinline pattern">^\d{10}$</code></div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                <div>Example: <code class="codeinline example">9000000009</code></div>
-        </td>
-    </tr>
-
-
-
-
-
-
-
-
-
-                                                                    </table>
-                                                                </div>
-
-
-
-                                                <h5>HTTP status: 400</h5>
-                                                <div>Invalid NHS number supplied.</div>
-
-
-                                                        <h6>Body</h6>
-
-
-                                                            <div class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/fhir+json</span>
-                                                            </div>
-
-                                                                <div class="body__example__header">Example</div>
-                                                                <div><pre><code>{
-  "resourceType" : "OperationOutcome",
-  "issue" : [ {
-    "severity" : "error",
-    "code" : "value",
-    "details" : {
-      "coding" : [ {
-        "system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
-        "version" : "1",
-        "code" : "INVALID_RESOURCE_ID",
-        "display" : "Resource Id is invalid"
-      } ]
-    }
-  } ]
-}</code></pre></div>
-
-
-
-
-                                                                <div class="body__schema__header">Schema
-                                                                    <span class="schema__header__buttons">
-                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('374f4d90-5cbf-46b7-80a5-3d8706318ac8')">Collapse all</button>
-                                                                        <button class='schemaButton js expandAll' onclick="expandAll('374f4d90-5cbf-46b7-80a5-3d8706318ac8')">Expand all</button>
-                                                                    </span>
-                                                                </div>
-                                                                <div class="body__schema" data-schema-uuid="374f4d90-5cbf-46b7-80a5-3d8706318ac8">
-                                                                    <table data-disablesort="true">
-                                                                        <thead>
-                                                                        <th colspan="2">Name</th>
-                                                                        <th>Description</th>
-                                                                        </thead>
-
-
-<tr class="expanded" data-schema-uuid="b85d66d0-8eb3-461b-8d71-9890ad059c96" data-indentation="0" colspan="2">
-    <td style="padding-left: 0em;" class="name_column">
-
-        <div>
-            <code class="type">object</code>
-
-        </div>
-
-
-
-
-
-
-
-    </td>
-
-    <td class="button_column">
-            <button class="collapser js" data-schema-uuid="b85d66d0-8eb3-461b-8d71-9890ad059c96" onclick="collapseChildren('b85d66d0-8eb3-461b-8d71-9890ad059c96')"></button>
-    </td>
-
-    <td class="description_column">
-
-
-        <div class="description">Outcome of an operation that does not result in a resource or bundle being returned (e.g. error, async/batch submission).</p>
-<p>Search outcomes:</p>
-<table data-disablesort="true">
-<thead>
-<tr>
-<th>Code</th>
-<th>Response Code</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>INVALID_SEARCH_DATA</td>
-<td>400</td>
-<td>The search parameters are invalid. A description of what exactly is at fault will be added to the display.</td>
-</tr>
-<tr>
-<td>TOO_MANY_MATCHES</td>
-<td>200</td>
-<td>Too many matches were found - user should be told to refine their search parameters.</td>
-</tr>
-</tbody>
-</table></div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    </td>
-</tr>
-
-
-    <tr class="expanded" data-schema-uuid="7e0e1a8f-9607-4215-a6f5-0c0aa0e0f156" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">resourceType</code></div>
-
-            <div>
-                <code class="type">string</code>
-
-            </div>
-
-
-
-
-            <div><code class="readonly">read-only</code></div>
-
-
-        </td>
-
-        <td class="button_column">
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">FHIR Resource Type.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                <div>Default: <code class="codeinline default">OperationOutcome</code></div>
-
-        </td>
-    </tr>
-
-
-
-
-
-    <tr class="expanded" data-schema-uuid="2dd81e85-039e-4093-bda6-4b57cc5a9848" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">issue</code></div>
-
-            <div>
-                <code class="type">array</code>
-
-            </div>
-
-
-
-
-
-
-
-        </td>
-
-        <td class="button_column">
-                    <button class="collapser js" data-schema-uuid="2dd81e85-039e-4093-bda6-4b57cc5a9848" onclick="collapseChildren('2dd81e85-039e-4093-bda6-4b57cc5a9848')"></button>
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">List of issues that have occurred.</div>
-
-
-
-
-
-
-
-
-
-
-
-            <div>Min items: <code class="codeinline minitems">1</code></div>
-
-
-
-
-
-
-
-        </td>
-    </tr>
-
-
-
-            <tr class="expanded" data-schema-uuid="80da859f-9764-4202-95c0-8140a168c427" data-indentation="2" colspan="2">
-                <td style="padding-left: 2em;" class="name_column">
-
-                    <div>
-                        <code class="type">object</code>
-
-                    </div>
-
-
-
-
-
-
-
-                </td>
-
-                <td class="button_column">
-                </td>
-
-                <td class="description_column">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                </td>
-            </tr>
-
-
-
-
-
-
-
-
-
-
-
-                                                                    </table>
-                                                                </div>
-
-
-                                        </article>
-                                    </div>
-                                    <div id="api-Patients-search-patient" class="article-section-with-sub-heading">
-                                        <article id="api-Patients-search-patient-0">
-                                            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-                                            <h3>Search for patient</h3>
-                                            <div class="endpoint_path">
-                                                <div class="method">get</div>
-                                                <div class="pre"><pre>/Patient</pre></div>
-
-                                                        <div class="try"><a onclick="tryEndpointNow('/Patients/search-patient')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
-                                            </div>
-
-                                            <p><h4 id="endpoint">Endpoint</h4>
-<p>Use this endpoint to search for a patient in PDS.</p>
-
-                                                <h4>Request</h4>
-
-
-                                                <div class="httpparams">
-                                                    <h5>Query parameters</h5>
-                                                    <table data-disablesort="true">
-                                                        <tr>
-                                                            <th>Name</th>
-                                                            <th>Description</th>
-                                                        </tr>
-                                                            <tr><td class="httpparams__name">_exact-match</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">Boolean</span>
-
-
-                                                                                <div>Default value: <code class="codeinline">false</code></div>
-
-                                                                                <div>The search only returns results where the <code class="codeinline">score</code> field is 1.0.</div>
-
-
-
-                                                                                <div>Example: <code class="codeinline">true</code></div>
-
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                            <tr><td class="httpparams__name">_history</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">Boolean</span>
-
-
-                                                                                <div>Default value: <code class="codeinline">false</code></div>
-
-                                                                                <div>The search looks for matches in historic information such as previous names and addresses.</div>
-
-
-
-                                                                                <div>Example: <code class="codeinline">true</code></div>
-
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                    </table>
-                                                </div>
-
-                                                <div class="httpparams">
-                                                    <h5>Headers</h5>
-                                                    <table data-disablesort="true">
-                                                        <tr>
-                                                            <th>Name</th>
-                                                            <th>Description</th>
-                                                        </tr>
-                                                            <tr><td class="httpparams__name">NHSD-Session-URID</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>), specifies the role the user is acting in.</div>
-
-                                                                                <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
-
-
-                                                                                <div>Example: <code class="codeinline">555021935107</code></div>
-
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                            <tr><td class="httpparams__name">Authorization</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">String</span>
-
-                                                                                <code class="codeinline">(^Bearer\ [[:ascii:]]+$)</code>
-
-
-                                                                                <div>An OAuthV2 access token presented in Bearer format.</p>
-<p>Note: This parameter is required unless interacting with the Sandbox.</div>
-
-
-
-                                                                                <div>Example: <code class="codeinline">Bearer g1112R_ccQ1Ebbb4gtHBP1aaaNM</code></div>
-
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                    </table>
-                                                </div>
-
-
-
-                                                    <h4>Response</h4>
-
-                                                <h5>HTTP status: 200</h5>
-                                                <div>A completed search, containing zero, one, or many matching patients.</div>
-
-
-                                                        <h6>Body</h6>
-
-
-                                                            <div class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/fhir+json</span>
-                                                            </div>
-
-                                                                <div class="body__example__header">Example</div>
-                                                                <div><pre><code>{
-  "resourceType" : "Bundle",
-  "type" : "searchset",
-  "timestamp" : "2019-12-25T12:00:00+00:00",
-  "total" : 1,
-  "entry" : [ {
-    "fullUrl" : "https://beta.api.digital.nhs.uk/personal-demographics/Patient/9000000009",
-    "search" : {
-      "score" : 1
-    }
-  } ]
-}</code></pre></div>
-
-
-
-
-                                                                <div class="body__schema__header">Schema
-                                                                    <span class="schema__header__buttons">
-                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('0f300798-fa95-4cc9-871c-996908042029')">Collapse all</button>
-                                                                        <button class='schemaButton js expandAll' onclick="expandAll('0f300798-fa95-4cc9-871c-996908042029')">Expand all</button>
-                                                                    </span>
-                                                                </div>
-                                                                <div class="body__schema" data-schema-uuid="0f300798-fa95-4cc9-871c-996908042029">
-                                                                    <table data-disablesort="true">
-                                                                        <thead>
-                                                                        <th colspan="2">Name</th>
-                                                                        <th>Description</th>
-                                                                        </thead>
-
-
-<tr class="expanded" data-schema-uuid="79eabd5d-9800-4aa6-8201-9ff591d7efdf" data-indentation="0" colspan="2">
-    <td style="padding-left: 0em;" class="name_column">
-
-        <div>
-            <code class="type">object</code>
-
-        </div>
-
-
-
-
-
-
-
-    </td>
-
-    <td class="button_column">
-            <button class="collapser js" data-schema-uuid="79eabd5d-9800-4aa6-8201-9ff591d7efdf" onclick="collapseChildren('79eabd5d-9800-4aa6-8201-9ff591d7efdf')"></button>
-    </td>
-
-    <td class="description_column">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    </td>
-</tr>
-
-
-    <tr class="expanded" data-schema-uuid="c62709c2-3a91-4d84-ae27-52873c12ea8c" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">resourceType</code></div>
-
-            <div>
-                <code class="type">string</code>
-
-            </div>
-
-
-
-
-
-
-
-        </td>
-
-        <td class="button_column">
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">FHIR Resource Type.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                <div>Default: <code class="codeinline default">Bundle</code></div>
-
-        </td>
-    </tr>
-
-
-
-
-
-    <tr class="expanded" data-schema-uuid="d26a2e42-0790-41d2-b8d6-30b759f7cb80" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">type</code></div>
-
-            <div>
-                <code class="type">string</code>
-
-            </div>
-
-
-
-
-
-
-
-        </td>
-
-        <td class="button_column">
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">FHIR Bundle Type.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                <div>Default: <code class="codeinline default">searchset</code></div>
-
-        </td>
-    </tr>
-
-
-
-
-
-
-
-
-
-                                                                    </table>
-                                                                </div>
-
-
-
-                                                <h5>HTTP status: 400</h5>
-                                                <div>Invalid search paramaters supplied.</div>
-
-
-                                                        <h6>Body</h6>
-
-
-                                                            <div class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/fhir+json</span>
-                                                            </div>
-
-
-
-                                                                        <div class="body__example__header">Examples</div>
-
-                                                                <div class="body__example__summary">too few search params</div>
-
-
-                                                                <div><pre><code>{
-  "resourceType" : "OperationOutcome",
-  "issue" : [ {
-    "severity" : "error",
-    "code" : "value"
-  } ]
-}</code></pre></div>
-
-                                                                <div class="body__example__summary">Invalid combination of search parameters</div>
-
-
-                                                                <div><pre><code>{
-  "resourceType" : "OperationOutcome",
-  "issue" : [ {
-    "severity" : "error",
-    "code" : "value"
-  } ]
-}</code></pre></div>
-
-
-                                                                <div class="body__schema__header">Schema
-                                                                    <span class="schema__header__buttons">
-                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('e1c55b08-17f8-4ff3-9c33-1a4d77b69863')">Collapse all</button>
-                                                                        <button class='schemaButton js expandAll' onclick="expandAll('e1c55b08-17f8-4ff3-9c33-1a4d77b69863')">Expand all</button>
-                                                                    </span>
-                                                                </div>
-                                                                <div class="body__schema" data-schema-uuid="e1c55b08-17f8-4ff3-9c33-1a4d77b69863">
-                                                                    <table data-disablesort="true">
-                                                                        <thead>
-                                                                        <th colspan="2">Name</th>
-                                                                        <th>Description</th>
-                                                                        </thead>
-
-
-<tr class="expanded" data-schema-uuid="5d847097-e8af-4ff5-8ff1-f18ebd060b56" data-indentation="0" colspan="2">
-    <td style="padding-left: 0em;" class="name_column">
-
-        <div>
-            <code class="type">object</code>
-            <code class="format">int(32)</code>
-        </div>
-
-        <div><code class="deprecated">deprecated</code></div>
-        <div><code class="uniqueitems">unique items</code></div>
-        <div><code class="nullable">nullable</code></div>
-        <div><code class="readonly">read-only</code></div>
-        <div><code class="writeonly">write-only</code></div>
-
-    </td>
-
-    <td class="button_column">
-    </td>
-
-    <td class="description_column">
-        <div class="title">Response Schema with all simple fields.</div>
-
-        <div class="description">Response Test Schema Object description in <code class="codeinline">Markdown</code>.</div>
-
-        <div>Pattern: <code class="codeinline pattern">^(?:[0-9]{4}-[0-9]{2}-[0-9]{2})?(?:[ T][0-9]{2}:[0-9]{2}:[0-9]{2})?(?:[.,][0-9]{3})?</code></div>
-
-        <div>Multiple of: <code class="codeinline multipleof">1.2</code><div>
-
-        <div>Maximum: <code class="codeinline maximum">2.2</code>
-            <code class="codeinline exclusivemaximum">(exclusive)</code>
-        </div>
-
-        <div>Minimum: <code class="codeinline minimum">-2.3</code>
-            <code class="codeinline exclusiveminimum">(exclusive)</code>
-        </div>
-
-        <div>Max length: <code class="codeinline maxlength">22</code></div>
-        <div>Min length: <code class="codeinline minlength">11</code></div>
-
-        <div>Max items: <code class="codeinline maxitems">44</code></div>
-        <div>Min items: <code class="codeinline minitems">33</code></div>
-
-        <div>Max properties: <code class="codeinline maxproperties">5</code></div>
-        <div>Min properties: <code class="codeinline minproperties">3</code></div>
-
-
-
-
-    </td>
-</tr>
-
-
-
-
-
-
-                                                                    </table>
-                                                                </div>
-
-
-                                        </article>
-                                    </div>
-                                    <div id="api-Patients-update-patient-partial" class="article-section-with-sub-heading">
-                                        <article id="api-Patients-update-patient-partial-0">
-                                            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-                                            <h3>Update a patient's resource</h3>
-                                            <div class="endpoint_path">
-                                                <div class="method">patch</div>
-                                                <div class="pre"><pre>/Patient/{id}</pre></div>
-
-                                                        <div class="try"><a onclick="tryEndpointNow('/Patients/update-patient-partial')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
-                                            </div>
-
-                                            <p><h4 id="overview">Overview</h4>
-<p>Use this endpoint to update patient details in PDS.</p>
-
-                                                <h4>Request</h4>
-
-                                                <div class="httpparams">
-                                                    <h5>Path parameters</h5>
-                                                    <table data-disablesort="true">
-                                                        <tr>
-                                                            <th>Name</th>
-                                                            <th>Description</th>
-                                                        </tr>
-                                                            <tr><td class="httpparams__name">id</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                <div>The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales.</div>
-
-
-
-                                                                                <div>Example: <code class="codeinline">9000000009</code></div>
-
-                                                                        </div>
-                                                                            <div class="httpparams__required">
-                                                                                Required
-                                                                            </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                    </table>
-                                                </div>
-
-
-                                                <div class="httpparams">
-                                                    <h5>Headers</h5>
-                                                    <table data-disablesort="true">
-                                                        <tr>
-                                                            <th>Name</th>
-                                                            <th>Description</th>
-                                                        </tr>
-                                                            <tr><td class="httpparams__name">NHSD-Session-URID</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>).</div>
-
-                                                                                <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
-
-
-                                                                                <div>Example: <code class="codeinline">555021935107</code></div>
-
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                            <tr><td class="httpparams__name">If-Match</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                <div>Latest known version identifier enclosed in quotes preceded by <code class="codeinline">W/</code>.</p>
-<p>Send the value of this resource's <code class="codeinline">ETag</code> response header (or <code class="codeinline">meta.versionId</code> property) as received.</div>
-
-                                                                                <div>Pattern: <code class="codeinline">/^W\/"[0-9]+"$/</code></div>
-
-
-                                                                                <div>Example: <code class="codeinline">W/"2"</code></div>
-
-                                                                        </div>
-                                                                            <div class="httpparams__required">
-                                                                                Required
-                                                                            </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                    </table>
-                                                </div>
-
-
-                                                <div class="httpparams">
-                                                    <h5>Body</h5>
-                                                        <div class="httpparams__required">Required</div>
-
-
-
-                                                                    <div class="body__contenttype">
-                                                                        <span class="body__contenttype__label">Content type: </span>
-                                                                        <span class="body__contenttype__value">application/json</span>
-                                                                    </div>
-
-
-
-                                                                                <div class="body__example__header">Examples</div>
-
-                                                                        <div class="body__example__summary">Add a new single item (deceasedDateTime) to the patient</div>
-
-
-                                                                        <div><pre><code>{
-  "patches" : [ {
-    "op" : "add",
-    "path" : "/deceasedDateTime",
-    "value" : "2010-10-22T00:00:00+00:00"
-  } ]
-}</code></pre></div>
-
-                                                                        <div class="body__example__summary">Update the simple item (gender)</div>
-
-
-                                                                        <div><pre><code>{
-  "patches" : [ {
-    "op" : "replace",
-    "path" : "/gender",
-    "value" : "male"
-  } ]
-}</code></pre></div>
-
-
-                                                                        <div class="body__schema__header">Schema
-                                                                            <span class="schema__header__buttons">
-                                                                                <button class='schemaButton js collapseAll' onclick="collapseAll('e054bcee-cb82-4544-a4f0-e46b06bd9be6')">Collapse all</button>
-                                                                                <button class='schemaButton js expandAll' onclick="expandAll('e054bcee-cb82-4544-a4f0-e46b06bd9be6')">Expand all</button>
-                                                                            </span>
-                                                                        </div>
-                                                                        <div class="body__schema" data-schema-uuid="e054bcee-cb82-4544-a4f0-e46b06bd9be6">
-                                                                            <table data-disablesort="true">
-                                                                                <thead>
-                                                                                <th colspan="2">Name</th>
-                                                                                <th>Description</th>
-                                                                                </thead>
-
-
-<tr class="expanded" data-schema-uuid="99ca5016-1726-46a8-8259-77f6f2b0a479" data-indentation="0" colspan="2">
-    <td style="padding-left: 0em;" class="name_column">
-
-        <div>
-            <code class="type">object</code>
-            <code class="format">int(32)</code>
-        </div>
-
-        <div><code class="deprecated">deprecated</code></div>
-        <div><code class="uniqueitems">unique items</code></div>
-        <div><code class="nullable">nullable</code></div>
-        <div><code class="readonly">read-only</code></div>
-        <div><code class="writeonly">write-only</code></div>
-
-    </td>
-
-    <td class="button_column">
-    </td>
-
-    <td class="description_column">
-        <div class="title">Request Schema with all simple fields.</div>
-
-        <div class="description">Request Test Schema Object description in <code class="codeinline">Markdown</code>.</div>
-
-        <div>Pattern: <code class="codeinline pattern">^(?:[0-9]{4}-[0-9]{2}-[0-9]{2})?(?:[ T][0-9]{2}:[0-9]{2}:[0-9]{2})?(?:[.,][0-9]{3})?</code></div>
-
-        <div>Multiple of: <code class="codeinline multipleof">1.2</code><div>
-
-        <div>Maximum: <code class="codeinline maximum">2.2</code>
-            <code class="codeinline exclusivemaximum">(exclusive)</code>
-        </div>
-
-        <div>Minimum: <code class="codeinline minimum">-2.3</code>
-            <code class="codeinline exclusiveminimum">(exclusive)</code>
-        </div>
-
-        <div>Max length: <code class="codeinline maxlength">22</code></div>
-        <div>Min length: <code class="codeinline minlength">11</code></div>
-
-        <div>Max items: <code class="codeinline maxitems">44</code></div>
-        <div>Min items: <code class="codeinline minitems">33</code></div>
-
-        <div>Max properties: <code class="codeinline maxproperties">5</code></div>
-        <div>Min properties: <code class="codeinline minproperties">3</code></div>
-
-
-
-
-    </td>
-</tr>
-
-
-
-
-
-
-                                                                            </table>
-                                                                        </div>
-
-
-                                                </div>
-
-                                                    <h4>Response</h4>
-
-                                                <h5>HTTP status: 202</h5>
-                                                <div>The patch was syntactically correct and was accepted.</div>
-
-                                                    <div class="httpparams">
-                                                        <h6>Headers</h6>
-                                                        <table data-disablesort="true">
-                                                            <tr>
-                                                                <th>Name</th>
-                                                                <th>Description</th>
-                                                            </tr>
-                                                                <tr><td class="httpparams__name">Content-Location</td>
-                                                                <td>
-                                                                    <div>
-                                                                        <div class="httpparams__description">
-                                                                            <div>
-                                                                                <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                    <div>Polling location of the update</div>
-
-
-
-                                                                                    <div>Example: <code class="codeinline">/Polling/20200522091633363041_461139_1524772598</code></div>
-
-                                                                            </div>
-                                                                        </div>
-                                                                    </div>
-                                                                </td>
-                                                                </tr>
-                                                                <tr><td class="httpparams__name">Retry-After</td>
-                                                                <td>
-                                                                    <div>
-                                                                        <div class="httpparams__description">
-                                                                            <div>
-                                                                                <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                    <div>Time to wait between polls in milliseconds</div>
-
-
-
-                                                                                    <div>Example: <code class="codeinline">100</code></div>
-
-                                                                            </div>
-                                                                        </div>
-                                                                    </div>
-                                                                </td>
-                                                                </tr>
-                                                        </table>
-                                                    </div>
-
-
-
-
-                                                <h5>HTTP status: 400</h5>
-                                                <div>Client error.</div>
-
-
-                                                        <h6>Body</h6>
-
-
-                                                            <div class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/fhir+json</span>
-                                                            </div>
-
-
-
-                                                                        <div class="body__example__header">Examples</div>
-
-                                                                <div class="body__example__summary">Invalid NHS number supplied</div>
-
-
-                                                                <div><pre><code>{
-  "resourceType" : "OperationOutcome",
-  "issue" : [ {
-    "severity" : "error",
-    "code" : "value",
-    "details" : {
-      "coding" : [ {
-        "system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
-        "version" : "1",
-        "code" : "INVALID_RESOURCE_ID",
-        "display" : "Resource Id is invalid"
-      } ]
-    }
-  } ]
-}</code></pre></div>
-
-                                                                <div class="body__example__summary">No patches submitted</div>
-
-
-                                                                <div><pre><code>{
-  "resourceType" : "OperationOutcome",
-  "issue" : [ {
-    "severity" : "error",
-    "code" : "required",
-    "details" : {
-      "coding" : [ {
-        "system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
-        "version" : "1",
-        "code" : "MISSING_VALUE",
-        "display" : "Missing value - patches"
-      } ]
-    }
-  } ]
-}</code></pre></div>
-
-
-                                                                <div class="body__schema__header">Schema
-                                                                    <span class="schema__header__buttons">
-                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('f31f9536-abac-4a8c-b8b0-ded9c3e12f48')">Collapse all</button>
-                                                                        <button class='schemaButton js expandAll' onclick="expandAll('f31f9536-abac-4a8c-b8b0-ded9c3e12f48')">Expand all</button>
-                                                                    </span>
-                                                                </div>
-                                                                <div class="body__schema" data-schema-uuid="f31f9536-abac-4a8c-b8b0-ded9c3e12f48">
-                                                                    <table data-disablesort="true">
-                                                                        <thead>
-                                                                        <th colspan="2">Name</th>
-                                                                        <th>Description</th>
-                                                                        </thead>
-
-
-<tr class="expanded" data-schema-uuid="fdfb6b48-06f0-4db7-8102-6c79dd31ab2f" data-indentation="0" colspan="2">
-    <td style="padding-left: 0em;" class="name_column">
-
-        <div>
-            <code class="type">object</code>
-
-        </div>
-
-
-
-
-
-
-
-    </td>
-
-    <td class="button_column">
-            <button class="collapser js" data-schema-uuid="fdfb6b48-06f0-4db7-8102-6c79dd31ab2f" onclick="collapseChildren('fdfb6b48-06f0-4db7-8102-6c79dd31ab2f')"></button>
-    </td>
-
-    <td class="description_column">
-
-
-        <div class="description">Outcome of an operation that does not result in a resource or bundle being returned (e.g. error, async/batch submission).</p>
-<p>Search outcomes:</p>
-<table data-disablesort="true">
-<thead>
-<tr>
-<th>Code</th>
-<th>Response Code</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>INVALID_SEARCH_DATA</td>
-<td>400</td>
-<td>The search parameters are invalid. A description of what exactly is at fault will be added to the display.</td>
-</tr>
-<tr>
-<td>TOO_MANY_MATCHES</td>
-<td>200</td>
-<td>Too many matches were found - user should be told to refine their search parameters.</td>
-</tr>
-</tbody>
-</table></div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    </td>
-</tr>
-
-
-    <tr class="expanded" data-schema-uuid="8b41dfb7-b585-4998-b021-526604811801" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">resourceType</code></div>
-
-            <div>
-                <code class="type">string</code>
-
-            </div>
-
-
-
-
-            <div><code class="readonly">read-only</code></div>
-
-
-        </td>
-
-        <td class="button_column">
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">FHIR Resource Type.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                <div>Default: <code class="codeinline default">OperationOutcome</code></div>
-
-        </td>
-    </tr>
-
-
-
-
-
-    <tr class="expanded" data-schema-uuid="7fa70c88-5989-4de7-b040-2bd9872d9f54" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">issue</code></div>
-
-            <div>
-                <code class="type">array</code>
-
-            </div>
-
-
-
-
-
-
-
-        </td>
-
-        <td class="button_column">
-                    <button class="collapser js" data-schema-uuid="7fa70c88-5989-4de7-b040-2bd9872d9f54" onclick="collapseChildren('7fa70c88-5989-4de7-b040-2bd9872d9f54')"></button>
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">List of issues that have occurred.</div>
-
-
-
-
-
-
-
-
-
-
-
-            <div>Min items: <code class="codeinline minitems">1</code></div>
-
-
-
-
-
-
-
-        </td>
-    </tr>
-
-
-
-            <tr class="expanded" data-schema-uuid="ca588ce3-c8d6-436c-a59d-49fc78776ca0" data-indentation="2" colspan="2">
-                <td style="padding-left: 2em;" class="name_column">
-
-                    <div>
-                        <code class="type">object</code>
-
-                    </div>
-
-
-
-
-
-
-
-                </td>
-
-                <td class="button_column">
-                        <button class="collapser js" data-schema-uuid="ca588ce3-c8d6-436c-a59d-49fc78776ca0" onclick="collapseChildren('ca588ce3-c8d6-436c-a59d-49fc78776ca0')"></button>
-                </td>
-
-                <td class="description_column">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                </td>
-            </tr>
-
-
-                <tr class="expanded" data-schema-uuid="0106017a-f5dd-4aaa-8c68-1a133a86a841" data-indentation="3" colspan="2">
-                    <td style="padding-left: 3em;" class="name_column">
-                    <div><code class="propertyName">severity</code></div>
-
-                        <div>
-                            <code class="type">string</code>
-
-                        </div>
-
-
-
-
-
-
-                        <div><code class="required">required</code></div>
-                    </td>
-
-                    <td class="button_column">
-                    </td>
-
-                    <td class="description_column">
-
-
-                        <div class="description">Severity of the error.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                        <div>Allowed values: <code class="codeinline">fatal</code>, <code class="codeinline">error</code>, <code class="codeinline">warning</code>, <code class="codeinline">information</code></div>
-
-
-                            <div>Example: <code class="codeinline example">error</code></div>
-                    </td>
-                </tr>
-
-
-
-
-
-                <tr class="expanded" data-schema-uuid="4a4db968-4fff-4d69-aff3-45c45e4834ce" data-indentation="3" colspan="2">
-                    <td style="padding-left: 3em;" class="name_column">
-                    <div><code class="propertyName">code</code></div>
-
-                        <div>
-                            <code class="type">string</code>
-
-                        </div>
-
-
-
-
-
-
-                        <div><code class="required">required</code></div>
-                    </td>
-
-                    <td class="button_column">
-                    </td>
-
-                    <td class="description_column">
-
-
-                        <div class="description">FHIR error code.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                        <div>Allowed values: <code class="codeinline">incomplete</code>, <code class="codeinline">throttled</code>, <code class="codeinline">informational</code></div>
-
-
-                            <div>Example: <code class="codeinline example">invalid</code></div>
-                    </td>
-                </tr>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                                                                    </table>
-                                                                </div>
-
-
-                                        </article>
-                                    </div>
-
-                    <div id="api-Polling" class="article-section">
-                        <h2>Endpoints: Polling</h2>
-                    </div>
-                                    <div id="api-Polling-polling" class="article-section-with-sub-heading">
-                                        <article id="api-Polling-polling-0">
-                                            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-                                            <h3>Retrieve the outcome of the accepted update.</h3>
-                                            <div class="endpoint_path">
-                                                <div class="method">get</div>
-                                                <div class="pre"><pre>/Polling/{message_id}</pre></div>
-
-                                                        <div class="try"><a onclick="tryEndpointNow('/Polling/polling')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
-                                            </div>
-
-                                            <p><h4 id="overview">Overview</h4>
-<p>Use this endpoint to poll for the outcome of an updated patient record.</p>
-
-                                                <h4>Request</h4>
-
-                                                <div class="httpparams">
-                                                    <h5>Path parameters</h5>
-                                                    <table data-disablesort="true">
-                                                        <tr>
-                                                            <th>Name</th>
-                                                            <th>Description</th>
-                                                        </tr>
-                                                            <tr><td class="httpparams__name">message_id</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                <div>The message ID of the accepted update that needs to be submitted to confirm the resource a successfully updated.</div>
-
-
-
-                                                                                <div>Example: <code class="codeinline">20200522091633363041000001</code></div>
-
-                                                                        </div>
-                                                                            <div class="httpparams__required">
-                                                                                Required
-                                                                            </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                    </table>
-                                                </div>
-
-
-                                                <div class="httpparams">
-                                                    <h5>Headers</h5>
-                                                    <table data-disablesort="true">
-                                                        <tr>
-                                                            <th>Name</th>
-                                                            <th>Description</th>
-                                                        </tr>
-                                                            <tr><td class="httpparams__name">NHSD-Session-URID</td>
-                                                            <td>
-                                                                <div>
-                                                                    <div class="httpparams__description">
-                                                                        <div>
-                                                                            <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>).</div>
-
-                                                                                <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
-
-
-                                                                                <div>Example: <code class="codeinline">555021935107</code></div>
-
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                            </td>
-                                                            </tr>
-                                                    </table>
-                                                </div>
-
-
-
-                                                    <h4>Response</h4>
-
-                                                <h5>HTTP status: 200</h5>
-                                                <div>Patient updated.</div>
-
-                                                    <div class="httpparams">
-                                                        <h6>Headers</h6>
-                                                        <table data-disablesort="true">
-                                                            <tr>
-                                                                <th>Name</th>
-                                                                <th>Description</th>
-                                                            </tr>
-                                                                <tr><td class="httpparams__name">ETag</td>
-                                                                <td>
-                                                                    <div>
-                                                                        <div class="httpparams__description">
-                                                                            <div>
-                                                                                <span class="httpparams__datatype">String</span>
-
-
-
-                                                                                    <div>Record version identifier enclosed in quotes and preceded by 'W/'. For example, <code class="codeinline">W/&quot;2&quot;</code>.</p>
-<p>Corresponds to <code class="codeinline">meta.versionId</code> attribute in the patient resource body.</div>
-
-                                                                                    <div>Pattern: <code class="codeinline">/^W\/"[0-9]+"$/</code></div>
-
-
-                                                                                    <div>Example: <code class="codeinline">W/"2"</code></div>
-
-                                                                            </div>
-                                                                        </div>
-                                                                    </div>
-                                                                </td>
-                                                                </tr>
-                                                        </table>
-                                                    </div>
-
-                                                        <h6>Body</h6>
-
-
-                                                            <div class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/fhir+json</span>
-                                                            </div>
-
-
-
-
-
-                                                                <div class="body__schema__header">Schema
-                                                                    <span class="schema__header__buttons">
-                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('6282c580-f255-4590-a54e-3fddcaea0593')">Collapse all</button>
-                                                                        <button class='schemaButton js expandAll' onclick="expandAll('6282c580-f255-4590-a54e-3fddcaea0593')">Expand all</button>
-                                                                    </span>
-                                                                </div>
-                                                                <div class="body__schema" data-schema-uuid="6282c580-f255-4590-a54e-3fddcaea0593">
-                                                                    <table data-disablesort="true">
-                                                                        <thead>
-                                                                        <th colspan="2">Name</th>
-                                                                        <th>Description</th>
-                                                                        </thead>
-
-
-<tr class="expanded" data-schema-uuid="59e5c20b-b091-4340-a9c8-66727873c509" data-indentation="0" colspan="2">
-    <td style="padding-left: 0em;" class="name_column">
-
-        <div>
-            <code class="type">object</code>
-
-        </div>
-
-
-
-
-
-
-
-    </td>
-
-    <td class="button_column">
-            <button class="collapser js" data-schema-uuid="59e5c20b-b091-4340-a9c8-66727873c509" onclick="collapseChildren('59e5c20b-b091-4340-a9c8-66727873c509')"></button>
-    </td>
-
-    <td class="description_column">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    </td>
-</tr>
-
-
-    <tr class="expanded" data-schema-uuid="6cf643ea-8b4d-4aca-a120-91b34ce40055" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">resourceType</code></div>
-
-            <div>
-                <code class="type">string</code>
-
-            </div>
-
-
-
-
-            <div><code class="readonly">read-only</code></div>
-
-
-        </td>
-
-        <td class="button_column">
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">FHIR resource type.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                <div>Default: <code class="codeinline default">Patient</code></div>
-
-        </td>
-    </tr>
-
-
-
-
-
-    <tr class="expanded" data-schema-uuid="d334ec92-1ed5-4972-afd6-ebee894b88ff" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">id</code></div>
-
-            <div>
-                <code class="type">string</code>
-
-            </div>
-
-
-
-
-
-
-            <div><code class="required">required</code></div>
-        </td>
-
-        <td class="button_column">
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales. Always 10 digits and must be a <a href="https://www.datadictionary.nhs.uk/data_dictionary/attributes/n/nhs/nhs_number_de.asp">valid NHS Number</a>.</div>
-
-            <div>Pattern: <code class="codeinline pattern">^\d{10}$</code></div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                <div>Example: <code class="codeinline example">9000000009</code></div>
-        </td>
-    </tr>
-
-
-
-
-
-
-
-
-
-                                                                    </table>
-                                                                </div>
-
-
-
-                                                <h5>HTTP status: 400</h5>
-                                                <div>Client error after the patch was accepted and patient was not updated.</div>
-
-
-                                                        <h6>Body</h6>
-
-
-                                                            <div class="body__contenttype">
-                                                                <span class="body__contenttype__label">Content type: </span>
-                                                                <span class="body__contenttype__value">application/fhir+json</span>
-                                                            </div>
-
-
-
-                                                                        <div class="body__example__header">Example</div>
-
-                                                                <div class="body__example__summary">Business rule failure; start date was after the end date.</div>
-
-
-                                                                <div><pre><code>{
-  "resourceType" : "OperationOutcome",
-  "issue" : [ {
-    "severity" : "error",
-    "code" : "structure",
-    "details" : {
-      "coding" : [ {
-        "system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
-        "version" : "1",
-        "code" : "INVALID_UPDATE",
-        "display" : "Invalid update with error - business effective start date is after the end date"
-      } ]
-    }
-  } ]
-}</code></pre></div>
-
-
-                                                                <div class="body__schema__header">Schema
-                                                                    <span class="schema__header__buttons">
-                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('53ee0b10-4b9f-4a68-b010-6099408f357a')">Collapse all</button>
-                                                                        <button class='schemaButton js expandAll' onclick="expandAll('53ee0b10-4b9f-4a68-b010-6099408f357a')">Expand all</button>
-                                                                    </span>
-                                                                </div>
-                                                                <div class="body__schema" data-schema-uuid="53ee0b10-4b9f-4a68-b010-6099408f357a">
-                                                                    <table data-disablesort="true">
-                                                                        <thead>
-                                                                        <th colspan="2">Name</th>
-                                                                        <th>Description</th>
-                                                                        </thead>
-
-
-<tr class="expanded" data-schema-uuid="69a8b19b-75a0-4089-b85b-a8ed87a1e8c7" data-indentation="0" colspan="2">
-    <td style="padding-left: 0em;" class="name_column">
-
-        <div>
-            <code class="type">object</code>
-
-        </div>
-
-
-
-
-
-
-
-    </td>
-
-    <td class="button_column">
-            <button class="collapser js" data-schema-uuid="69a8b19b-75a0-4089-b85b-a8ed87a1e8c7" onclick="collapseChildren('69a8b19b-75a0-4089-b85b-a8ed87a1e8c7')"></button>
-    </td>
-
-    <td class="description_column">
-
-
-        <div class="description">Outcome of an operation that does not result in a resource or bundle being returned (e.g. error, async/batch submission).</p>
-<p>Search outcomes:</p>
-<table data-disablesort="true">
-<thead>
-<tr>
-<th>Code</th>
-<th>Response Code</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>INVALID_SEARCH_DATA</td>
-<td>400</td>
-<td>The search parameters are invalid. A description of what exactly is at fault will be added to the display.</td>
-</tr>
-<tr>
-<td>TOO_MANY_MATCHES</td>
-<td>200</td>
-<td>Too many matches were found - user should be told to refine their search parameters.</td>
-</tr>
-</tbody>
-</table></div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    </td>
-</tr>
-
-
-    <tr class="expanded" data-schema-uuid="4cf84597-4fa6-4d29-a82d-634d95f3aa24" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">resourceType</code></div>
-
-            <div>
-                <code class="type">string</code>
-
-            </div>
-
-
-
-
-            <div><code class="readonly">read-only</code></div>
-
-
-        </td>
-
-        <td class="button_column">
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">FHIR Resource Type.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                <div>Default: <code class="codeinline default">OperationOutcome</code></div>
-
-        </td>
-    </tr>
-
-
-
-
-
-    <tr class="expanded" data-schema-uuid="3696ab57-f5eb-4832-9795-f931cedd0c26" data-indentation="1" colspan="2">
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">issue</code></div>
-
-            <div>
-                <code class="type">array</code>
-
-            </div>
-
-
-
-
-
-
-
-        </td>
-
-        <td class="button_column">
-                    <button class="collapser js" data-schema-uuid="3696ab57-f5eb-4832-9795-f931cedd0c26" onclick="collapseChildren('3696ab57-f5eb-4832-9795-f931cedd0c26')"></button>
-        </td>
-
-        <td class="description_column">
-
-
-            <div class="description">List of issues that have occurred.</div>
-
-
-
-
-
-
-
-
-
-
-
-            <div>Min items: <code class="codeinline minitems">1</code></div>
-
-
-
-
-
-
-
-        </td>
-    </tr>
-
-
-
-            <tr class="expanded" data-schema-uuid="0810ddb6-572f-4c11-a39f-8640c2824045" data-indentation="2" colspan="2">
-                <td style="padding-left: 2em;" class="name_column">
-
-                    <div>
-                        <code class="type">object</code>
-
-                    </div>
-
-
-
-
-
-
-
-                </td>
-
-                <td class="button_column">
-                        <button class="collapser js" data-schema-uuid="0810ddb6-572f-4c11-a39f-8640c2824045" onclick="collapseChildren('0810ddb6-572f-4c11-a39f-8640c2824045')"></button>
-                </td>
-
-                <td class="description_column">
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                </td>
-            </tr>
-
-
-                <tr class="expanded" data-schema-uuid="13eae277-a586-4507-9414-c3d8e6c41603" data-indentation="3" colspan="2">
-                    <td style="padding-left: 3em;" class="name_column">
-                    <div><code class="propertyName">severity</code></div>
-
-                        <div>
-                            <code class="type">string</code>
-
-                        </div>
-
-
-
-
-
-
-                        <div><code class="required">required</code></div>
-                    </td>
-
-                    <td class="button_column">
-                    </td>
-
-                    <td class="description_column">
-
-
-                        <div class="description">Severity of the error.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                        <div>Allowed values: <code class="codeinline">fatal</code>, <code class="codeinline">error</code>, <code class="codeinline">warning</code>, <code class="codeinline">information</code></div>
-
-
-                            <div>Example: <code class="codeinline example">error</code></div>
-                    </td>
-                </tr>
-
-
-
-
-
-                <tr class="expanded" data-schema-uuid="862beb1d-8147-4cbd-a929-01f8d98875f5" data-indentation="3" colspan="2">
-                    <td style="padding-left: 3em;" class="name_column">
-                    <div><code class="propertyName">code</code></div>
-
-                        <div>
-                            <code class="type">string</code>
-
-                        </div>
-
-
-
-
-
-
-                        <div><code class="required">required</code></div>
-                    </td>
-
-                    <td class="button_column">
-                    </td>
-
-                    <td class="description_column">
-
-
-                        <div class="description">FHIR error code.</div>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                        <div>Allowed values: <code class="codeinline">invalid</code>, <code class="codeinline">structure</code>, <code class="codeinline">required</code>, <code class="codeinline">value</code></div>
-
-
-                            <div>Example: <code class="codeinline example">invalid</code></div>
-                    </td>
-                </tr>
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-                                                                    </table>
-                                                                </div>
-
-
-                                        </article>
-                                    </div>
-
+    <div id="api-Patients" class="article-section">
+        <h2>Endpoints: Patients</h2>
     </div>
+    <div id="api-Patients-get-patient" class="article-section-with-sub-heading">
+        <article id="api-Patients-get-patient-0">
+            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+            <h3>Retrieve a patient's resource</h3>
+            <div class="endpoint_path">
+                <div class="method">get</div>
+                <div class="pre"><pre>/Patient/{id}</pre></div>
+                <div class="try"><a onclick="tryEndpointNow('/Patients/get-patient')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
+            </div>
+            <p><h4 id="overview">Overview</h4>
+            <p>Use this endpoint to get patient details from PDS for a given NHS Number.</p>
+            <h4>Request</h4>
+            <div class="httpparams">
+                <h5>Path parameters</h5>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">id</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales.</div>
+                                        <div>Example: <code class="codeinline">9000000009</code></div>
+                                    </div>
+                                    <div class="httpparams__required">
+                                        Required
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <div class="httpparams">
+                <h5>Headers</h5>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">NHSD-Session-URID</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>).</div>
+                                        <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
+                                        <div>Example: <code class="codeinline">555021935107</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <h4>Response</h4>
+            <h5>HTTP status: 200</h5>
+            <div>Information successfully returned.</div>
+            <div class="httpparams">
+                <h6>Headers</h6>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">ETag</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>Record version identifier enclosed in quotes and preceded by 'W/'. For example, <code class="codeinline">W/&quot;2&quot;</code>.</div>
+                                        <div>Pattern: <code class="codeinline">/^W\/"[0-9]+"$/</code></div>
+                                        <div>Example: <code class="codeinline">W/"2"</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <h6>Body</h6>
+            <div class="body__contenttype">
+                <span class="body__contenttype__label">Content type: </span>
+                <span class="body__contenttype__value">application/fhir+json</span>
+            </div>
+            <div class="body__example__header">Example</div>
+            <div><pre><code>{
+"address" : [ {
+"id" : "456",
+"line" : [ "1 Trevelyan Square", "Boar Lane", "City Centre", "Leeds", "West Yorkshire" ],
+"postalCode" : "LS1 6AE",
+"use" : "home"
+} ],
+"birthDate" : "2010-10-22"
+}</code></pre></div>
+            <div class="body__schema__header">Schema
+                <span class="schema__header__buttons">
+<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+</span>
+            </div>
+            <div class="body__schema" data-schema-uuid="">
+                <table data-disablesort="true">
+                    <thead>
+                    <th>Name</th>
+                    <th>Description</th>
+                    </thead>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+                        <td style="padding-left: 0.0em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+                            <div>
+                                <code class="type">object</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">resourceType</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="readonly">read-only</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">FHIR resource type.</div>
+                            <div>Default: <code class="codeinline default">Patient</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">id</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="required">required</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales. Always 10 digits and must be a <a href="https://www.datadictionary.nhs.uk/data_dictionary/attributes/n/nhs/nhs_number_de.asp">valid NHS Number</a>.</div>
+                            <div>Pattern: <code class="codeinline pattern">^\d{10}$</code></div>
+                            <div>Example: <code class="codeinline example">9000000009</code></div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <h5>HTTP status: 400</h5>
+            <div>Invalid NHS number supplied.</div>
+            <h6>Body</h6>
+            <div class="body__contenttype">
+                <span class="body__contenttype__label">Content type: </span>
+                <span class="body__contenttype__value">application/fhir+json</span>
+            </div>
+            <div class="body__example__header">Example</div>
+            <div><pre><code>{
+"resourceType" : "OperationOutcome",
+"issue" : [ {
+"severity" : "error",
+"code" : "value",
+"details" : {
+"coding" : [ {
+"system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
+"version" : "1",
+"code" : "INVALID_RESOURCE_ID",
+"display" : "Resource Id is invalid"
+} ]
+}
+} ]
+}</code></pre></div>
+            <div class="body__schema__header">Schema
+                <span class="schema__header__buttons">
+<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+</span>
+            </div>
+            <div class="body__schema" data-schema-uuid="">
+                <table data-disablesort="true">
+                    <thead>
+                    <th>Name</th>
+                    <th>Description</th>
+                    </thead>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+                        <td style="padding-left: 0.0em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+                            <div>
+                                <code class="type">object</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">Outcome of an operation that does not result in a resource or bundle being returned (e.g. error, async/batch submission).</p>
+                                <p>Search outcomes:</p>
+                                <table data-disablesort="true">
+                                    <thead>
+                                    <tr>
+                                        <th>Code</th>
+                                        <th>Response Code</th>
+                                        <th>Description</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td>INVALID_SEARCH_DATA</td>
+                                        <td>400</td>
+                                        <td>The search parameters are invalid. A description of what exactly is at fault will be added to the display.</td>
+                                    </tr>
+                                    <tr>
+                                        <td>TOO_MANY_MATCHES</td>
+                                        <td>200</td>
+                                        <td>Too many matches were found - user should be told to refine their search parameters.</td>
+                                    </tr>
+                                    </tbody>
+                                </table></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">resourceType</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="readonly">read-only</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">FHIR Resource Type.</div>
+                            <div>Default: <code class="codeinline default">OperationOutcome</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">issue</code></div>
+                            <div>
+                                <code class="type">array</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">List of issues that have occurred.</div>
+                            <div>Min items: <code class="codeinline minitems">1</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="2" colspan="2">
+                        <td style="padding-left: 3.0em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span>
+                            <div>
+                                <code class="type">object</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </article>
+    </div>
+    <div id="api-Patients-search-patient" class="article-section-with-sub-heading">
+        <article id="api-Patients-search-patient-0">
+            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+            <h3>Search for patient</h3>
+            <div class="endpoint_path">
+                <div class="method">get</div>
+                <div class="pre"><pre>/Patient</pre></div>
+                <div class="try"><a onclick="tryEndpointNow('/Patients/search-patient')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
+            </div>
+            <p><h4 id="endpoint">Endpoint</h4>
+            <p>Use this endpoint to search for a patient in PDS.</p>
+            <h4>Request</h4>
+            <div class="httpparams">
+                <h5>Query parameters</h5>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">_exact-match</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">Boolean</span>
+                                        <div>Default value: <code class="codeinline">false</code></div>
+                                        <div>The search only returns results where the <code class="codeinline">score</code> field is 1.0.</div>
+                                        <div>Example: <code class="codeinline">true</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr><td class="httpparams__name">_history</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">Boolean</span>
+                                        <div>Default value: <code class="codeinline">false</code></div>
+                                        <div>The search looks for matches in historic information such as previous names and addresses.</div>
+                                        <div>Example: <code class="codeinline">true</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <div class="httpparams">
+                <h5>Headers</h5>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">NHSD-Session-URID</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>), specifies the role the user is acting in.</div>
+                                        <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
+                                        <div>Example: <code class="codeinline">555021935107</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr><td class="httpparams__name">Authorization</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <code class="codeinline">(^Bearer\ [[:ascii:]]+$)</code>
+                                        <div>An OAuthV2 access token presented in Bearer format.</p>
+                                            <p>Note: This parameter is required unless interacting with the Sandbox.</div>
+                                        <div>Example: <code class="codeinline">Bearer g1112R_ccQ1Ebbb4gtHBP1aaaNM</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <h4>Response</h4>
+            <h5>HTTP status: 200</h5>
+            <div>A completed search, containing zero, one, or many matching patients.</div>
+            <h6>Body</h6>
+            <div class="body__contenttype">
+                <span class="body__contenttype__label">Content type: </span>
+                <span class="body__contenttype__value">application/fhir+json</span>
+            </div>
+            <div class="body__example__header">Example</div>
+            <div><pre><code>{
+"resourceType" : "Bundle",
+"type" : "searchset",
+"timestamp" : "2019-12-25T12:00:00+00:00",
+"total" : 1,
+"entry" : [ {
+"fullUrl" : "https://beta.api.digital.nhs.uk/personal-demographics/Patient/9000000009",
+"search" : {
+"score" : 1
+}
+} ]
+}</code></pre></div>
+            <div class="body__schema__header">Schema
+                <span class="schema__header__buttons">
+<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+</span>
+            </div>
+            <div class="body__schema" data-schema-uuid="">
+                <table data-disablesort="true">
+                    <thead>
+                    <th>Name</th>
+                    <th>Description</th>
+                    </thead>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+                        <td style="padding-left: 0.0em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+                            <div>
+                                <code class="type">object</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">resourceType</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">FHIR Resource Type.</div>
+                            <div>Default: <code class="codeinline default">Bundle</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">type</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">FHIR Bundle Type.</div>
+                            <div>Default: <code class="codeinline default">searchset</code></div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <h5>HTTP status: 400</h5>
+            <div>Invalid search paramaters supplied.</div>
+            <h6>Body</h6>
+            <div class="body__contenttype">
+                <span class="body__contenttype__label">Content type: </span>
+                <span class="body__contenttype__value">application/fhir+json</span>
+            </div>
+            <div class="body__example__header">Examples</div>
+            <div class="body__example__summary">too few search params</div>
+            <div><pre><code>{
+"resourceType" : "OperationOutcome",
+"issue" : [ {
+"severity" : "error",
+"code" : "value"
+} ]
+}</code></pre></div>
+            <div class="body__example__summary">Invalid combination of search parameters</div>
+            <div><pre><code>{
+"resourceType" : "OperationOutcome",
+"issue" : [ {
+"severity" : "error",
+"code" : "value"
+} ]
+}</code></pre></div>
+            <div class="body__schema__header">Schema
+                <span class="schema__header__buttons">
+<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+</span>
+            </div>
+            <div class="body__schema" data-schema-uuid="">
+                <table data-disablesort="true">
+                    <thead>
+                    <th>Name</th>
+                    <th>Description</th>
+                    </thead>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+                        <td style="padding-left: 0.0em;" class="name_column">
+                            <div>
+                                <code class="type">object</code>
+                                <code class="format">int(32)</code>
+                            </div>
+                            <div><code class="deprecated">deprecated</code></div>
+                            <div><code class="uniqueitems">unique items</code></div>
+                            <div><code class="nullable">nullable</code></div>
+                            <div><code class="readonly">read-only</code></div>
+                            <div><code class="writeonly">write-only</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="title">Response Schema with all simple fields.</div>
+                            <div class="description">Response Test Schema Object description in <code class="codeinline">Markdown</code>.</div>
+                            <div>Pattern: <code class="codeinline pattern">^(?:[0-9]{4}-[0-9]{2}-[0-9]{2})?(?:[ T][0-9]{2}:[0-9]{2}:[0-9]{2})?(?:[.,][0-9]{3})?</code></div>
+                            <div>Multiple of: <code class="codeinline multipleof">1.2</code><div>
+                                <div>Maximum: <code class="codeinline maximum">2.2</code>
+                                    <code class="codeinline exclusivemaximum">(exclusive)</code>
+                                </div>
+                                <div>Minimum: <code class="codeinline minimum">-2.3</code>
+                                    <code class="codeinline exclusiveminimum">(exclusive)</code>
+                                </div>
+                                <div>Max length: <code class="codeinline maxlength">22</code></div>
+                                <div>Min length: <code class="codeinline minlength">11</code></div>
+                                <div>Max items: <code class="codeinline maxitems">44</code></div>
+                                <div>Min items: <code class="codeinline minitems">33</code></div>
+                                <div>Max properties: <code class="codeinline maxproperties">5</code></div>
+                                <div>Min properties: <code class="codeinline minproperties">3</code></div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </article>
+    </div>
+    <div id="api-Patients-update-patient-partial" class="article-section-with-sub-heading">
+        <article id="api-Patients-update-patient-partial-0">
+            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+            <h3>Update a patient's resource</h3>
+            <div class="endpoint_path">
+                <div class="method">patch</div>
+                <div class="pre"><pre>/Patient/{id}</pre></div>
+                <div class="try"><a onclick="tryEndpointNow('/Patients/update-patient-partial')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
+            </div>
+            <p><h4 id="overview">Overview</h4>
+            <p>Use this endpoint to update patient details in PDS.</p>
+            <h4>Request</h4>
+            <div class="httpparams">
+                <h5>Path parameters</h5>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">id</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales.</div>
+                                        <div>Example: <code class="codeinline">9000000009</code></div>
+                                    </div>
+                                    <div class="httpparams__required">
+                                        Required
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <div class="httpparams">
+                <h5>Headers</h5>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">NHSD-Session-URID</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>).</div>
+                                        <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
+                                        <div>Example: <code class="codeinline">555021935107</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr><td class="httpparams__name">If-Match</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>Latest known version identifier enclosed in quotes preceded by <code class="codeinline">W/</code>.</p>
+                                            <p>Send the value of this resource's <code class="codeinline">ETag</code> response header (or <code class="codeinline">meta.versionId</code> property) as received.</div>
+                                        <div>Pattern: <code class="codeinline">/^W\/"[0-9]+"$/</code></div>
+                                        <div>Example: <code class="codeinline">W/"2"</code></div>
+                                    </div>
+                                    <div class="httpparams__required">
+                                        Required
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <div class="httpparams">
+                <h5>Body</h5>
+                <div class="httpparams__required">Required</div>
+                <div class="body__contenttype">
+                    <span class="body__contenttype__label">Content type: </span>
+                    <span class="body__contenttype__value">application/json</span>
+                </div>
+                <div class="body__example__header">Examples</div>
+                <div class="body__example__summary">Add a new single item (deceasedDateTime) to the patient</div>
+                <div><pre><code>{
+"patches" : [ {
+"op" : "add",
+"path" : "/deceasedDateTime",
+"value" : "2010-10-22T00:00:00+00:00"
+} ]
+}</code></pre></div>
+                <div class="body__example__summary">Update the simple item (gender)</div>
+                <div><pre><code>{
+"patches" : [ {
+"op" : "replace",
+"path" : "/gender",
+"value" : "male"
+} ]
+}</code></pre></div>
+                <div class="body__schema__header">Schema
+                    <span class="schema__header__buttons">
+<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+</span>
+                </div>
+                <div class="body__schema" data-schema-uuid="">
+                    <table data-disablesort="true">
+                        <thead>
+                        <th>Name</th>
+                        <th>Description</th>
+                        </thead>
+                        <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+                            <td style="padding-left: 0.0em;" class="name_column">
+                                <div>
+                                    <code class="type">object</code>
+                                    <code class="format">int(32)</code>
+                                </div>
+                                <div><code class="deprecated">deprecated</code></div>
+                                <div><code class="uniqueitems">unique items</code></div>
+                                <div><code class="nullable">nullable</code></div>
+                                <div><code class="readonly">read-only</code></div>
+                                <div><code class="writeonly">write-only</code></div>
+                            </td>
+                            <td class="description_column">
+                                <div class="title">Request Schema with all simple fields.</div>
+                                <div class="description">Request Test Schema Object description in <code class="codeinline">Markdown</code>.</div>
+                                <div>Pattern: <code class="codeinline pattern">^(?:[0-9]{4}-[0-9]{2}-[0-9]{2})?(?:[ T][0-9]{2}:[0-9]{2}:[0-9]{2})?(?:[.,][0-9]{3})?</code></div>
+                                <div>Multiple of: <code class="codeinline multipleof">1.2</code><div>
+                                    <div>Maximum: <code class="codeinline maximum">2.2</code>
+                                        <code class="codeinline exclusivemaximum">(exclusive)</code>
+                                    </div>
+                                    <div>Minimum: <code class="codeinline minimum">-2.3</code>
+                                        <code class="codeinline exclusiveminimum">(exclusive)</code>
+                                    </div>
+                                    <div>Max length: <code class="codeinline maxlength">22</code></div>
+                                    <div>Min length: <code class="codeinline minlength">11</code></div>
+                                    <div>Max items: <code class="codeinline maxitems">44</code></div>
+                                    <div>Min items: <code class="codeinline minitems">33</code></div>
+                                    <div>Max properties: <code class="codeinline maxproperties">5</code></div>
+                                    <div>Min properties: <code class="codeinline minproperties">3</code></div>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+            <h4>Response</h4>
+            <h5>HTTP status: 202</h5>
+            <div>The patch was syntactically correct and was accepted.</div>
+            <div class="httpparams">
+                <h6>Headers</h6>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">Content-Location</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>Polling location of the update</div>
+                                        <div>Example: <code class="codeinline">/Polling/20200522091633363041_461139_1524772598</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr><td class="httpparams__name">Retry-After</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>Time to wait between polls in milliseconds</div>
+                                        <div>Example: <code class="codeinline">100</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <h5>HTTP status: 400</h5>
+            <div>Client error.</div>
+            <h6>Body</h6>
+            <div class="body__contenttype">
+                <span class="body__contenttype__label">Content type: </span>
+                <span class="body__contenttype__value">application/fhir+json</span>
+            </div>
+            <div class="body__example__header">Examples</div>
+            <div class="body__example__summary">Invalid NHS number supplied</div>
+            <div><pre><code>{
+"resourceType" : "OperationOutcome",
+"issue" : [ {
+"severity" : "error",
+"code" : "value",
+"details" : {
+"coding" : [ {
+"system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
+"version" : "1",
+"code" : "INVALID_RESOURCE_ID",
+"display" : "Resource Id is invalid"
+} ]
+}
+} ]
+}</code></pre></div>
+            <div class="body__example__summary">No patches submitted</div>
+            <div><pre><code>{
+"resourceType" : "OperationOutcome",
+"issue" : [ {
+"severity" : "error",
+"code" : "required",
+"details" : {
+"coding" : [ {
+"system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
+"version" : "1",
+"code" : "MISSING_VALUE",
+"display" : "Missing value - patches"
+} ]
+}
+} ]
+}</code></pre></div>
+            <div class="body__schema__header">Schema
+                <span class="schema__header__buttons">
+<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+</span>
+            </div>
+            <div class="body__schema" data-schema-uuid="">
+                <table data-disablesort="true">
+                    <thead>
+                    <th>Name</th>
+                    <th>Description</th>
+                    </thead>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+                        <td style="padding-left: 0.0em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+                            <div>
+                                <code class="type">object</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">Outcome of an operation that does not result in a resource or bundle being returned (e.g. error, async/batch submission).</p>
+                                <p>Search outcomes:</p>
+                                <table data-disablesort="true">
+                                    <thead>
+                                    <tr>
+                                        <th>Code</th>
+                                        <th>Response Code</th>
+                                        <th>Description</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td>INVALID_SEARCH_DATA</td>
+                                        <td>400</td>
+                                        <td>The search parameters are invalid. A description of what exactly is at fault will be added to the display.</td>
+                                    </tr>
+                                    <tr>
+                                        <td>TOO_MANY_MATCHES</td>
+                                        <td>200</td>
+                                        <td>Too many matches were found - user should be told to refine their search parameters.</td>
+                                    </tr>
+                                    </tbody>
+                                </table></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">resourceType</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="readonly">read-only</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">FHIR Resource Type.</div>
+                            <div>Default: <code class="codeinline default">OperationOutcome</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">issue</code></div>
+                            <div>
+                                <code class="type">array</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">List of issues that have occurred.</div>
+                            <div>Min items: <code class="codeinline minitems">1</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="2" colspan="2">
+                        <td style="padding-left: 3.0em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 35.4%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span>
+                            <div>
+                                <code class="type">object</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
+                        <td style="padding-left: 4.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
+                            <div><code class="propertyName">severity</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="required">required</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">Severity of the error.</div>
+                            <div>Allowed values: <code class="codeinline">fatal</code>, <code class="codeinline">error</code>, <code class="codeinline">warning</code>, <code class="codeinline">information</code></div>
+                            <div>Example: <code class="codeinline example">error</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
+                        <td style="padding-left: 4.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
+                            <div><code class="propertyName">code</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="required">required</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">FHIR error code.</div>
+                            <div>Allowed values: <code class="codeinline">incomplete</code>, <code class="codeinline">throttled</code>, <code class="codeinline">informational</code></div>
+                            <div>Example: <code class="codeinline example">invalid</code></div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </article>
+    </div>
+    <div id="api-Polling" class="article-section">
+        <h2>Endpoints: Polling</h2>
+    </div>
+    <div id="api-Polling-polling" class="article-section-with-sub-heading">
+        <article id="api-Polling-polling-0">
+            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+            <h3>Retrieve the outcome of the accepted update.</h3>
+            <div class="endpoint_path">
+                <div class="method">get</div>
+                <div class="pre"><pre>/Polling/{message_id}</pre></div>
+                <div class="try"><a onclick="tryEndpointNow('/Polling/polling')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
+            </div>
+            <p><h4 id="overview">Overview</h4>
+            <p>Use this endpoint to poll for the outcome of an updated patient record.</p>
+            <h4>Request</h4>
+            <div class="httpparams">
+                <h5>Path parameters</h5>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">message_id</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>The message ID of the accepted update that needs to be submitted to confirm the resource a successfully updated.</div>
+                                        <div>Example: <code class="codeinline">20200522091633363041000001</code></div>
+                                    </div>
+                                    <div class="httpparams__required">
+                                        Required
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <div class="httpparams">
+                <h5>Headers</h5>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">NHSD-Session-URID</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>).</div>
+                                        <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
+                                        <div>Example: <code class="codeinline">555021935107</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <h4>Response</h4>
+            <h5>HTTP status: 200</h5>
+            <div>Patient updated.</div>
+            <div class="httpparams">
+                <h6>Headers</h6>
+                <table data-disablesort="true">
+                    <tr>
+                        <th>Name</th>
+                        <th>Description</th>
+                    </tr>
+                    <tr><td class="httpparams__name">ETag</td>
+                        <td>
+                            <div>
+                                <div class="httpparams__description">
+                                    <div>
+                                        <span class="httpparams__datatype">String</span>
+                                        <div>Record version identifier enclosed in quotes and preceded by 'W/'. For example, <code class="codeinline">W/&quot;2&quot;</code>.</p>
+                                            <p>Corresponds to <code class="codeinline">meta.versionId</code> attribute in the patient resource body.</div>
+                                        <div>Pattern: <code class="codeinline">/^W\/"[0-9]+"$/</code></div>
+                                        <div>Example: <code class="codeinline">W/"2"</code></div>
+                                    </div>
+                                </div>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <h6>Body</h6>
+            <div class="body__contenttype">
+                <span class="body__contenttype__label">Content type: </span>
+                <span class="body__contenttype__value">application/fhir+json</span>
+            </div>
+            <div class="body__schema__header">Schema
+                <span class="schema__header__buttons">
+<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+</span>
+            </div>
+            <div class="body__schema" data-schema-uuid="">
+                <table data-disablesort="true">
+                    <thead>
+                    <th>Name</th>
+                    <th>Description</th>
+                    </thead>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+                        <td style="padding-left: 0.0em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+                            <div>
+                                <code class="type">object</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">resourceType</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="readonly">read-only</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">FHIR resource type.</div>
+                            <div>Default: <code class="codeinline default">Patient</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">id</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="required">required</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales. Always 10 digits and must be a <a href="https://www.datadictionary.nhs.uk/data_dictionary/attributes/n/nhs/nhs_number_de.asp">valid NHS Number</a>.</div>
+                            <div>Pattern: <code class="codeinline pattern">^\d{10}$</code></div>
+                            <div>Example: <code class="codeinline example">9000000009</code></div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+            <h5>HTTP status: 400</h5>
+            <div>Client error after the patch was accepted and patient was not updated.</div>
+            <h6>Body</h6>
+            <div class="body__contenttype">
+                <span class="body__contenttype__label">Content type: </span>
+                <span class="body__contenttype__value">application/fhir+json</span>
+            </div>
+            <div class="body__example__header">Example</div>
+            <div class="body__example__summary">Business rule failure; start date was after the end date.</div>
+            <div><pre><code>{
+"resourceType" : "OperationOutcome",
+"issue" : [ {
+"severity" : "error",
+"code" : "structure",
+"details" : {
+"coding" : [ {
+"system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
+"version" : "1",
+"code" : "INVALID_UPDATE",
+"display" : "Invalid update with error - business effective start date is after the end date"
+} ]
+}
+} ]
+}</code></pre></div>
+            <div class="body__schema__header">Schema
+                <span class="schema__header__buttons">
+<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+</span>
+            </div>
+            <div class="body__schema" data-schema-uuid="">
+                <table data-disablesort="true">
+                    <thead>
+                    <th>Name</th>
+                    <th>Description</th>
+                    </thead>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+                        <td style="padding-left: 0.0em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+                            <div>
+                                <code class="type">object</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">Outcome of an operation that does not result in a resource or bundle being returned (e.g. error, async/batch submission).</p>
+                                <p>Search outcomes:</p>
+                                <table data-disablesort="true">
+                                    <thead>
+                                    <tr>
+                                        <th>Code</th>
+                                        <th>Response Code</th>
+                                        <th>Description</th>
+                                    </tr>
+                                    </thead>
+                                    <tbody>
+                                    <tr>
+                                        <td>INVALID_SEARCH_DATA</td>
+                                        <td>400</td>
+                                        <td>The search parameters are invalid. A description of what exactly is at fault will be added to the display.</td>
+                                    </tr>
+                                    <tr>
+                                        <td>TOO_MANY_MATCHES</td>
+                                        <td>200</td>
+                                        <td>Too many matches were found - user should be told to refine their search parameters.</td>
+                                    </tr>
+                                    </tbody>
+                                </table></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">resourceType</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="readonly">read-only</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">FHIR Resource Type.</div>
+                            <div>Default: <code class="codeinline default">OperationOutcome</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+                        <td style="padding-left: 1.5em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+                            <div><code class="propertyName">issue</code></div>
+                            <div>
+                                <code class="type">array</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">List of issues that have occurred.</div>
+                            <div>Min items: <code class="codeinline minitems">1</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="2" colspan="2">
+                        <td style="padding-left: 3.0em;" class="name_column">
+                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 35.4%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span>
+                            <div>
+                                <code class="type">object</code>
+                            </div>
+                        </td>
+                        <td class="description_column">
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
+                        <td style="padding-left: 4.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
+                            <div><code class="propertyName">severity</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="required">required</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">Severity of the error.</div>
+                            <div>Allowed values: <code class="codeinline">fatal</code>, <code class="codeinline">error</code>, <code class="codeinline">warning</code>, <code class="codeinline">information</code></div>
+                            <div>Example: <code class="codeinline example">error</code></div>
+                        </td>
+                    </tr>
+                    <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
+                        <td style="padding-left: 4.5em;" class="name_column">
+                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
+                            <div><code class="propertyName">code</code></div>
+                            <div>
+                                <code class="type">string</code>
+                            </div>
+                            <div><code class="required">required</code></div>
+                        </td>
+                        <td class="description_column">
+                            <div class="description">FHIR error code.</div>
+                            <div>Allowed values: <code class="codeinline">invalid</code>, <code class="codeinline">structure</code>, <code class="codeinline">required</code>, <code class="codeinline">value</code></div>
+                            <div>Example: <code class="codeinline example">invalid</code></div>
+                        </td>
+                    </tr>
+                </table>
+            </div>
+        </article>
+    </div>
+</div>

--- a/repository-data/webfiles/src/main/resources/site/src/scss/components/_api-specification.scss
+++ b/repository-data/webfiles/src/main/resources/site/src/scss/components/_api-specification.scss
@@ -167,6 +167,7 @@
 
     button.collapser, button.expander {
         float:left;
+        position: absolute;
         width: 2em;
         height: 2em;
     }
@@ -179,10 +180,80 @@
     table th,
     table td.name_column {
         word-break: normal;
+        position: relative;
+        div {
+            padding-left: 1.75em;
+        }
     }
 
     table td.button_column {
         width: 42px;
+    }
+
+    .vertical-schema-border {
+        position: absolute;
+        content: ' ';
+        height: 110%;
+        background:  hsl(210, 60%, var(--border-lightness));
+        width: 5px;
+        margin-top: -13px !important;
+        margin-left: var(--border-padding);
+    }
+
+    .short-vertical-schema-border {
+        position: absolute;
+        content: ' ';
+        height: 26px;
+        background: hsl(210, 60%, var(--border-lightness));
+        width: 5px;
+        margin-top: -13px !important;
+        margin-left: var(--border-padding);
+        border-bottom-left-radius: 100px;
+    }
+
+    .horizontal-schema-border {
+        position: absolute;
+        content: " ";
+        margin-left: var(--border-padding);
+        width: 2.5em;
+        height: 5px;
+        background: hsl(210, 60%, var(--border-lightness));
+        margin-top: .75em;
+        z-index: -1;
+        border-top-right-radius: 100px;
+        border-bottom-right-radius: 100px;
+    }
+
+    .short-horizontal-schema-border {
+        position: absolute;
+        content: " ";
+        margin-left: var(--border-padding);
+        width: 1.85em;
+        height: 5px;
+        background: hsl(210, 60%, var(--border-lightness));
+        margin-top: .75em;
+        z-index: -1;
+        border-bottom-left-radius: 100px;
+    }
+
+    .child-schema-border {
+        position: absolute;
+        content: " ";
+        background: hsl(210, 60%, var(--border-lightness));
+        width: 5px;
+        margin-left: var(--border-padding);
+        height: 100%;
+        top: 3px;
+        z-index: -1;
+        border-bottom-left-radius: 100px;
+    }
+
+    .expander ~ .child-schema-border {
+        display: none;
+    }
+
+    .name_column :not([class*="schema-border"]) {
+        margin-left: .5em;
     }
 
     /*


### PR DESCRIPTION
Changes to implement rendering of a tree diagram alongside the schema, to further indicate nesting. Said tree diagram is made up of absolutely-positioned divs, referred to in code as "borders". The tree diagram ties in visually to expander/collapser buttons, which have been moved to the left of the name column. Each indented level has lighting and padding set as CSS vars.

![image](https://user-images.githubusercontent.com/48717159/119130100-a6d2e380-ba2f-11eb-983d-45a7a72f3cc6.png)

The main bit of work is in introducing the BorderHelper. I have also updated the UUIDHelper to implement the Helper interface, and the IndentationHelper to let it return a weighted indentation value (useful for controlling the amount of padding between 'indentations').