### PR TITLE
[ADZ-1219] OAS spec import and rerender fix

### DIFF
--- a/cms/src/test/java/uk/nhs/digital/apispecs/swagger/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/swagger/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest.java
@@ -70,7 +70,7 @@ public class SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest {
         // given
         final String incompleteSpecificationJson = from("oasV3_incomplete_no_components-field.json");
 
-        final String expectedSpecHtml = from("oasV3_complete.html");
+        final String expectedSpecHtml = from("oasV3_incomplete_no_components-field.html");
 
         // when
         final String actualSpecHtml = swaggerCodeGenApiSpecHtmlProvider.htmlFrom(incompleteSpecificationJson);

--- a/cms/src/test/resources/test-data/api-specifications/ApiSpecSyncFromApigeeJobIntegrationTest/oasV3_complete.json
+++ b/cms/src/test/resources/test-data/api-specifications/ApiSpecSyncFromApigeeJobIntegrationTest/oasV3_complete.json
@@ -106,6 +106,11 @@
                                             "type": "string",
                                             "description": "FHIR Bundle Type.",
                                             "default": "searchset"
+                                        },
+                                        "deathDateTime" : {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "example": "2021-04-22T10:00:00+00:00"
                                         }
                                     }
                                 },
@@ -790,6 +795,11 @@
                         "type": "string",
                         "pattern": "^\\d{10}$",
                         "example": "9000000009"
+                    },
+                    "deathDateTime" : {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2021-04-22T10:00:00+00:00"
                     }
                 }
             }

--- a/cms/src/test/resources/test-data/api-specifications/SchemaHelperTest/schemaObjectsMultiLevelHierarchy-properties.html
+++ b/cms/src/test/resources/test-data/api-specifications/SchemaHelperTest/schemaObjectsMultiLevelHierarchy-properties.html
@@ -1,82 +1,89 @@
-<tr>
-    <td style="padding-left: 0em;" class="name_column">
-        <div>
-            <code class="type">object</code>
-        </div>
+<tr class="expanded" data-schema-uuid="d605a7b6-ccc5-4274-be0f-2158f10af67c" data-indentation="0" colspan="2">
+    <td style="padding-left: 0.0em;" class="name_column">
+    <button class="collapser js" data-schema-uuid="d605a7b6-ccc5-4274-be0f-2158f10af67c" onclick="collapseChildren('d605a7b6-ccc5-4274-be0f-2158f10af67c')"></button>
+    <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+    <div>
+        <code class="type">object</code>
+    </div>
     </td>
     <td class="description_column">
         <div class="title">top-level schema 0</div>
     </td>
 </tr>
-    <tr>
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">properties-schema-1-1</code></div>
-            <div>
-                <code class="type">object</code>
+<tr class="expanded" data-schema-uuid="15a60851-a2dc-4673-9982-942c5f958394" data-indentation="1" colspan="2">
+    <td style="padding-left: 1.5em;" class="name_column">
+    <button class="collapser js" data-schema-uuid="15a60851-a2dc-4673-9982-942c5f958394" onclick="collapseChildren('15a60851-a2dc-4673-9982-942c5f958394')"></button>
+    <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+    <div><code class="propertyName">properties-schema-1-1</code></div>
+    <div>
+        <code class="type">object</code>
+    </div>
+    </td>
+    <td class="description_column">
+        <div class="title">properties schema 1-1</div>
+    </td>
+</tr>
+<tr class="expanded" data-schema-uuid="f496544f-b459-4c18-a85c-d806d1684500" data-indentation="2" colspan="2">
+    <td style="padding-left: 3.0em;" class="name_column">
+    <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="vertical-schema-border" style="--border-padding: -1.75em; --border-lightness: 31.4%"></span>
+    <div><code class="propertyName">properties-schema-1-1-1</code></div>
+    <div>
+        <code class="type">object</code>
+        <code class="format">float</code>
+    </div>
+    <div><code class="deprecated">deprecated</code></div>
+    <div><code class="uniqueitems">unique items</code></div>
+    <div><code class="nullable">nullable</code></div>
+    <div><code class="readonly">read-only</code></div>
+    <div><code class="writeonly">write-only</code></div>
+    </td>
+    <td class="description_column">
+        <div class="title">properties schema 1-1-1</div>
+        <div class="description">Test Schema Object description in <code>Markdown rendered to HTML</code>.</div>
+        <div>Pattern: <code class="codeinline pattern">^(?:[1])?</code></div>
+        <div>Multiple of: <code class="codeinline multipleof">1.3</code><div>
+            <div>Maximum: <code class="codeinline maximum">2.5</code>
+                <code class="codeinline exclusivemaximum">(exclusive)</code>
             </div>
-        </td>
-        <td class="description_column">
-            <div class="title">properties schema 1-1</div>
-        </td>
-    </tr>
-        <tr>
-            <td style="padding-left: 2em;" class="name_column">
-            <div><code class="propertyName">properties-schema-1-1-1</code></div>
-                <div>
-                    <code class="type">object</code>
-                    <code class="format">float</code>
-                </div>
-                <div><code class="deprecated">deprecated</code></div>
-                <div><code class="uniqueitems">unique items</code></div>
-                <div><code class="nullable">nullable</code></div>
-                <div><code class="readonly">read-only</code></div>
-                <div><code class="writeonly">write-only</code></div>
-            </td>
-            <td class="description_column">
-                <div class="title">properties schema 1-1-1</div>
-                <div class="description">Test Schema Object description in <code>Markdown rendered to HTML</code>.</div>
-                <div>Pattern: <code class="codeinline pattern">^(?:[1])?</code></div>
-                <div>Multiple of: <code class="codeinline multipleof">1.3</code><div>
-                <div>Maximum: <code class="codeinline maximum">2.5</code>
-                    <code class="codeinline exclusivemaximum">(exclusive)</code>
-                </div>
-                <div>Minimum: <code class="codeinline minimum">-2.4</code>
-                    <code class="codeinline exclusiveminimum">(inclusive)</code>
-                </div>
-                <div>Max length: <code class="codeinline maxlength">23</code></div>
-                <div>Min length: <code class="codeinline minlength">12</code></div>
-                <div>Max items: <code class="codeinline maxitems">45</code></div>
-                <div>Min items: <code class="codeinline minitems">36</code></div>
-                <div>Max properties: <code class="codeinline maxproperties">6</code></div>
-                <div>Min properties: <code class="codeinline minproperties">4</code></div>
-                <div>Allowed values: <code class="codeinline">enum-a</code>, <code class="codeinline">enum-b</code></div>
-                    <div>Default: <pre><code>{
-  &quot;property&quot; : &quot;default value&quot;
-}</code></pre></div>
-                    <div>Example: <pre><code>{
-  &quot;property&quot; : &quot;example value&quot;
-}</code></pre></div>
-            </td>
-        </tr>
-        <tr>
-            <td style="padding-left: 2em;" class="name_column">
-            <div><code class="propertyName">properties-schema-1-1-2</code></div>
-                <div>
-                    <code class="type">object</code>
-                </div>
-            </td>
-            <td class="description_column">
-                <div class="title">properties schema 1-1-2</div>
-            </td>
-        </tr>
-    <tr>
-        <td style="padding-left: 1em;" class="name_column">
-        <div><code class="propertyName">properties-schema-1-2</code></div>
-            <div>
-                <code class="type">object</code>
+            <div>Minimum: <code class="codeinline minimum">-2.4</code>
+                <code class="codeinline exclusiveminimum">(inclusive)</code>
             </div>
-        </td>
-        <td class="description_column">
-            <div class="title">properties schema 1-2</div>
-        </td>
-    </tr>
+            <div>Max length: <code class="codeinline maxlength">23</code></div>
+            <div>Min length: <code class="codeinline minlength">12</code></div>
+            <div>Max items: <code class="codeinline maxitems">45</code></div>
+            <div>Min items: <code class="codeinline minitems">36</code></div>
+            <div>Max properties: <code class="codeinline maxproperties">6</code></div>
+            <div>Min properties: <code class="codeinline minproperties">4</code></div>
+            <div>Allowed values: <code class="codeinline">enum-a</code>, <code class="codeinline">enum-b</code></div>
+            <div>Default: <pre><code>{
+&quot;property&quot; : &quot;default value&quot;
+}</code></pre></div>
+            <div>Example: <pre><code>{
+&quot;property&quot; : &quot;example value&quot;
+}</code></pre></div>
+    </td>
+</tr>
+<tr class="expanded" data-schema-uuid="e8678f72-48bf-4e64-9170-6f104ae9234c" data-indentation="2" colspan="2">
+    <td style="padding-left: 3.0em;" class="name_column">
+    <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="vertical-schema-border" style="--border-padding: -1.75em; --border-lightness: 31.4%"></span>
+    <div><code class="propertyName">properties-schema-1-1-2</code></div>
+    <div>
+        <code class="type">object</code>
+    </div>
+    </td>
+    <td class="description_column">
+        <div class="title">properties schema 1-1-2</div>
+    </td>
+</tr>
+<tr class="expanded" data-schema-uuid="5bfd2b4f-762c-4a93-88ee-54d4d0842198" data-indentation="1" colspan="2">
+    <td style="padding-left: 1.5em;" class="name_column">
+    <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+    <div><code class="propertyName">properties-schema-1-2</code></div>
+    <div>
+        <code class="type">object</code>
+    </div>
+    </td>
+    <td class="description_column">
+        <div class="title">properties schema 1-2</div>
+    </td>
+</tr>

--- a/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/oasV3_complete.html
+++ b/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/oasV3_complete.html
@@ -1,16 +1,16 @@
 <div class="column column--one-third page-block--sticky-nav page-block--sidebar article-section-nav-outer-wrapper apispecification">
-    <!-- start sticky-nav -->
-    <div id="sticky-nav">
-        <div class="article-section-nav-wrapper">
-            <div class="article-section-nav">
-                <h2 class="article-section-nav__title">Page contents</h2>
-                <div class="scrollable-component">
-                    <nav>
-                        <ol class="article-section-nav__list">
-                            <li>
-                                <a href="#top" aria-label="Scroll to 'Top of page'"
-                                   title="Scroll to 'Top of page'">Top of page</a>
-                            </li>
+<!-- start sticky-nav -->
+<div id="sticky-nav">
+    <div class="article-section-nav-wrapper">
+        <div class="article-section-nav">
+            <h2 class="article-section-nav__title">Page contents</h2>
+            <div class="scrollable-component">
+                <nav>
+                    <ol class="article-section-nav__list">
+                        <li>
+                            <a href="#top" aria-label="Scroll to 'Top of page'"
+                               title="Scroll to 'Top of page'">Top of page</a>
+                        </li>
                             <li>
                                 <a href="#api-description__overview"
                                    aria-label="Scroll to 'Overview'"
@@ -21,1186 +21,1199 @@
                                    aria-label="Scroll to 'Legal use'"
                                    title="Scroll to 'Legal use'">Legal use</a>
                             </li>
