### PR TITLE
[ADZ-1178] First version working preview create and base changed

### DIFF
--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/pages/apispecification.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/pages/apispecification.yaml
@@ -8,6 +8,13 @@ definitions:
         jcr:primaryType: hst:component
       hst:referencecomponent: hst:abstractpages/apppage
       jcr:primaryType: hst:component
+    /hst:hst/hst:configurations/common/hst:pages/api-catalogue-preview:
+      /main:
+        hst:componentclassname: uk.nhs.digital.common.components.apicatalogue.ApiCatalogueComponent
+        hst:template: api-catalogue-preview
+        jcr:primaryType: hst:component
+      hst:referencecomponent: hst:abstractpages/nhsd-apppage
+      jcr:primaryType: hst:component
     /hst:hst/hst:configurations/common/hst:pages/apispecification:
       /main:
         hst:componentclassname: uk.nhs.digital.common.components.ApiSpecificationComponent

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
@@ -338,6 +338,10 @@ definitions:
             hst:componentconfigurationid: hst:pages/api-catalogue
             hst:relativecontentpath: ${parent}/content
             jcr:primaryType: hst:sitemapitem
+          /preview:
+            hst:componentconfigurationid: hst:pages/api-catalogue-preview
+            hst:relativecontentpath: ${parent}/preview
+            jcr:primaryType: hst:sitemapitem
           hst:relativecontentpath: developer/api-catalogue
           jcr:primaryType: hst:sitemapitem
         hst:componentconfigurationid: hst:pages/nhsd-developer-hub

--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/templates.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/templates.yaml
@@ -11,6 +11,9 @@ definitions:
       /api-catalogue:
         hst:renderpath: webfile:/freemarker/common/api-catalogue.ftl
         jcr:primaryType: hst:template
+      /api-catalogue-preview:
+        hst:renderpath: webfile:/freemarker/common/api-catalogue-preview.ftl
+        jcr:primaryType: hst:template
       /apiendpoint-article:
         hst:renderpath: webfile:/freemarker/common/apiendpoint-article.ftl
         jcr:primaryType: hst:template

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/api-catalogue-preview.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/api-catalogue-preview.ftl
@@ -1,0 +1,67 @@
+<#ftl output_format="HTML">
+<#include "../include/imports.ftl">
+<#include "macro/metaTags.ftl">
+<#include "macro/contentPixel.ftl">
+<#include "macro/scrollableFilterNav.ftl">
+<#include "macro/apiCatalogueEntries.ftl">
+<#include "macro/component/lastModified.ftl">
+<#include "macro/svgIcons.ftl">
+
+<#-- @ftlvariable name="document" type="uk.nhs.digital.website.beans.ComponentList" -->
+<#-- @ftlvariable name="filtersModel" type="uk.nhs.digital.common.components.apicatalogue.filters.Filters" -->
+<#-- @ftlvariable name="section" type="uk.nhs.digital.common.components.apicatalogue.filters.Section" -->
+<#-- @ftlvariable name="filter" type="uk.nhs.digital.common.components.apicatalogue.filters.Subsection" -->
+
+<#-- Add meta tags -->
+<@metaTags></@metaTags>
+<#-- Content Page Pixel -->
+<@contentPixel document.getCanonicalUUID() document.title></@contentPixel>
+
+<article class="article article--filtered-list api-catalogue">
+    <div class="grid-wrapper grid-wrapper--article">
+        <div class="grid-row">
+            <div class="column column--two-thirds column--reset">
+                <div class="article-header article-header--secondary">
+                    <h1 data-uipath="document.title">${document.title}</h1>
+                </div>
+            </div>
+        </div>
+        APi Catalogue - Preview
+        <div class="grid-row">
+            <div class="column column--two-thirds column--reset">
+                <#-- [FTL-BEGIN] 'Summary and optional Body' sections -->
+                <div id="section-summary" class="article-section article-section--summary  no-border">
+                    <div class="grid-row">
+                        <div class="column column--reset">
+                            <div class="rich-text-content">
+                                <div data-uipath="website.linkslist.summary"><@hst.html hippohtml=document.summary contentRewriter=gaContentRewriter/></div>
+                                <#if document.body?has_content??>
+                                    <@hst.html hippohtml=document.body contentRewriter=gaContentRewriter/>
+                                </#if>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <#-- [FTL-END] 'Summary and optional Body' sections -->
+            </div>
+        </div>
+
+        <#assign alphabetical_hash = group_blocks(flat_blocks(apiCatalogueLinks true))/>
+
+        <#if alphabetical_hash??>
+            <div class="grid-row">
+                <div class="column column--one-third page-block page-block--sidebar sticky sticky--top">
+                    <@scrollableFilterNav alphabetical_hash filtersModel></@scrollableFilterNav>
+                </div>
+
+                <div class="column column--two-thirds page-block page-block--main">
+                    <@apiCatalogueEntries alphabetical_hash filtersModel></@apiCatalogueEntries>
+                    <div class="article-section muted">
+                        <@lastModified document.lastModified false></@lastModified>
+                    </div>
+                </div>
+            </div>
+
+        </#if>
+    </div>
+</article>


### PR DESCRIPTION
Creating preview page with new templates - Header and Footer. 
Only accessible at api-catalogue/preview.