-                            <li>
-                                <a href="#api-Patients"
-                                   aria-label="Endpoints: Patients"
-                                   title="Endpoints: Patients">Endpoints: Patients</a>
-                            </li>
-                            <li class="section-numbered">
-                                <a href="#api-Patients-get-patient"
-                                   aria-label="get-patient"
-                                   title="get-patient">Retrieve a patient's resource</a>
-                            </li>
-                            <li class="section-numbered">
-                                <a href="#api-Patients-search-patient"
-                                   aria-label="search-patient"
-                                   title="search-patient">Search for patient</a>
-                            </li>
-                            <li class="section-numbered">
-                                <a href="#api-Patients-update-patient-partial"
-                                   aria-label="update-patient-partial"
-                                   title="update-patient-partial">Update a patient's resource</a>
-                            </li>
-                            <li>
-                                <a href="#api-Polling"
-                                   aria-label="Endpoints: Polling"
-                                   title="Endpoints: Polling">Endpoints: Polling</a>
-                            </li>
-                            <li class="section-numbered">
-                                <a href="#api-Polling-polling"
-                                   aria-label="polling"
-                                   title="polling">Retrieve the outcome of the accepted update.</a>
-                            </li>
-                        </ol>
-                    </nav>
-                </div>
+                                        <li>
+                                            <a href="#api-Patients"
+                                               aria-label="Endpoints: Patients"
+                                               title="Endpoints: Patients">Endpoints: Patients</a>
+                                        </li>
+                                        <li class="section-numbered">
+                                            <a href="#api-Patients-get-patient"
+                                               aria-label="get-patient"
+                                               title="get-patient">Retrieve a patient's resource</a>
+                                        </li>
+                                        <li class="section-numbered">
+                                            <a href="#api-Patients-search-patient"
+                                               aria-label="search-patient"
+                                               title="search-patient">Search for patient</a>
+                                        </li>
+                                        <li class="section-numbered">
+                                            <a href="#api-Patients-update-patient-partial"
+                                               aria-label="update-patient-partial"
+                                               title="update-patient-partial">Update a patient's resource</a>
+                                        </li>
+                                        <li>
+                                            <a href="#api-Polling"
+                                               aria-label="Endpoints: Polling"
+                                               title="Endpoints: Polling">Endpoints: Polling</a>
+                                        </li>
+                                        <li class="section-numbered">
+                                            <a href="#api-Polling-polling"
+                                               aria-label="polling"
+                                               title="polling">Retrieve the outcome of the accepted update.</a>
+                                        </li>
+                    </ol>
+                </nav>
             </div>
         </div>
     </div>
-    <!-- end sticky-nav -->
+</div>
+<!-- end sticky-nav -->
 </div>
 <div id="content" class="column column--two-thirds page-block page-block--main apispecification" aria-label="Document content">
     <!-- API Title: Personal Demographics Service (FHIR) API -->
     <div id="api-description" class="article-section">
         <h2 id="api-description__overview">Overview</h2>
-        <p>Use this API to access the <a href="https://digital.nhs.uk/services/demographics">Personal Demographics Service (PDS)</a></p>
-        <h2 id="api-description__legal-use">Legal use</h2>
-        <p>This API can only be used where there is a legal basis.
+<p>Use this API to access the <a href="https://digital.nhs.uk/services/demographics">Personal Demographics Service (PDS)</a></p>
+<h2 id="api-description__legal-use">Legal use</h2>
+<p>This API can only be used where there is a legal basis.
     </div>
-    <div id="api-Patients" class="article-section">
-        <h2>Endpoints: Patients</h2>
-    </div>
-    <div id="api-Patients-get-patient" class="article-section-with-sub-heading">
-        <article id="api-Patients-get-patient-0">
-            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-            <h3>Retrieve a patient's resource</h3>
-            <div class="endpoint_path">
-                <div class="method">get</div>
-                <div class="pre"><pre>/Patient/{id}</pre></div>
-                <div class="try"><a onclick="tryEndpointNow('/Patients/get-patient')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
-            </div>
-            <p><h4 id="overview">Overview</h4>
-            <p>Use this endpoint to get patient details from PDS for a given NHS Number.</p>
-            <h4>Request</h4>
-            <div class="httpparams">
-                <h5>Path parameters</h5>
-                <table data-disablesort="true">
-                    <tr>
-                        <th>Name</th>
-                        <th>Description</th>
-                    </tr>
-                    <tr><td class="httpparams__name">id</td>
-                        <td>
-                            <div>
-                                <div class="httpparams__description">
-                                    <div>
-                                        <span class="httpparams__datatype">String</span>
-                                        <div>The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales.</div>
-                                        <div>Example: <code class="codeinline">9000000009</code></div>
-                                    </div>
-                                    <div class="httpparams__required">
-                                        Required
-                                    </div>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-            <div class="httpparams">
-                <h5>Headers</h5>
-                <table data-disablesort="true">
-                    <tr>
-                        <th>Name</th>
-                        <th>Description</th>
-                    </tr>
-                    <tr><td class="httpparams__name">NHSD-Session-URID</td>
-                        <td>
-                            <div>
-                                <div class="httpparams__description">
-                                    <div>
-                                        <span class="httpparams__datatype">String</span>
-                                        <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>).</div>
-                                        <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
-                                        <div>Example: <code class="codeinline">555021935107</code></div>
-                                    </div>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-            <h4>Response</h4>
-            <h5>HTTP status: 200</h5>
-            <div>Information successfully returned.</div>
-            <div class="httpparams">
-                <h6>Headers</h6>
-                <table data-disablesort="true">
-                    <tr>
-                        <th>Name</th>
-                        <th>Description</th>
-                    </tr>
-                    <tr><td class="httpparams__name">ETag</td>
-                        <td>
-                            <div>
-                                <div class="httpparams__description">
-                                    <div>
-                                        <span class="httpparams__datatype">String</span>
-                                        <div>Record version identifier enclosed in quotes and preceded by 'W/'. For example, <code class="codeinline">W/&quot;2&quot;</code>.</div>
-                                        <div>Pattern: <code class="codeinline">/^W\/"[0-9]+"$/</code></div>
-                                        <div>Example: <code class="codeinline">W/"2"</code></div>
-                                    </div>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-            <h6>Body</h6>
-            <div class="body__contenttype">
-                <span class="body__contenttype__label">Content type: </span>
-                <span class="body__contenttype__value">application/fhir+json</span>
-            </div>
-            <div class="body__example__header">Example</div>
-            <div><pre><code>{
-"address" : [ {
-"id" : "456",
-"line" : [ "1 Trevelyan Square", "Boar Lane", "City Centre", "Leeds", "West Yorkshire" ],
-"postalCode" : "LS1 6AE",
-"use" : "home"
-} ],
-"birthDate" : "2010-10-22"
+                    <div id="api-Patients" class="article-section">
+                        <h2>Endpoints: Patients</h2>
+                    </div>
+                                    <div id="api-Patients-get-patient" class="article-section-with-sub-heading">
+                                        <article id="api-Patients-get-patient-0">
+                                            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+                                            <h3>Retrieve a patient's resource</h3>
+                                            <div class="endpoint_path">
+                                                <div class="method">get</div>
+                                                <div class="pre"><pre>/Patient/{id}</pre></div>
+                                                        <div class="try"><a onclick="tryEndpointNow('/Patients/get-patient')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
+                                            </div>
+                                            <p><h4 id="overview">Overview</h4>
+<p>Use this endpoint to get patient details from PDS for a given NHS Number.</p>
+                                                <h4>Request</h4>
+                                                <div class="httpparams">
+                                                    <h5>Path parameters</h5>
+                                                    <table data-disablesort="true">
+                                                        <tr>
+                                                            <th>Name</th>
+                                                            <th>Description</th>
+                                                        </tr>
+                                                            <tr><td class="httpparams__name">id</td>
+                                                            <td>
+                                                                <div>
+                                                                    <div class="httpparams__description">
+                                                                        <div>
+                                                                            <span class="httpparams__datatype">String</span>
+                                                                                <div>The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales.</div>
+                                                                                <div>Example: <code class="codeinline">9000000009</code></div>
+                                                                        </div>
+                                                                            <div class="httpparams__required">
+                                                                                Required
+                                                                            </div>
+                                                                    </div>
+                                                                </div>
+                                                            </td>
+                                                            </tr>
+                                                    </table>
+                                                </div>
+                                                <div class="httpparams">
+                                                    <h5>Headers</h5>
+                                                    <table data-disablesort="true">
+                                                        <tr>
+                                                            <th>Name</th>
+                                                            <th>Description</th>
+                                                        </tr>
+                                                            <tr><td class="httpparams__name">NHSD-Session-URID</td>
+                                                            <td>
+                                                                <div>
+                                                                    <div class="httpparams__description">
+                                                                        <div>
+                                                                            <span class="httpparams__datatype">String</span>
+                                                                                <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>).</div>
+                                                                                <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
+                                                                                <div>Example: <code class="codeinline">555021935107</code></div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </td>
+                                                            </tr>
+                                                    </table>
+                                                </div>
+                                                    <h4>Response</h4>
+                                                <h5>HTTP status: 200</h5>
+                                                <div>Information successfully returned.</div>
+                                                    <div class="httpparams">
+                                                        <h6>Headers</h6>
+                                                        <table data-disablesort="true">
+                                                            <tr>
+                                                                <th>Name</th>
+                                                                <th>Description</th>
+                                                            </tr>
+                                                                <tr><td class="httpparams__name">ETag</td>
+                                                                <td>
+                                                                    <div>
+                                                                        <div class="httpparams__description">
+                                                                            <div>
+                                                                                <span class="httpparams__datatype">String</span>
+                                                                                    <div>Record version identifier enclosed in quotes and preceded by 'W/'. For example, <code class="codeinline">W/&quot;2&quot;</code>.</div>
+                                                                                    <div>Pattern: <code class="codeinline">/^W\/"[0-9]+"$/</code></div>
+                                                                                    <div>Example: <code class="codeinline">W/"2"</code></div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </td>
+                                                                </tr>
+                                                        </table>
+                                                    </div>
+                                                        <h6>Body</h6>
+                                                            <div class="body__contenttype">
+                                                                <span class="body__contenttype__label">Content type: </span>
+                                                                <span class="body__contenttype__value">application/fhir+json</span>
+                                                            </div>
+                                                                <div class="body__example__header">Example</div>
+                                                                <div><pre><code>{
+  "address" : [ {
+    "id" : "456",
+    "line" : [ "1 Trevelyan Square", "Boar Lane", "City Centre", "Leeds", "West Yorkshire" ],
+    "postalCode" : "LS1 6AE",
+    "use" : "home"
+  } ],
+  "birthDate" : "2010-10-22"
 }</code></pre></div>
-            <div class="body__schema__header">Schema
-                <span class="schema__header__buttons">
-<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
-<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
-</span>
+                                                                <div class="body__schema__header">Schema
+                                                                    <span class="schema__header__buttons">
+                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+                                                                        <button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+                                                                    </span>
+                                                                </div>
+                                                                <div class="body__schema" data-schema-uuid="">
+                                                                    <table data-disablesort="true">
+                                                                        <thead>
+                                                                        <th>Name</th>
+                                                                        <th>Description</th>
+                                                                        </thead>
+<tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+    <td style="padding-left: 0.0em;" class="name_column">
+            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+        <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+        <div>
+            <code class="type">object</code>
+        </div>
+    </td>
+    <td class="description_column">
+    </td>
+</tr>
+    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+        <td style="padding-left: 1.5em;" class="name_column">
+            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+        <div><code class="propertyName">resourceType</code></div>
+            <div>
+                <code class="type">string</code>
             </div>
-            <div class="body__schema" data-schema-uuid="">
-                <table data-disablesort="true">
-                    <thead>
-                    <th>Name</th>
-                    <th>Description</th>
-                    </thead>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
-                        <td style="padding-left: 0.0em;" class="name_column">
-                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
-                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
-                            <div>
-                                <code class="type">object</code>
-                            </div>
-                        </td>
-                        <td class="description_column">
-                        </td>
-                    </tr>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
-                        <td style="padding-left: 1.5em;" class="name_column">
-                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
-                            <div><code class="propertyName">resourceType</code></div>
-                            <div>
-                                <code class="type">string</code>
-                            </div>
-                            <div><code class="readonly">read-only</code></div>
-                        </td>
-                        <td class="description_column">
-                            <div class="description">FHIR resource type.</div>
-                            <div>Default: <code class="codeinline default">Patient</code></div>
-                        </td>
-                    </tr>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
-                        <td style="padding-left: 1.5em;" class="name_column">
-                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
-                            <div><code class="propertyName">id</code></div>
-                            <div>
-                                <code class="type">string</code>
-                            </div>
-                            <div><code class="required">required</code></div>
-                        </td>
-                        <td class="description_column">
-                            <div class="description">The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales. Always 10 digits and must be a <a href="https://www.datadictionary.nhs.uk/data_dictionary/attributes/n/nhs/nhs_number_de.asp">valid NHS Number</a>.</div>
-                            <div>Pattern: <code class="codeinline pattern">^\d{10}$</code></div>
-                            <div>Example: <code class="codeinline example">9000000009</code></div>
-                        </td>
-                    </tr>
-                </table>
+            <div><code class="readonly">read-only</code></div>
+        </td>
+        <td class="description_column">
+            <div class="description">FHIR resource type.</div>
+                <div>Default: <code class="codeinline default">Patient</code></div>
+        </td>
+    </tr>
+    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+        <td style="padding-left: 1.5em;" class="name_column">
+            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+        <div><code class="propertyName">id</code></div>
+            <div>
+                <code class="type">string</code>
             </div>
-            <h5>HTTP status: 400</h5>
-            <div>Invalid NHS number supplied.</div>
-            <h6>Body</h6>
-            <div class="body__contenttype">
-                <span class="body__contenttype__label">Content type: </span>
-                <span class="body__contenttype__value">application/fhir+json</span>
-            </div>
-            <div class="body__example__header">Example</div>
-            <div><pre><code>{
-"resourceType" : "OperationOutcome",
-"issue" : [ {
-"severity" : "error",
-"code" : "value",
-"details" : {
-"coding" : [ {
-"system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
-"version" : "1",
-"code" : "INVALID_RESOURCE_ID",
-"display" : "Resource Id is invalid"
-} ]
-}
-} ]
+            <div><code class="required">required</code></div>
+        </td>
+        <td class="description_column">
+            <div class="description">The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales. Always 10 digits and must be a <a href="https://www.datadictionary.nhs.uk/data_dictionary/attributes/n/nhs/nhs_number_de.asp">valid NHS Number</a>.</div>
+            <div>Pattern: <code class="codeinline pattern">^\d{10}$</code></div>
+                <div>Example: <code class="codeinline example">9000000009</code></div>
+        </td>
+    </tr>
+                                                                    </table>
+                                                                </div>
+                                                <h5>HTTP status: 400</h5>
+                                                <div>Invalid NHS number supplied.</div>
+                                                        <h6>Body</h6>
+                                                            <div class="body__contenttype">
+                                                                <span class="body__contenttype__label">Content type: </span>
+                                                                <span class="body__contenttype__value">application/fhir+json</span>
+                                                            </div>
+                                                                <div class="body__example__header">Example</div>
+                                                                <div><pre><code>{
+  "resourceType" : "OperationOutcome",
+  "issue" : [ {
+    "severity" : "error",
+    "code" : "value",
+    "details" : {
+      "coding" : [ {
+        "system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
+        "version" : "1",
+        "code" : "INVALID_RESOURCE_ID",
+        "display" : "Resource Id is invalid"
+      } ]
+    }
+  } ]
 }</code></pre></div>
-            <div class="body__schema__header">Schema
-                <span class="schema__header__buttons">
-<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
-<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
-</span>
+                                                                <div class="body__schema__header">Schema
+                                                                    <span class="schema__header__buttons">
+                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+                                                                        <button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+                                                                    </span>
+                                                                </div>
+                                                                <div class="body__schema" data-schema-uuid="">
+                                                                    <table data-disablesort="true">
+                                                                        <thead>
+                                                                        <th>Name</th>
+                                                                        <th>Description</th>
+                                                                        </thead>
+<tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+    <td style="padding-left: 0.0em;" class="name_column">
+            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+        <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+        <div>
+            <code class="type">object</code>
+        </div>
+    </td>
+    <td class="description_column">
+        <div class="description">Outcome of an operation that does not result in a resource or bundle being returned (e.g. error, async/batch submission).</p>
+<p>Search outcomes:</p>
+<table data-disablesort="true">
+<thead>
+<tr>
+<th>Code</th>
+<th>Response Code</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>INVALID_SEARCH_DATA</td>
+<td>400</td>
+<td>The search parameters are invalid. A description of what exactly is at fault will be added to the display.</td>
+</tr>
+<tr>
+<td>TOO_MANY_MATCHES</td>
+<td>200</td>
+<td>Too many matches were found - user should be told to refine their search parameters.</td>
+</tr>
+</tbody>
+</table></div>
+    </td>
+</tr>
+    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+        <td style="padding-left: 1.5em;" class="name_column">
+            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+        <div><code class="propertyName">resourceType</code></div>
+            <div>
+                <code class="type">string</code>
             </div>
-            <div class="body__schema" data-schema-uuid="">
-                <table data-disablesort="true">
-                    <thead>
-                    <th>Name</th>
-                    <th>Description</th>
-                    </thead>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
-                        <td style="padding-left: 0.0em;" class="name_column">
-                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
-                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
-                            <div>
-                                <code class="type">object</code>
-                            </div>
-                        </td>
-                        <td class="description_column">
-                            <div class="description">Outcome of an operation that does not result in a resource or bundle being returned (e.g. error, async/batch submission).</p>
-                                <p>Search outcomes:</p>
-                                <table data-disablesort="true">
-                                    <thead>
-                                    <tr>
-                                        <th>Code</th>
-                                        <th>Response Code</th>
-                                        <th>Description</th>
-                                    </tr>
-                                    </thead>
-                                    <tbody>
-                                    <tr>
-                                        <td>INVALID_SEARCH_DATA</td>
-                                        <td>400</td>
-                                        <td>The search parameters are invalid. A description of what exactly is at fault will be added to the display.</td>
-                                    </tr>
-                                    <tr>
-                                        <td>TOO_MANY_MATCHES</td>
-                                        <td>200</td>
-                                        <td>Too many matches were found - user should be told to refine their search parameters.</td>
-                                    </tr>
-                                    </tbody>
-                                </table></div>
-                        </td>
-                    </tr>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
-                        <td style="padding-left: 1.5em;" class="name_column">
-                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
-                            <div><code class="propertyName">resourceType</code></div>
-                            <div>
-                                <code class="type">string</code>
-                            </div>
-                            <div><code class="readonly">read-only</code></div>
-                        </td>
-                        <td class="description_column">
-                            <div class="description">FHIR Resource Type.</div>
-                            <div>Default: <code class="codeinline default">OperationOutcome</code></div>
-                        </td>
-                    </tr>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
-                        <td style="padding-left: 1.5em;" class="name_column">
-                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
-                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
-                            <div><code class="propertyName">issue</code></div>
-                            <div>
-                                <code class="type">array</code>
-                            </div>
-                        </td>
-                        <td class="description_column">
-                            <div class="description">List of issues that have occurred.</div>
-                            <div>Min items: <code class="codeinline minitems">1</code></div>
-                        </td>
-                    </tr>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="2" colspan="2">
-                        <td style="padding-left: 3.0em;" class="name_column">
-                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span>
-                            <div>
-                                <code class="type">object</code>
-                            </div>
-                        </td>
-                        <td class="description_column">
-                        </td>
-                    </tr>
-                </table>
+            <div><code class="readonly">read-only</code></div>
+        </td>
+        <td class="description_column">
+            <div class="description">FHIR Resource Type.</div>
+                <div>Default: <code class="codeinline default">OperationOutcome</code></div>
+        </td>
+    </tr>
+    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+        <td style="padding-left: 1.5em;" class="name_column">
+                    <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+        <div><code class="propertyName">issue</code></div>
+            <div>
+                <code class="type">array</code>
             </div>
-        </article>
-    </div>
-    <div id="api-Patients-search-patient" class="article-section-with-sub-heading">
-        <article id="api-Patients-search-patient-0">
-            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-            <h3>Search for patient</h3>
-            <div class="endpoint_path">
-                <div class="method">get</div>
-                <div class="pre"><pre>/Patient</pre></div>
-                <div class="try"><a onclick="tryEndpointNow('/Patients/search-patient')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
-            </div>
-            <p><h4 id="endpoint">Endpoint</h4>
-            <p>Use this endpoint to search for a patient in PDS.</p>
-            <h4>Request</h4>
-            <div class="httpparams">
-                <h5>Query parameters</h5>
-                <table data-disablesort="true">
-                    <tr>
-                        <th>Name</th>
-                        <th>Description</th>
-                    </tr>
-                    <tr><td class="httpparams__name">_exact-match</td>
-                        <td>
-                            <div>
-                                <div class="httpparams__description">
-                                    <div>
-                                        <span class="httpparams__datatype">Boolean</span>
-                                        <div>Default value: <code class="codeinline">false</code></div>
-                                        <div>The search only returns results where the <code class="codeinline">score</code> field is 1.0.</div>
-                                        <div>Example: <code class="codeinline">true</code></div>
+        </td>
+        <td class="description_column">
+            <div class="description">List of issues that have occurred.</div>
+            <div>Min items: <code class="codeinline minitems">1</code></div>
+        </td>
+    </tr>
+            <tr class="expanded" data-schema-uuid="" data-indentation="2" colspan="2">
+                <td style="padding-left: 3.0em;" class="name_column">
+                    <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span>
+                    <div>
+                        <code class="type">object</code>
+                    </div>
+                </td>
+                <td class="description_column">
+                </td>
+            </tr>
+                                                                    </table>
+                                                                </div>
+                                        </article>
                                     </div>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                    <tr><td class="httpparams__name">_history</td>
-                        <td>
-                            <div>
-                                <div class="httpparams__description">
-                                    <div>
-                                        <span class="httpparams__datatype">Boolean</span>
-                                        <div>Default value: <code class="codeinline">false</code></div>
-                                        <div>The search looks for matches in historic information such as previous names and addresses.</div>
-                                        <div>Example: <code class="codeinline">true</code></div>
-                                    </div>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-            <div class="httpparams">
-                <h5>Headers</h5>
-                <table data-disablesort="true">
-                    <tr>
-                        <th>Name</th>
-                        <th>Description</th>
-                    </tr>
-                    <tr><td class="httpparams__name">NHSD-Session-URID</td>
-                        <td>
-                            <div>
-                                <div class="httpparams__description">
-                                    <div>
-                                        <span class="httpparams__datatype">String</span>
-                                        <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>), specifies the role the user is acting in.</div>
-                                        <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
-                                        <div>Example: <code class="codeinline">555021935107</code></div>
-                                    </div>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                    <tr><td class="httpparams__name">Authorization</td>
-                        <td>
-                            <div>
-                                <div class="httpparams__description">
-                                    <div>
-                                        <span class="httpparams__datatype">String</span>
-                                        <code class="codeinline">(^Bearer\ [[:ascii:]]+$)</code>
-                                        <div>An OAuthV2 access token presented in Bearer format.</p>
-                                            <p>Note: This parameter is required unless interacting with the Sandbox.</div>
-                                        <div>Example: <code class="codeinline">Bearer g1112R_ccQ1Ebbb4gtHBP1aaaNM</code></div>
-                                    </div>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-            <h4>Response</h4>
-            <h5>HTTP status: 200</h5>
-            <div>A completed search, containing zero, one, or many matching patients.</div>
-            <h6>Body</h6>
-            <div class="body__contenttype">
-                <span class="body__contenttype__label">Content type: </span>
-                <span class="body__contenttype__value">application/fhir+json</span>
-            </div>
-            <div class="body__example__header">Example</div>
-            <div><pre><code>{
-"resourceType" : "Bundle",
-"type" : "searchset",
-"timestamp" : "2019-12-25T12:00:00+00:00",
-"total" : 1,
-"entry" : [ {
-"fullUrl" : "https://beta.api.digital.nhs.uk/personal-demographics/Patient/9000000009",
-"search" : {
-"score" : 1
-}
-} ]
+                                    <div id="api-Patients-search-patient" class="article-section-with-sub-heading">
+                                        <article id="api-Patients-search-patient-0">
+                                            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+                                            <h3>Search for patient</h3>
+                                            <div class="endpoint_path">
+                                                <div class="method">get</div>
+                                                <div class="pre"><pre>/Patient</pre></div>
+                                                        <div class="try"><a onclick="tryEndpointNow('/Patients/search-patient')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
+                                            </div>
+                                            <p><h4 id="endpoint">Endpoint</h4>
+<p>Use this endpoint to search for a patient in PDS.</p>
+                                                <h4>Request</h4>
+                                                <div class="httpparams">
+                                                    <h5>Query parameters</h5>
+                                                    <table data-disablesort="true">
+                                                        <tr>
+                                                            <th>Name</th>
+                                                            <th>Description</th>
+                                                        </tr>
+                                                            <tr><td class="httpparams__name">_exact-match</td>
+                                                            <td>
+                                                                <div>
+                                                                    <div class="httpparams__description">
+                                                                        <div>
+                                                                            <span class="httpparams__datatype">Boolean</span>
+                                                                                <div>Default value: <code class="codeinline">false</code></div>
+                                                                                <div>The search only returns results where the <code class="codeinline">score</code> field is 1.0.</div>
+                                                                                <div>Example: <code class="codeinline">true</code></div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </td>
+                                                            </tr>
+                                                            <tr><td class="httpparams__name">_history</td>
+                                                            <td>
+                                                                <div>
+                                                                    <div class="httpparams__description">
+                                                                        <div>
+                                                                            <span class="httpparams__datatype">Boolean</span>
+                                                                                <div>Default value: <code class="codeinline">false</code></div>
+                                                                                <div>The search looks for matches in historic information such as previous names and addresses.</div>
+                                                                                <div>Example: <code class="codeinline">true</code></div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </td>
+                                                            </tr>
+                                                    </table>
+                                                </div>
+                                                <div class="httpparams">
+                                                    <h5>Headers</h5>
+                                                    <table data-disablesort="true">
+                                                        <tr>
+                                                            <th>Name</th>
+                                                            <th>Description</th>
+                                                        </tr>
+                                                            <tr><td class="httpparams__name">NHSD-Session-URID</td>
+                                                            <td>
+                                                                <div>
+                                                                    <div class="httpparams__description">
+                                                                        <div>
+                                                                            <span class="httpparams__datatype">String</span>
+                                                                                <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>), specifies the role the user is acting in.</div>
+                                                                                <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
+                                                                                <div>Example: <code class="codeinline">555021935107</code></div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </td>
+                                                            </tr>
+                                                            <tr><td class="httpparams__name">Authorization</td>
+                                                            <td>
+                                                                <div>
+                                                                    <div class="httpparams__description">
+                                                                        <div>
+                                                                            <span class="httpparams__datatype">String</span>
+                                                                                <code class="codeinline">(^Bearer\ [[:ascii:]]+$)</code>
+                                                                                <div>An OAuthV2 access token presented in Bearer format.</p>
+<p>Note: This parameter is required unless interacting with the Sandbox.</div>
+                                                                                <div>Example: <code class="codeinline">Bearer g1112R_ccQ1Ebbb4gtHBP1aaaNM</code></div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </td>
+                                                            </tr>
+                                                    </table>
+                                                </div>
+                                                    <h4>Response</h4>
+                                                <h5>HTTP status: 200</h5>
+                                                <div>A completed search, containing zero, one, or many matching patients.</div>
+                                                        <h6>Body</h6>
+                                                            <div class="body__contenttype">
+                                                                <span class="body__contenttype__label">Content type: </span>
+                                                                <span class="body__contenttype__value">application/fhir+json</span>
+                                                            </div>
+                                                                <div class="body__example__header">Example</div>
+                                                                <div><pre><code>{
+  "resourceType" : "Bundle",
+  "type" : "searchset",
+  "timestamp" : "2019-12-25T12:00:00+00:00",
+  "total" : 1,
+  "entry" : [ {
+    "fullUrl" : "https://beta.api.digital.nhs.uk/personal-demographics/Patient/9000000009",
+    "search" : {
+      "score" : 1
+    }
+  } ]
 }</code></pre></div>
-            <div class="body__schema__header">Schema
-                <span class="schema__header__buttons">
-<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
-<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
-</span>
+                                                                <div class="body__schema__header">Schema
+                                                                    <span class="schema__header__buttons">
+                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+                                                                        <button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+                                                                    </span>
+                                                                </div>
+                                                                <div class="body__schema" data-schema-uuid="">
+                                                                    <table data-disablesort="true">
+                                                                        <thead>
+                                                                        <th>Name</th>
+                                                                        <th>Description</th>
+                                                                        </thead>
+<tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+    <td style="padding-left: 0.0em;" class="name_column">
+            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+        <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+        <div>
+            <code class="type">object</code>
+        </div>
+    </td>
+    <td class="description_column">
+    </td>
+</tr>
+    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+        <td style="padding-left: 1.5em;" class="name_column">
+            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+        <div><code class="propertyName">resourceType</code></div>
+            <div>
+                <code class="type">string</code>
             </div>
-            <div class="body__schema" data-schema-uuid="">
-                <table data-disablesort="true">
-                    <thead>
-                    <th>Name</th>
-                    <th>Description</th>
-                    </thead>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
-                        <td style="padding-left: 0.0em;" class="name_column">
-                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
-                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
-                            <div>
-                                <code class="type">object</code>
-                            </div>
-                        </td>
-                        <td class="description_column">
-                        </td>
-                    </tr>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
-                        <td style="padding-left: 1.5em;" class="name_column">
-                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
-                            <div><code class="propertyName">resourceType</code></div>
-                            <div>
-                                <code class="type">string</code>
-                            </div>
-                        </td>
-                        <td class="description_column">
-                            <div class="description">FHIR Resource Type.</div>
-                            <div>Default: <code class="codeinline default">Bundle</code></div>
-                        </td>
-                    </tr>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
-                        <td style="padding-left: 1.5em;" class="name_column">
-                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
-                            <div><code class="propertyName">type</code></div>
-                            <div>
-                                <code class="type">string</code>
-                            </div>
-                        </td>
-                        <td class="description_column">
-                            <div class="description">FHIR Bundle Type.</div>
-                            <div>Default: <code class="codeinline default">searchset</code></div>
-                        </td>
-                    </tr>
-                </table>
+        </td>
+        <td class="description_column">
+            <div class="description">FHIR Resource Type.</div>
+                <div>Default: <code class="codeinline default">Bundle</code></div>
+        </td>
+    </tr>
+    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+        <td style="padding-left: 1.5em;" class="name_column">
+            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+        <div><code class="propertyName">type</code></div>
+            <div>
+                <code class="type">string</code>
             </div>
-            <h5>HTTP status: 400</h5>
-            <div>Invalid search paramaters supplied.</div>
-            <h6>Body</h6>
-            <div class="body__contenttype">
-                <span class="body__contenttype__label">Content type: </span>
-                <span class="body__contenttype__value">application/fhir+json</span>
+        </td>
+        <td class="description_column">
+            <div class="description">FHIR Bundle Type.</div>
+                <div>Default: <code class="codeinline default">searchset</code></div>
+        </td>
+    </tr>
+    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+        <td style="padding-left: 1.5em;" class="name_column">
+            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+        <div><code class="propertyName">deathDateTime</code></div>
+            <div>
+                <code class="type">string</code>
+                <code class="format">date-time</code>
             </div>
-            <div class="body__example__header">Examples</div>
-            <div class="body__example__summary">too few search params</div>
-            <div><pre><code>{
-"resourceType" : "OperationOutcome",
-"issue" : [ {
-"severity" : "error",
-"code" : "value"
-} ]
+        </td>
+        <td class="description_column">
+                <div>Example: <code class="codeinline example">2021-04-22T10:00Z</code></div>
+        </td>
+    </tr>
+                                                                    </table>
+                                                                </div>
+                                                <h5>HTTP status: 400</h5>
+                                                <div>Invalid search paramaters supplied.</div>
+                                                        <h6>Body</h6>
+                                                            <div class="body__contenttype">
+                                                                <span class="body__contenttype__label">Content type: </span>
+                                                                <span class="body__contenttype__value">application/fhir+json</span>
+                                                            </div>
+                                                                        <div class="body__example__header">Examples</div>
+                                                                <div class="body__example__summary">too few search params</div>
+                                                                <div><pre><code>{
+  "resourceType" : "OperationOutcome",
+  "issue" : [ {
+    "severity" : "error",
+    "code" : "value"
+  } ]
 }</code></pre></div>
-            <div class="body__example__summary">Invalid combination of search parameters</div>
-            <div><pre><code>{
-"resourceType" : "OperationOutcome",
-"issue" : [ {
-"severity" : "error",
-"code" : "value"
-} ]
+                                                                <div class="body__example__summary">Invalid combination of search parameters</div>
+                                                                <div><pre><code>{
+  "resourceType" : "OperationOutcome",
+  "issue" : [ {
+    "severity" : "error",
+    "code" : "value"
+  } ]
 }</code></pre></div>
-            <div class="body__schema__header">Schema
-                <span class="schema__header__buttons">
-<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
-<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
-</span>
-            </div>
-            <div class="body__schema" data-schema-uuid="">
-                <table data-disablesort="true">
-                    <thead>
-                    <th>Name</th>
-                    <th>Description</th>
-                    </thead>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
-                        <td style="padding-left: 0.0em;" class="name_column">
-                            <div>
-                                <code class="type">object</code>
-                                <code class="format">int(32)</code>
-                            </div>
-                            <div><code class="deprecated">deprecated</code></div>
-                            <div><code class="uniqueitems">unique items</code></div>
-                            <div><code class="nullable">nullable</code></div>
-                            <div><code class="readonly">read-only</code></div>
-                            <div><code class="writeonly">write-only</code></div>
-                        </td>
-                        <td class="description_column">
-                            <div class="title">Response Schema with all simple fields.</div>
-                            <div class="description">Response Test Schema Object description in <code class="codeinline">Markdown</code>.</div>
-                            <div>Pattern: <code class="codeinline pattern">^(?:[0-9]{4}-[0-9]{2}-[0-9]{2})?(?:[ T][0-9]{2}:[0-9]{2}:[0-9]{2})?(?:[.,][0-9]{3})?</code></div>
-                            <div>Multiple of: <code class="codeinline multipleof">1.2</code><div>
-                                <div>Maximum: <code class="codeinline maximum">2.2</code>
-                                    <code class="codeinline exclusivemaximum">(exclusive)</code>
-                                </div>
-                                <div>Minimum: <code class="codeinline minimum">-2.3</code>
-                                    <code class="codeinline exclusiveminimum">(exclusive)</code>
-                                </div>
-                                <div>Max length: <code class="codeinline maxlength">22</code></div>
-                                <div>Min length: <code class="codeinline minlength">11</code></div>
-                                <div>Max items: <code class="codeinline maxitems">44</code></div>
-                                <div>Min items: <code class="codeinline minitems">33</code></div>
-                                <div>Max properties: <code class="codeinline maxproperties">5</code></div>
-                                <div>Min properties: <code class="codeinline minproperties">3</code></div>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-        </article>
-    </div>
-    <div id="api-Patients-update-patient-partial" class="article-section-with-sub-heading">
-        <article id="api-Patients-update-patient-partial-0">
-            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-            <h3>Update a patient's resource</h3>
-            <div class="endpoint_path">
-                <div class="method">patch</div>
-                <div class="pre"><pre>/Patient/{id}</pre></div>
-                <div class="try"><a onclick="tryEndpointNow('/Patients/update-patient-partial')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
-            </div>
-            <p><h4 id="overview">Overview</h4>
-            <p>Use this endpoint to update patient details in PDS.</p>
-            <h4>Request</h4>
-            <div class="httpparams">
-                <h5>Path parameters</h5>
-                <table data-disablesort="true">
-                    <tr>
-                        <th>Name</th>
-                        <th>Description</th>
-                    </tr>
-                    <tr><td class="httpparams__name">id</td>
-                        <td>
-                            <div>
-                                <div class="httpparams__description">
-                                    <div>
-                                        <span class="httpparams__datatype">String</span>
-                                        <div>The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales.</div>
-                                        <div>Example: <code class="codeinline">9000000009</code></div>
+                                                                <div class="body__schema__header">Schema
+                                                                    <span class="schema__header__buttons">
+                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+                                                                        <button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+                                                                    </span>
+                                                                </div>
+                                                                <div class="body__schema" data-schema-uuid="">
+                                                                    <table data-disablesort="true">
+                                                                        <thead>
+                                                                        <th>Name</th>
+                                                                        <th>Description</th>
+                                                                        </thead>
+<tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+    <td style="padding-left: 0.0em;" class="name_column">
+        <div>
+            <code class="type">object</code>
+            <code class="format">int(32)</code>
+        </div>
+        <div><code class="deprecated">deprecated</code></div>
+        <div><code class="uniqueitems">unique items</code></div>
+        <div><code class="nullable">nullable</code></div>
+        <div><code class="readonly">read-only</code></div>
+        <div><code class="writeonly">write-only</code></div>
+    </td>
+    <td class="description_column">
+        <div class="title">Response Schema with all simple fields.</div>
+        <div class="description">Response Test Schema Object description in <code class="codeinline">Markdown</code>.</div>
+        <div>Pattern: <code class="codeinline pattern">^(?:[0-9]{4}-[0-9]{2}-[0-9]{2})?(?:[ T][0-9]{2}:[0-9]{2}:[0-9]{2})?(?:[.,][0-9]{3})?</code></div>
+        <div>Multiple of: <code class="codeinline multipleof">1.2</code><div>
+        <div>Maximum: <code class="codeinline maximum">2.2</code>
+            <code class="codeinline exclusivemaximum">(exclusive)</code>
+        </div>
+        <div>Minimum: <code class="codeinline minimum">-2.3</code>
+            <code class="codeinline exclusiveminimum">(exclusive)</code>
+        </div>
+        <div>Max length: <code class="codeinline maxlength">22</code></div>
+        <div>Min length: <code class="codeinline minlength">11</code></div>
+        <div>Max items: <code class="codeinline maxitems">44</code></div>
+        <div>Min items: <code class="codeinline minitems">33</code></div>
+        <div>Max properties: <code class="codeinline maxproperties">5</code></div>
+        <div>Min properties: <code class="codeinline minproperties">3</code></div>
+    </td>
+</tr>
+                                                                    </table>
+                                                                </div>
+                                        </article>
                                     </div>
-                                    <div class="httpparams__required">
-                                        Required
-                                    </div>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-            <div class="httpparams">
-                <h5>Headers</h5>
-                <table data-disablesort="true">
-                    <tr>
-                        <th>Name</th>
-                        <th>Description</th>
-                    </tr>
-                    <tr><td class="httpparams__name">NHSD-Session-URID</td>
-                        <td>
-                            <div>
-                                <div class="httpparams__description">
-                                    <div>
-                                        <span class="httpparams__datatype">String</span>
-                                        <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>).</div>
-                                        <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
-                                        <div>Example: <code class="codeinline">555021935107</code></div>
-                                    </div>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                    <tr><td class="httpparams__name">If-Match</td>
-                        <td>
-                            <div>
-                                <div class="httpparams__description">
-                                    <div>
-                                        <span class="httpparams__datatype">String</span>
-                                        <div>Latest known version identifier enclosed in quotes preceded by <code class="codeinline">W/</code>.</p>
-                                            <p>Send the value of this resource's <code class="codeinline">ETag</code> response header (or <code class="codeinline">meta.versionId</code> property) as received.</div>
-                                        <div>Pattern: <code class="codeinline">/^W\/"[0-9]+"$/</code></div>
-                                        <div>Example: <code class="codeinline">W/"2"</code></div>
-                                    </div>
-                                    <div class="httpparams__required">
-                                        Required
-                                    </div>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-            <div class="httpparams">
-                <h5>Body</h5>
-                <div class="httpparams__required">Required</div>
-                <div class="body__contenttype">
-                    <span class="body__contenttype__label">Content type: </span>
-                    <span class="body__contenttype__value">application/json</span>
-                </div>
-                <div class="body__example__header">Examples</div>
-                <div class="body__example__summary">Add a new single item (deceasedDateTime) to the patient</div>
-                <div><pre><code>{
-"patches" : [ {
-"op" : "add",
-"path" : "/deceasedDateTime",
-"value" : "2010-10-22T00:00:00+00:00"
-} ]
+                                    <div id="api-Patients-update-patient-partial" class="article-section-with-sub-heading">
+                                        <article id="api-Patients-update-patient-partial-0">
+                                            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+                                            <h3>Update a patient's resource</h3>
+                                            <div class="endpoint_path">
+                                                <div class="method">patch</div>
+                                                <div class="pre"><pre>/Patient/{id}</pre></div>
+                                                        <div class="try"><a onclick="tryEndpointNow('/Patients/update-patient-partial')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
+                                            </div>
+                                            <p><h4 id="overview">Overview</h4>
+<p>Use this endpoint to update patient details in PDS.</p>
+                                                <h4>Request</h4>
+                                                <div class="httpparams">
+                                                    <h5>Path parameters</h5>
+                                                    <table data-disablesort="true">
+                                                        <tr>
+                                                            <th>Name</th>
+                                                            <th>Description</th>
+                                                        </tr>
+                                                            <tr><td class="httpparams__name">id</td>
+                                                            <td>
+                                                                <div>
+                                                                    <div class="httpparams__description">
+                                                                        <div>
+                                                                            <span class="httpparams__datatype">String</span>
+                                                                                <div>The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales.</div>
+                                                                                <div>Example: <code class="codeinline">9000000009</code></div>
+                                                                        </div>
+                                                                            <div class="httpparams__required">
+                                                                                Required
+                                                                            </div>
+                                                                    </div>
+                                                                </div>
+                                                            </td>
+                                                            </tr>
+                                                    </table>
+                                                </div>
+                                                <div class="httpparams">
+                                                    <h5>Headers</h5>
+                                                    <table data-disablesort="true">
+                                                        <tr>
+                                                            <th>Name</th>
+                                                            <th>Description</th>
+                                                        </tr>
+                                                            <tr><td class="httpparams__name">NHSD-Session-URID</td>
+                                                            <td>
+                                                                <div>
+                                                                    <div class="httpparams__description">
+                                                                        <div>
+                                                                            <span class="httpparams__datatype">String</span>
+                                                                                <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>).</div>
+                                                                                <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
+                                                                                <div>Example: <code class="codeinline">555021935107</code></div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </td>
+                                                            </tr>
+                                                            <tr><td class="httpparams__name">If-Match</td>
+                                                            <td>
+                                                                <div>
+                                                                    <div class="httpparams__description">
+                                                                        <div>
+                                                                            <span class="httpparams__datatype">String</span>
+                                                                                <div>Latest known version identifier enclosed in quotes preceded by <code class="codeinline">W/</code>.</p>
+<p>Send the value of this resource's <code class="codeinline">ETag</code> response header (or <code class="codeinline">meta.versionId</code> property) as received.</div>
+                                                                                <div>Pattern: <code class="codeinline">/^W\/"[0-9]+"$/</code></div>
+                                                                                <div>Example: <code class="codeinline">W/"2"</code></div>
+                                                                        </div>
+                                                                            <div class="httpparams__required">
+                                                                                Required
+                                                                            </div>
+                                                                    </div>
+                                                                </div>
+                                                            </td>
+                                                            </tr>
+                                                    </table>
+                                                </div>
+                                                <div class="httpparams">
+                                                    <h5>Body</h5>
+                                                        <div class="httpparams__required">Required</div>
+                                                                    <div class="body__contenttype">
+                                                                        <span class="body__contenttype__label">Content type: </span>
+                                                                        <span class="body__contenttype__value">application/json</span>
+                                                                    </div>
+                                                                                <div class="body__example__header">Examples</div>
+                                                                        <div class="body__example__summary">Add a new single item (deceasedDateTime) to the patient</div>
+                                                                        <div><pre><code>{
+  "patches" : [ {
+    "op" : "add",
+    "path" : "/deceasedDateTime",
+    "value" : "2010-10-22T00:00:00+00:00"
+  } ]
 }</code></pre></div>
-                <div class="body__example__summary">Update the simple item (gender)</div>
-                <div><pre><code>{
-"patches" : [ {
-"op" : "replace",
-"path" : "/gender",
-"value" : "male"
-} ]
+                                                                        <div class="body__example__summary">Update the simple item (gender)</div>
+                                                                        <div><pre><code>{
+  "patches" : [ {
+    "op" : "replace",
+    "path" : "/gender",
+    "value" : "male"
+  } ]
 }</code></pre></div>
-                <div class="body__schema__header">Schema
-                    <span class="schema__header__buttons">
-<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
-<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
-</span>
-                </div>
-                <div class="body__schema" data-schema-uuid="">
-                    <table data-disablesort="true">
-                        <thead>
-                        <th>Name</th>
-                        <th>Description</th>
-                        </thead>
-                        <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
-                            <td style="padding-left: 0.0em;" class="name_column">
-                                <div>
-                                    <code class="type">object</code>
-                                    <code class="format">int(32)</code>
-                                </div>
-                                <div><code class="deprecated">deprecated</code></div>
-                                <div><code class="uniqueitems">unique items</code></div>
-                                <div><code class="nullable">nullable</code></div>
-                                <div><code class="readonly">read-only</code></div>
-                                <div><code class="writeonly">write-only</code></div>
-                            </td>
-                            <td class="description_column">
-                                <div class="title">Request Schema with all simple fields.</div>
-                                <div class="description">Request Test Schema Object description in <code class="codeinline">Markdown</code>.</div>
-                                <div>Pattern: <code class="codeinline pattern">^(?:[0-9]{4}-[0-9]{2}-[0-9]{2})?(?:[ T][0-9]{2}:[0-9]{2}:[0-9]{2})?(?:[.,][0-9]{3})?</code></div>
-                                <div>Multiple of: <code class="codeinline multipleof">1.2</code><div>
-                                    <div>Maximum: <code class="codeinline maximum">2.2</code>
-                                        <code class="codeinline exclusivemaximum">(exclusive)</code>
-                                    </div>
-                                    <div>Minimum: <code class="codeinline minimum">-2.3</code>
-                                        <code class="codeinline exclusiveminimum">(exclusive)</code>
-                                    </div>
-                                    <div>Max length: <code class="codeinline maxlength">22</code></div>
-                                    <div>Min length: <code class="codeinline minlength">11</code></div>
-                                    <div>Max items: <code class="codeinline maxitems">44</code></div>
-                                    <div>Min items: <code class="codeinline minitems">33</code></div>
-                                    <div>Max properties: <code class="codeinline maxproperties">5</code></div>
-                                    <div>Min properties: <code class="codeinline minproperties">3</code></div>
-                            </td>
-                        </tr>
-                    </table>
-                </div>
-            </div>
-            <h4>Response</h4>
-            <h5>HTTP status: 202</h5>
-            <div>The patch was syntactically correct and was accepted.</div>
-            <div class="httpparams">
-                <h6>Headers</h6>
-                <table data-disablesort="true">
-                    <tr>
-                        <th>Name</th>
-                        <th>Description</th>
-                    </tr>
-                    <tr><td class="httpparams__name">Content-Location</td>
-                        <td>
-                            <div>
-                                <div class="httpparams__description">
-                                    <div>
-                                        <span class="httpparams__datatype">String</span>
-                                        <div>Polling location of the update</div>
-                                        <div>Example: <code class="codeinline">/Polling/20200522091633363041_461139_1524772598</code></div>
-                                    </div>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                    <tr><td class="httpparams__name">Retry-After</td>
-                        <td>
-                            <div>
-                                <div class="httpparams__description">
-                                    <div>
-                                        <span class="httpparams__datatype">String</span>
-                                        <div>Time to wait between polls in milliseconds</div>
-                                        <div>Example: <code class="codeinline">100</code></div>
-                                    </div>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-            <h5>HTTP status: 400</h5>
-            <div>Client error.</div>
-            <h6>Body</h6>
-            <div class="body__contenttype">
-                <span class="body__contenttype__label">Content type: </span>
-                <span class="body__contenttype__value">application/fhir+json</span>
-            </div>
-            <div class="body__example__header">Examples</div>
-            <div class="body__example__summary">Invalid NHS number supplied</div>
-            <div><pre><code>{
-"resourceType" : "OperationOutcome",
-"issue" : [ {
-"severity" : "error",
-"code" : "value",
-"details" : {
-"coding" : [ {
-"system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
-"version" : "1",
-"code" : "INVALID_RESOURCE_ID",
-"display" : "Resource Id is invalid"
-} ]
-}
-} ]
+                                                                        <div class="body__schema__header">Schema
+                                                                            <span class="schema__header__buttons">
+                                                                                <button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+                                                                                <button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+                                                                            </span>
+                                                                        </div>
+                                                                        <div class="body__schema" data-schema-uuid="">
+                                                                            <table data-disablesort="true">
+                                                                                <thead>
+                                                                                <th>Name</th>
+                                                                                <th>Description</th>
+                                                                                </thead>
+<tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+    <td style="padding-left: 0.0em;" class="name_column">
+        <div>
+            <code class="type">object</code>
+            <code class="format">int(32)</code>
+        </div>
+        <div><code class="deprecated">deprecated</code></div>
+        <div><code class="uniqueitems">unique items</code></div>
+        <div><code class="nullable">nullable</code></div>
+        <div><code class="readonly">read-only</code></div>
+        <div><code class="writeonly">write-only</code></div>
+    </td>
+    <td class="description_column">
+        <div class="title">Request Schema with all simple fields.</div>
+        <div class="description">Request Test Schema Object description in <code class="codeinline">Markdown</code>.</div>
+        <div>Pattern: <code class="codeinline pattern">^(?:[0-9]{4}-[0-9]{2}-[0-9]{2})?(?:[ T][0-9]{2}:[0-9]{2}:[0-9]{2})?(?:[.,][0-9]{3})?</code></div>
+        <div>Multiple of: <code class="codeinline multipleof">1.2</code><div>
+        <div>Maximum: <code class="codeinline maximum">2.2</code>
+            <code class="codeinline exclusivemaximum">(exclusive)</code>
+        </div>
+        <div>Minimum: <code class="codeinline minimum">-2.3</code>
+            <code class="codeinline exclusiveminimum">(exclusive)</code>
+        </div>
+        <div>Max length: <code class="codeinline maxlength">22</code></div>
+        <div>Min length: <code class="codeinline minlength">11</code></div>
+        <div>Max items: <code class="codeinline maxitems">44</code></div>
+        <div>Min items: <code class="codeinline minitems">33</code></div>
+        <div>Max properties: <code class="codeinline maxproperties">5</code></div>
+        <div>Min properties: <code class="codeinline minproperties">3</code></div>
+    </td>
+</tr>
+                                                                            </table>
+                                                                        </div>
+                                                </div>
+                                                    <h4>Response</h4>
+                                                <h5>HTTP status: 202</h5>
+                                                <div>The patch was syntactically correct and was accepted.</div>
+                                                    <div class="httpparams">
+                                                        <h6>Headers</h6>
+                                                        <table data-disablesort="true">
+                                                            <tr>
+                                                                <th>Name</th>
+                                                                <th>Description</th>
+                                                            </tr>
+                                                                <tr><td class="httpparams__name">Content-Location</td>
+                                                                <td>
+                                                                    <div>
+                                                                        <div class="httpparams__description">
+                                                                            <div>
+                                                                                <span class="httpparams__datatype">String</span>
+                                                                                    <div>Polling location of the update</div>
+                                                                                    <div>Example: <code class="codeinline">/Polling/20200522091633363041_461139_1524772598</code></div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </td>
+                                                                </tr>
+                                                                <tr><td class="httpparams__name">Retry-After</td>
+                                                                <td>
+                                                                    <div>
+                                                                        <div class="httpparams__description">
+                                                                            <div>
+                                                                                <span class="httpparams__datatype">String</span>
+                                                                                    <div>Time to wait between polls in milliseconds</div>
+                                                                                    <div>Example: <code class="codeinline">100</code></div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </td>
+                                                                </tr>
+                                                        </table>
+                                                    </div>
+                                                <h5>HTTP status: 400</h5>
+                                                <div>Client error.</div>
+                                                        <h6>Body</h6>
+                                                            <div class="body__contenttype">
+                                                                <span class="body__contenttype__label">Content type: </span>
+                                                                <span class="body__contenttype__value">application/fhir+json</span>
+                                                            </div>
+                                                                        <div class="body__example__header">Examples</div>
+                                                                <div class="body__example__summary">Invalid NHS number supplied</div>
+                                                                <div><pre><code>{
+  "resourceType" : "OperationOutcome",
+  "issue" : [ {
+    "severity" : "error",
+    "code" : "value",
+    "details" : {
+      "coding" : [ {
+        "system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
+        "version" : "1",
+        "code" : "INVALID_RESOURCE_ID",
+        "display" : "Resource Id is invalid"
+      } ]
+    }
+  } ]
 }</code></pre></div>
-            <div class="body__example__summary">No patches submitted</div>
-            <div><pre><code>{
-"resourceType" : "OperationOutcome",
-"issue" : [ {
-"severity" : "error",
-"code" : "required",
-"details" : {
-"coding" : [ {
-"system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
-"version" : "1",
-"code" : "MISSING_VALUE",
-"display" : "Missing value - patches"
-} ]
-}
-} ]
+                                                                <div class="body__example__summary">No patches submitted</div>
+                                                                <div><pre><code>{
+  "resourceType" : "OperationOutcome",
+  "issue" : [ {
+    "severity" : "error",
+    "code" : "required",
+    "details" : {
+      "coding" : [ {
+        "system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
+        "version" : "1",
+        "code" : "MISSING_VALUE",
+        "display" : "Missing value - patches"
+      } ]
+    }
+  } ]
 }</code></pre></div>
-            <div class="body__schema__header">Schema
-                <span class="schema__header__buttons">
-<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
-<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
-</span>
+                                                                <div class="body__schema__header">Schema
+                                                                    <span class="schema__header__buttons">
+                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+                                                                        <button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+                                                                    </span>
+                                                                </div>
+                                                                <div class="body__schema" data-schema-uuid="">
+                                                                    <table data-disablesort="true">
+                                                                        <thead>
+                                                                        <th>Name</th>
+                                                                        <th>Description</th>
+                                                                        </thead>
+<tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+    <td style="padding-left: 0.0em;" class="name_column">
+            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+        <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+        <div>
+            <code class="type">object</code>
+        </div>
+    </td>
+    <td class="description_column">
+        <div class="description">Outcome of an operation that does not result in a resource or bundle being returned (e.g. error, async/batch submission).</p>
+<p>Search outcomes:</p>
+<table data-disablesort="true">
+<thead>
+<tr>
+<th>Code</th>
+<th>Response Code</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>INVALID_SEARCH_DATA</td>
+<td>400</td>
+<td>The search parameters are invalid. A description of what exactly is at fault will be added to the display.</td>
+</tr>
+<tr>
+<td>TOO_MANY_MATCHES</td>
+<td>200</td>
+<td>Too many matches were found - user should be told to refine their search parameters.</td>
+</tr>
+</tbody>
+</table></div>
+    </td>
+</tr>
+    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+        <td style="padding-left: 1.5em;" class="name_column">
+            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+        <div><code class="propertyName">resourceType</code></div>
+            <div>
+                <code class="type">string</code>
             </div>
-            <div class="body__schema" data-schema-uuid="">
-                <table data-disablesort="true">
-                    <thead>
-                    <th>Name</th>
-                    <th>Description</th>
-                    </thead>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
-                        <td style="padding-left: 0.0em;" class="name_column">
-                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
-                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
-                            <div>
-                                <code class="type">object</code>
-                            </div>
-                        </td>
-                        <td class="description_column">
-                            <div class="description">Outcome of an operation that does not result in a resource or bundle being returned (e.g. error, async/batch submission).</p>
-                                <p>Search outcomes:</p>
-                                <table data-disablesort="true">
-                                    <thead>
-                                    <tr>
-                                        <th>Code</th>
-                                        <th>Response Code</th>
-                                        <th>Description</th>
-                                    </tr>
-                                    </thead>
-                                    <tbody>
-                                    <tr>
-                                        <td>INVALID_SEARCH_DATA</td>
-                                        <td>400</td>
-                                        <td>The search parameters are invalid. A description of what exactly is at fault will be added to the display.</td>
-                                    </tr>
-                                    <tr>
-                                        <td>TOO_MANY_MATCHES</td>
-                                        <td>200</td>
-                                        <td>Too many matches were found - user should be told to refine their search parameters.</td>
-                                    </tr>
-                                    </tbody>
-                                </table></div>
-                        </td>
-                    </tr>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
-                        <td style="padding-left: 1.5em;" class="name_column">
-                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
-                            <div><code class="propertyName">resourceType</code></div>
-                            <div>
-                                <code class="type">string</code>
-                            </div>
-                            <div><code class="readonly">read-only</code></div>
-                        </td>
-                        <td class="description_column">
-                            <div class="description">FHIR Resource Type.</div>
-                            <div>Default: <code class="codeinline default">OperationOutcome</code></div>
-                        </td>
-                    </tr>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
-                        <td style="padding-left: 1.5em;" class="name_column">
-                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
-                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
-                            <div><code class="propertyName">issue</code></div>
-                            <div>
-                                <code class="type">array</code>
-                            </div>
-                        </td>
-                        <td class="description_column">
-                            <div class="description">List of issues that have occurred.</div>
-                            <div>Min items: <code class="codeinline minitems">1</code></div>
-                        </td>
-                    </tr>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="2" colspan="2">
-                        <td style="padding-left: 3.0em;" class="name_column">
-                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
-                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 35.4%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span>
-                            <div>
-                                <code class="type">object</code>
-                            </div>
-                        </td>
-                        <td class="description_column">
-                        </td>
-                    </tr>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
-                        <td style="padding-left: 4.5em;" class="name_column">
-                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
-                            <div><code class="propertyName">severity</code></div>
-                            <div>
-                                <code class="type">string</code>
-                            </div>
-                            <div><code class="required">required</code></div>
-                        </td>
-                        <td class="description_column">
-                            <div class="description">Severity of the error.</div>
-                            <div>Allowed values: <code class="codeinline">fatal</code>, <code class="codeinline">error</code>, <code class="codeinline">warning</code>, <code class="codeinline">information</code></div>
+            <div><code class="readonly">read-only</code></div>
+        </td>
+        <td class="description_column">
+            <div class="description">FHIR Resource Type.</div>
+                <div>Default: <code class="codeinline default">OperationOutcome</code></div>
+        </td>
+    </tr>
+    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+        <td style="padding-left: 1.5em;" class="name_column">
+                    <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+        <div><code class="propertyName">issue</code></div>
+            <div>
+                <code class="type">array</code>
+            </div>
+        </td>
+        <td class="description_column">
+            <div class="description">List of issues that have occurred.</div>
+            <div>Min items: <code class="codeinline minitems">1</code></div>
+        </td>
+    </tr>
+            <tr class="expanded" data-schema-uuid="" data-indentation="2" colspan="2">
+                <td style="padding-left: 3.0em;" class="name_column">
+                        <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                    <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 35.4%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span>
+                    <div>
+                        <code class="type">object</code>
+                    </div>
+                </td>
+                <td class="description_column">
+                </td>
+            </tr>
+                <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
+                    <td style="padding-left: 4.5em;" class="name_column">
+                        <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
+                    <div><code class="propertyName">severity</code></div>
+                        <div>
+                            <code class="type">string</code>
+                        </div>
+                        <div><code class="required">required</code></div>
+                    </td>
+                    <td class="description_column">
+                        <div class="description">Severity of the error.</div>
+                        <div>Allowed values: <code class="codeinline">fatal</code>, <code class="codeinline">error</code>, <code class="codeinline">warning</code>, <code class="codeinline">information</code></div>
                             <div>Example: <code class="codeinline example">error</code></div>
-                        </td>
-                    </tr>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
-                        <td style="padding-left: 4.5em;" class="name_column">
-                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
-                            <div><code class="propertyName">code</code></div>
-                            <div>
-                                <code class="type">string</code>
-                            </div>
-                            <div><code class="required">required</code></div>
-                        </td>
-                        <td class="description_column">
-                            <div class="description">FHIR error code.</div>
-                            <div>Allowed values: <code class="codeinline">incomplete</code>, <code class="codeinline">throttled</code>, <code class="codeinline">informational</code></div>
+                    </td>
+                </tr>
+                <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
+                    <td style="padding-left: 4.5em;" class="name_column">
+                        <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
+                    <div><code class="propertyName">code</code></div>
+                        <div>
+                            <code class="type">string</code>
+                        </div>
+                        <div><code class="required">required</code></div>
+                    </td>
+                    <td class="description_column">
+                        <div class="description">FHIR error code.</div>
+                        <div>Allowed values: <code class="codeinline">incomplete</code>, <code class="codeinline">throttled</code>, <code class="codeinline">informational</code></div>
                             <div>Example: <code class="codeinline example">invalid</code></div>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-        </article>
-    </div>
-    <div id="api-Polling" class="article-section">
-        <h2>Endpoints: Polling</h2>
-    </div>
-    <div id="api-Polling-polling" class="article-section-with-sub-heading">
-        <article id="api-Polling-polling-0">
-            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-            <h3>Retrieve the outcome of the accepted update.</h3>
-            <div class="endpoint_path">
-                <div class="method">get</div>
-                <div class="pre"><pre>/Polling/{message_id}</pre></div>
-                <div class="try"><a onclick="tryEndpointNow('/Polling/polling')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
-            </div>
-            <p><h4 id="overview">Overview</h4>
-            <p>Use this endpoint to poll for the outcome of an updated patient record.</p>
-            <h4>Request</h4>
-            <div class="httpparams">
-                <h5>Path parameters</h5>
-                <table data-disablesort="true">
-                    <tr>
-                        <th>Name</th>
-                        <th>Description</th>
-                    </tr>
-                    <tr><td class="httpparams__name">message_id</td>
-                        <td>
-                            <div>
-                                <div class="httpparams__description">
-                                    <div>
-                                        <span class="httpparams__datatype">String</span>
-                                        <div>The message ID of the accepted update that needs to be submitted to confirm the resource a successfully updated.</div>
-                                        <div>Example: <code class="codeinline">20200522091633363041000001</code></div>
+                    </td>
+                </tr>
+                                                                    </table>
+                                                                </div>
+                                        </article>
                                     </div>
-                                    <div class="httpparams__required">
-                                        Required
-                                    </div>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                </table>
+                    <div id="api-Polling" class="article-section">
+                        <h2>Endpoints: Polling</h2>
+                    </div>
+                                    <div id="api-Polling-polling" class="article-section-with-sub-heading">
+                                        <article id="api-Polling-polling-0">
+                                            <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+                                            <h3>Retrieve the outcome of the accepted update.</h3>
+                                            <div class="endpoint_path">
+                                                <div class="method">get</div>
+                                                <div class="pre"><pre>/Polling/{message_id}</pre></div>
+                                                        <div class="try"><a onclick="tryEndpointNow('/Polling/polling')" class="ctabtn-left ctabtn--nhs-digital-button" onkeyup="return vjsu.onKeyUp(event)">Try this API</a></div>
+                                            </div>
+                                            <p><h4 id="overview">Overview</h4>
+<p>Use this endpoint to poll for the outcome of an updated patient record.</p>
+                                                <h4>Request</h4>
+                                                <div class="httpparams">
+                                                    <h5>Path parameters</h5>
+                                                    <table data-disablesort="true">
+                                                        <tr>
+                                                            <th>Name</th>
+                                                            <th>Description</th>
+                                                        </tr>
+                                                            <tr><td class="httpparams__name">message_id</td>
+                                                            <td>
+                                                                <div>
+                                                                    <div class="httpparams__description">
+                                                                        <div>
+                                                                            <span class="httpparams__datatype">String</span>
+                                                                                <div>The message ID of the accepted update that needs to be submitted to confirm the resource a successfully updated.</div>
+                                                                                <div>Example: <code class="codeinline">20200522091633363041000001</code></div>
+                                                                        </div>
+                                                                            <div class="httpparams__required">
+                                                                                Required
+                                                                            </div>
+                                                                    </div>
+                                                                </div>
+                                                            </td>
+                                                            </tr>
+                                                    </table>
+                                                </div>
+                                                <div class="httpparams">
+                                                    <h5>Headers</h5>
+                                                    <table data-disablesort="true">
+                                                        <tr>
+                                                            <th>Name</th>
+                                                            <th>Description</th>
+                                                        </tr>
+                                                            <tr><td class="httpparams__name">NHSD-Session-URID</td>
+                                                            <td>
+                                                                <div>
+                                                                    <div class="httpparams__description">
+                                                                        <div>
+                                                                            <span class="httpparams__datatype">String</span>
+                                                                                <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>).</div>
+                                                                                <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
+                                                                                <div>Example: <code class="codeinline">555021935107</code></div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                            </td>
+                                                            </tr>
+                                                    </table>
+                                                </div>
+                                                    <h4>Response</h4>
+                                                <h5>HTTP status: 200</h5>
+                                                <div>Patient updated.</div>
+                                                    <div class="httpparams">
+                                                        <h6>Headers</h6>
+                                                        <table data-disablesort="true">
+                                                            <tr>
+                                                                <th>Name</th>
+                                                                <th>Description</th>
+                                                            </tr>
+                                                                <tr><td class="httpparams__name">ETag</td>
+                                                                <td>
+                                                                    <div>
+                                                                        <div class="httpparams__description">
+                                                                            <div>
+                                                                                <span class="httpparams__datatype">String</span>
+                                                                                    <div>Record version identifier enclosed in quotes and preceded by 'W/'. For example, <code class="codeinline">W/&quot;2&quot;</code>.</p>
+<p>Corresponds to <code class="codeinline">meta.versionId</code> attribute in the patient resource body.</div>
+                                                                                    <div>Pattern: <code class="codeinline">/^W\/"[0-9]+"$/</code></div>
+                                                                                    <div>Example: <code class="codeinline">W/"2"</code></div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </td>
+                                                                </tr>
+                                                        </table>
+                                                    </div>
+                                                        <h6>Body</h6>
+                                                            <div class="body__contenttype">
+                                                                <span class="body__contenttype__label">Content type: </span>
+                                                                <span class="body__contenttype__value">application/fhir+json</span>
+                                                            </div>
+                                                                <div class="body__schema__header">Schema
+                                                                    <span class="schema__header__buttons">
+                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+                                                                        <button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+                                                                    </span>
+                                                                </div>
+                                                                <div class="body__schema" data-schema-uuid="">
+                                                                    <table data-disablesort="true">
+                                                                        <thead>
+                                                                        <th>Name</th>
+                                                                        <th>Description</th>
+                                                                        </thead>
+<tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+    <td style="padding-left: 0.0em;" class="name_column">
+            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+        <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+        <div>
+            <code class="type">object</code>
+        </div>
+    </td>
+    <td class="description_column">
+    </td>
+</tr>
+    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+        <td style="padding-left: 1.5em;" class="name_column">
+            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+        <div><code class="propertyName">resourceType</code></div>
+            <div>
+                <code class="type">string</code>
             </div>
-            <div class="httpparams">
-                <h5>Headers</h5>
-                <table data-disablesort="true">
-                    <tr>
-                        <th>Name</th>
-                        <th>Description</th>
-                    </tr>
-                    <tr><td class="httpparams__name">NHSD-Session-URID</td>
-                        <td>
-                            <div>
-                                <div class="httpparams__description">
-                                    <div>
-                                        <span class="httpparams__datatype">String</span>
-                                        <div>A User Role ID (<code class="codeinline">URID</code>), also known as a User Role Profile ID (<code class="codeinline">URPID</code>).</div>
-                                        <div>Pattern: <code class="codeinline">/^[0-9]+$/</code></div>
-                                        <div>Example: <code class="codeinline">555021935107</code></div>
-                                    </div>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                </table>
+            <div><code class="readonly">read-only</code></div>
+        </td>
+        <td class="description_column">
+            <div class="description">FHIR resource type.</div>
+                <div>Default: <code class="codeinline default">Patient</code></div>
+        </td>
+    </tr>
+    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+        <td style="padding-left: 1.5em;" class="name_column">
+            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+        <div><code class="propertyName">id</code></div>
+            <div>
+                <code class="type">string</code>
             </div>
-            <h4>Response</h4>
-            <h5>HTTP status: 200</h5>
-            <div>Patient updated.</div>
-            <div class="httpparams">
-                <h6>Headers</h6>
-                <table data-disablesort="true">
-                    <tr>
-                        <th>Name</th>
-                        <th>Description</th>
-                    </tr>
-                    <tr><td class="httpparams__name">ETag</td>
-                        <td>
-                            <div>
-                                <div class="httpparams__description">
-                                    <div>
-                                        <span class="httpparams__datatype">String</span>
-                                        <div>Record version identifier enclosed in quotes and preceded by 'W/'. For example, <code class="codeinline">W/&quot;2&quot;</code>.</p>
-                                            <p>Corresponds to <code class="codeinline">meta.versionId</code> attribute in the patient resource body.</div>
-                                        <div>Pattern: <code class="codeinline">/^W\/"[0-9]+"$/</code></div>
-                                        <div>Example: <code class="codeinline">W/"2"</code></div>
-                                    </div>
-                                </div>
-                            </div>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-            <h6>Body</h6>
-            <div class="body__contenttype">
-                <span class="body__contenttype__label">Content type: </span>
-                <span class="body__contenttype__value">application/fhir+json</span>
-            </div>
-            <div class="body__schema__header">Schema
-                <span class="schema__header__buttons">
-<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
-<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
-</span>
-            </div>
-            <div class="body__schema" data-schema-uuid="">
-                <table data-disablesort="true">
-                    <thead>
-                    <th>Name</th>
-                    <th>Description</th>
-                    </thead>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
-                        <td style="padding-left: 0.0em;" class="name_column">
-                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
-                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
-                            <div>
-                                <code class="type">object</code>
-                            </div>
-                        </td>
-                        <td class="description_column">
-                        </td>
-                    </tr>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
-                        <td style="padding-left: 1.5em;" class="name_column">
-                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
-                            <div><code class="propertyName">resourceType</code></div>
-                            <div>
-                                <code class="type">string</code>
-                            </div>
-                            <div><code class="readonly">read-only</code></div>
-                        </td>
-                        <td class="description_column">
-                            <div class="description">FHIR resource type.</div>
-                            <div>Default: <code class="codeinline default">Patient</code></div>
-                        </td>
-                    </tr>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
-                        <td style="padding-left: 1.5em;" class="name_column">
-                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
-                            <div><code class="propertyName">id</code></div>
-                            <div>
-                                <code class="type">string</code>
-                            </div>
-                            <div><code class="required">required</code></div>
-                        </td>
-                        <td class="description_column">
-                            <div class="description">The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales. Always 10 digits and must be a <a href="https://www.datadictionary.nhs.uk/data_dictionary/attributes/n/nhs/nhs_number_de.asp">valid NHS Number</a>.</div>
-                            <div>Pattern: <code class="codeinline pattern">^\d{10}$</code></div>
-                            <div>Example: <code class="codeinline example">9000000009</code></div>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-            <h5>HTTP status: 400</h5>
-            <div>Client error after the patch was accepted and patient was not updated.</div>
-            <h6>Body</h6>
-            <div class="body__contenttype">
-                <span class="body__contenttype__label">Content type: </span>
-                <span class="body__contenttype__value">application/fhir+json</span>
-            </div>
-            <div class="body__example__header">Example</div>
-            <div class="body__example__summary">Business rule failure; start date was after the end date.</div>
-            <div><pre><code>{
-"resourceType" : "OperationOutcome",
-"issue" : [ {
-"severity" : "error",
-"code" : "structure",
-"details" : {
-"coding" : [ {
-"system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
-"version" : "1",
-"code" : "INVALID_UPDATE",
-"display" : "Invalid update with error - business effective start date is after the end date"
-} ]
-}
-} ]
+            <div><code class="required">required</code></div>
+        </td>
+        <td class="description_column">
+            <div class="description">The patient's NHS Number. The primary identifier of a patient, unique within NHS England and Wales. Always 10 digits and must be a <a href="https://www.datadictionary.nhs.uk/data_dictionary/attributes/n/nhs/nhs_number_de.asp">valid NHS Number</a>.</div>
+            <div>Pattern: <code class="codeinline pattern">^\d{10}$</code></div>
+                <div>Example: <code class="codeinline example">9000000009</code></div>
+        </td>
+    </tr>
+                                                                    </table>
+                                                                </div>
+                                                <h5>HTTP status: 400</h5>
+                                                <div>Client error after the patch was accepted and patient was not updated.</div>
+                                                        <h6>Body</h6>
+                                                            <div class="body__contenttype">
+                                                                <span class="body__contenttype__label">Content type: </span>
+                                                                <span class="body__contenttype__value">application/fhir+json</span>
+                                                            </div>
+                                                                        <div class="body__example__header">Example</div>
+                                                                <div class="body__example__summary">Business rule failure; start date was after the end date.</div>
+                                                                <div><pre><code>{
+  "resourceType" : "OperationOutcome",
+  "issue" : [ {
+    "severity" : "error",
+    "code" : "structure",
+    "details" : {
+      "coding" : [ {
+        "system" : "https://fhir.nhs.uk/R4/CodeSystem/Spine-ErrorOrWarningCode",
+        "version" : "1",
+        "code" : "INVALID_UPDATE",
+        "display" : "Invalid update with error - business effective start date is after the end date"
+      } ]
+    }
+  } ]
 }</code></pre></div>
-            <div class="body__schema__header">Schema
-                <span class="schema__header__buttons">
-<button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
-<button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
-</span>
+                                                                <div class="body__schema__header">Schema
+                                                                    <span class="schema__header__buttons">
+                                                                        <button class='schemaButton js collapseAll' onclick="collapseAll('')">Collapse all</button>
+                                                                        <button class='schemaButton js expandAll' onclick="expandAll('')">Expand all</button>
+                                                                    </span>
+                                                                </div>
+                                                                <div class="body__schema" data-schema-uuid="">
+                                                                    <table data-disablesort="true">
+                                                                        <thead>
+                                                                        <th>Name</th>
+                                                                        <th>Description</th>
+                                                                        </thead>
+<tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
+    <td style="padding-left: 0.0em;" class="name_column">
+            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+        <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
+        <div>
+            <code class="type">object</code>
+        </div>
+    </td>
+    <td class="description_column">
+        <div class="description">Outcome of an operation that does not result in a resource or bundle being returned (e.g. error, async/batch submission).</p>
+<p>Search outcomes:</p>
+<table data-disablesort="true">
+<thead>
+<tr>
+<th>Code</th>
+<th>Response Code</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>INVALID_SEARCH_DATA</td>
+<td>400</td>
+<td>The search parameters are invalid. A description of what exactly is at fault will be added to the display.</td>
+</tr>
+<tr>
+<td>TOO_MANY_MATCHES</td>
+<td>200</td>
+<td>Too many matches were found - user should be told to refine their search parameters.</td>
+</tr>
+</tbody>
+</table></div>
+    </td>
+</tr>
+    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+        <td style="padding-left: 1.5em;" class="name_column">
+            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+        <div><code class="propertyName">resourceType</code></div>
+            <div>
+                <code class="type">string</code>
             </div>
-            <div class="body__schema" data-schema-uuid="">
-                <table data-disablesort="true">
-                    <thead>
-                    <th>Name</th>
-                    <th>Description</th>
-                    </thead>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="0" colspan="2">
-                        <td style="padding-left: 0.0em;" class="name_column">
-                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
-                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
-                            <div>
-                                <code class="type">object</code>
-                            </div>
-                        </td>
-                        <td class="description_column">
-                            <div class="description">Outcome of an operation that does not result in a resource or bundle being returned (e.g. error, async/batch submission).</p>
-                                <p>Search outcomes:</p>
-                                <table data-disablesort="true">
-                                    <thead>
-                                    <tr>
-                                        <th>Code</th>
-                                        <th>Response Code</th>
-                                        <th>Description</th>
-                                    </tr>
-                                    </thead>
-                                    <tbody>
-                                    <tr>
-                                        <td>INVALID_SEARCH_DATA</td>
-                                        <td>400</td>
-                                        <td>The search parameters are invalid. A description of what exactly is at fault will be added to the display.</td>
-                                    </tr>
-                                    <tr>
-                                        <td>TOO_MANY_MATCHES</td>
-                                        <td>200</td>
-                                        <td>Too many matches were found - user should be told to refine their search parameters.</td>
-                                    </tr>
-                                    </tbody>
-                                </table></div>
-                        </td>
-                    </tr>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
-                        <td style="padding-left: 1.5em;" class="name_column">
-                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
-                            <div><code class="propertyName">resourceType</code></div>
-                            <div>
-                                <code class="type">string</code>
-                            </div>
-                            <div><code class="readonly">read-only</code></div>
-                        </td>
-                        <td class="description_column">
-                            <div class="description">FHIR Resource Type.</div>
-                            <div>Default: <code class="codeinline default">OperationOutcome</code></div>
-                        </td>
-                    </tr>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
-                        <td style="padding-left: 1.5em;" class="name_column">
-                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
-                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
-                            <div><code class="propertyName">issue</code></div>
-                            <div>
-                                <code class="type">array</code>
-                            </div>
-                        </td>
-                        <td class="description_column">
-                            <div class="description">List of issues that have occurred.</div>
-                            <div>Min items: <code class="codeinline minitems">1</code></div>
-                        </td>
-                    </tr>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="2" colspan="2">
-                        <td style="padding-left: 3.0em;" class="name_column">
-                            <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
-                            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 35.4%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span>
-                            <div>
-                                <code class="type">object</code>
-                            </div>
-                        </td>
-                        <td class="description_column">
-                        </td>
-                    </tr>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
-                        <td style="padding-left: 4.5em;" class="name_column">
-                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
-                            <div><code class="propertyName">severity</code></div>
-                            <div>
-                                <code class="type">string</code>
-                            </div>
-                            <div><code class="required">required</code></div>
-                        </td>
-                        <td class="description_column">
-                            <div class="description">Severity of the error.</div>
-                            <div>Allowed values: <code class="codeinline">fatal</code>, <code class="codeinline">error</code>, <code class="codeinline">warning</code>, <code class="codeinline">information</code></div>
+            <div><code class="readonly">read-only</code></div>
+        </td>
+        <td class="description_column">
+            <div class="description">FHIR Resource Type.</div>
+                <div>Default: <code class="codeinline default">OperationOutcome</code></div>
+        </td>
+    </tr>
+    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
+        <td style="padding-left: 1.5em;" class="name_column">
+                    <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+            <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+        <div><code class="propertyName">issue</code></div>
+            <div>
+                <code class="type">array</code>
+            </div>
+        </td>
+        <td class="description_column">
+            <div class="description">List of issues that have occurred.</div>
+            <div>Min items: <code class="codeinline minitems">1</code></div>
+        </td>
+    </tr>
+            <tr class="expanded" data-schema-uuid="" data-indentation="2" colspan="2">
+                <td style="padding-left: 3.0em;" class="name_column">
+                        <button class="collapser js" data-schema-uuid="" onclick="collapseChildren('')"></button>
+                    <span class="child-schema-border" style="--border-padding: 1.25em; --border-lightness: 35.4%"></span><span class="short-horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span>
+                    <div>
+                        <code class="type">object</code>
+                    </div>
+                </td>
+                <td class="description_column">
+                </td>
+            </tr>
+                <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
+                    <td style="padding-left: 4.5em;" class="name_column">
+                        <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
+                    <div><code class="propertyName">severity</code></div>
+                        <div>
+                            <code class="type">string</code>
+                        </div>
+                        <div><code class="required">required</code></div>
+                    </td>
+                    <td class="description_column">
+                        <div class="description">Severity of the error.</div>
+                        <div>Allowed values: <code class="codeinline">fatal</code>, <code class="codeinline">error</code>, <code class="codeinline">warning</code>, <code class="codeinline">information</code></div>
                             <div>Example: <code class="codeinline example">error</code></div>
-                        </td>
-                    </tr>
-                    <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
-                        <td style="padding-left: 4.5em;" class="name_column">
-                            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
-                            <div><code class="propertyName">code</code></div>
-                            <div>
-                                <code class="type">string</code>
-                            </div>
-                            <div><code class="required">required</code></div>
-                        </td>
-                        <td class="description_column">
-                            <div class="description">FHIR error code.</div>
-                            <div>Allowed values: <code class="codeinline">invalid</code>, <code class="codeinline">structure</code>, <code class="codeinline">required</code>, <code class="codeinline">value</code></div>
+                    </td>
+                </tr>
+                <tr class="expanded" data-schema-uuid="" data-indentation="3" colspan="2">
+                    <td style="padding-left: 4.5em;" class="name_column">
+                        <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
+                    <div><code class="propertyName">code</code></div>
+                        <div>
+                            <code class="type">string</code>
+                        </div>
+                        <div><code class="required">required</code></div>
+                    </td>
+                    <td class="description_column">
+                        <div class="description">FHIR error code.</div>
+                        <div>Allowed values: <code class="codeinline">invalid</code>, <code class="codeinline">structure</code>, <code class="codeinline">required</code>, <code class="codeinline">value</code></div>
                             <div>Example: <code class="codeinline example">invalid</code></div>
-                        </td>
-                    </tr>
-                </table>
-            </div>
-        </article>
+                    </td>
+                </tr>
+                                                                    </table>
+                                                                </div>
+                                        </article>
+                                    </div>
     </div>
-</div>

--- a/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/oasV3_complete.json
+++ b/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/oasV3_complete.json
@@ -106,6 +106,11 @@
                                             "type": "string",
                                             "description": "FHIR Bundle Type.",
                                             "default": "searchset"
+                                        },
+                                        "deathDateTime" : {
+                                            "type": "string",
+                                            "format": "date-time",
+                                            "example": "2021-04-22T10:00:00+00:00"
                                         }
                                     }
                                 },
@@ -790,6 +795,11 @@
                         "type": "string",
                         "pattern": "^\\d{10}$",
                         "example": "9000000009"
+                    },
+                    "deathDateTime" : {
+                        "type": "string",
+                        "format": "date-time",
+                        "example": "2021-04-22T10:00:00+00:00"
                     }
                 }
             }

--- a/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/oasV3_incomplete_no_components-field.html
+++ b/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/oasV3_incomplete_no_components-field.html
@@ -482,7 +482,7 @@
     </tr>
     <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
         <td style="padding-left: 1.5em;" class="name_column">
-            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
+            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
         <div><code class="propertyName">type</code></div>
             <div>
                 <code class="type">string</code>
@@ -491,19 +491,6 @@
         <td class="description_column">
             <div class="description">FHIR Bundle Type.</div>
                 <div>Default: <code class="codeinline default">searchset</code></div>
-        </td>
-    </tr>
-    <tr class="expanded" data-schema-uuid="" data-indentation="1" colspan="2">
-        <td style="padding-left: 1.5em;" class="name_column">
-            <span class="horizontal-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="short-vertical-schema-border" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
-        <div><code class="propertyName">deathDateTime</code></div>
-            <div>
-                <code class="type">string</code>
-                <code class="format">date-time</code>
-            </div>
-        </td>
-        <td class="description_column">
-                <div>Example: <code class="codeinline example">2021-04-22T10:00Z</code></div>
         </td>
     </tr>
                                                                     </table>

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <bloomreach.forge.ipfilter.version>3.1.0</bloomreach.forge.ipfilter.version>
 
         <bloomreach.inference-engine.version>4.0.0</bloomreach.inference-engine.version>
-        <com.fasterxml.jackson.version>2.11.2</com.fasterxml.jackson.version>
+        <com.fasterxml.jackson.version>2.12.2</com.fasterxml.jackson.version>
 
         <hippo-addon-inference-engine.version>3.0.1</hippo-addon-inference-engine.version>
 


### PR DESCRIPTION
Recent update of swagger-codegen-generators from
1.0.25 to 1.0.26 broke importing and re-rendering
of API specifications as the new version of the
library was compiled with newer Jackson version.

This commit fixes this by upgrading Jackson dependencies
to corresponding from version 2.11.2 to 2.12.2.

Also:
* In SchemaHelperTest restores a test case previously
  deleted by mistake.
* Makes SchemaHelperTest no longer create a temporary
  JSON datafile (feeding JSON to parser directly, instead).
* Expands test case
  rendersSpecification_whenCompleteOpenApiJsonAsHtml
  with data that triggered the (now fixed) bug.