### PR TITLE
ADZ-1243 Updater Script to update nodes.

### DIFF
--- a/cms/src/test/java/uk/nhs/digital/apispecs/swagger/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/swagger/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest.java
@@ -21,6 +21,7 @@ import org.mockito.Mock;
 import uk.nhs.digital.apispecs.model.ApiSpecificationDocument;
 import uk.nhs.digital.test.util.TestDataCache;
 
+
 @RunWith(DataProviderRunner.class)
 public class SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest {
 

--- a/repository-data/README.md
+++ b/repository-data/README.md
@@ -19,12 +19,15 @@ when deploying the application locally (-Pcargo.run), but not included when buil
 -Pdist-with-development-data. You can add repository data into the development module by moving YAML
 sources, or by configuring auto-export to export certain repository paths to the development module.
 
+This module also provides [updater scripts](https://documentation.bloomreach.com/14/library/concepts/update/updater-scripts.html). To run any of them, access http://localhost:8080/cms/systemupdater with the application running locally.
+ApiSpecificationRenderer is one such script, helping to shorten development cycle when making changes to the logic of rendering API specifications, where it allows to quickly see their effect without having to restart the application.
+
 The *webfiles* module is intended to contribute webfiles (only) to the repository data. Like the
 application module, it is intended to be included on every environment.
 
 If your application requires so, you can create more repository-data submodules to be deployed to the
 environments of your liking, similar to above described default setup.
 
-NOTE: We have added another module called local which contains the bare minimum config required to run 
+NOTE: We have added another module called local which contains the bare minimum config required to run
 and test locally without including development data. This is useful for testing locally
 on a 'production like' environment.

--- a/repository-data/local/src/main/resources/hcm-config/configuration/update/ApiSpecificationRenderer/ApiSpecificationRenderer.groovy
+++ b/repository-data/local/src/main/resources/hcm-config/configuration/update/ApiSpecificationRenderer/ApiSpecificationRenderer.groovy
@@ -1,0 +1,219 @@
+package org.hippoecm.frontend.plugins.cms.admin.updater
+
+import org.hippoecm.repository.util.JcrUtils
+
+import javax.jcr.*
+import org.onehippo.repository.update.BaseNodeUpdateVisitor
+
+import java.util.stream.Collectors
+
+class ApiSpecificationRenderer extends BaseNodeUpdateVisitor {
+
+    // target/tomcat9x is the current working directory.
+    // All relative paths in this script are relative to that directory.
+
+    // CLASSES_DIR is relative to that directory.
+    private static final String CLASSES_DIR = "temp/CodegenRunner"
+
+    private String specificationJsonFileToRender
+
+    private String html
+
+    private String homePath = System.getProperty("user.home")
+
+    @Override
+    void initialize(final Session session) throws RepositoryException {
+        super.initialize(session)
+
+        log.info("INITIALISING...")
+
+        specificationJsonFileToRender = parametersMap['specificationJsonFile']
+
+        "mkdir ${CLASSES_DIR}".execute()
+
+        compileClasses()
+
+        html = generateHtml()
+
+        log.info("INITIALISING DONE")
+    }
+
+    @Override
+    boolean doUpdate(Node node) {
+        // Query returns the hippo:handle node for the document
+        // (which has the 3 variants)
+        try {
+            if (node.hasNodes()) {
+                return updateNode(node)
+            }
+        } catch (e) {
+            log.error("Failed to process record ${node}.", e)
+        }
+
+        return false
+    }
+
+    @Override
+    boolean undoUpdate(Node node) throws RepositoryException, UnsupportedOperationException {
+        return false
+    }
+
+    boolean updateNode(Node n) {
+        def nodeType = n.getPrimaryNodeType().getName()
+
+        if ("website:apispecification".equals(nodeType)) {
+
+            JcrUtils.ensureIsCheckedOut(n)
+
+            n.setProperty("website:html", html)
+
+            log.info("UPDATED")
+
+            return true
+        }
+
+        return false
+    }
+
+    void compileClasses() {
+
+        log.info("COMPILATION...")
+
+
+        def command = [
+                "javac",
+                "-d", CLASSES_DIR,
+                "-classpath", String.join(":",
+            "${homePath}/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.12.2/jackson-annotations-2.12.2.jar",
+            "${homePath}/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.12.2/jackson-core-2.12.2.jar",
+            "${homePath}/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.12.2/jackson-databind-2.12.2.jar",
+            "${homePath}/.m2/repository/com/github/jknack/handlebars-helpers/4.2.0/handlebars-helpers-4.2.0.jar",
+            "${homePath}/.m2/repository/com/github/jknack/handlebars/4.2.0/handlebars-4.2.0.jar",
+            "${homePath}/.m2/repository/commons-io/commons-io/2.8.0/commons-io-2.8.0.jar",
+            "${homePath}/.m2/repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar",
+            "${homePath}/.m2/repository/io/swagger/codegen/v3/swagger-codegen-generators/1.0.26/swagger-codegen-generators-1.0.26.jar",
+            "${homePath}/.m2/repository/io/swagger/codegen/v3/swagger-codegen/3.0.26/swagger-codegen-3.0.26.jar",
+            "${homePath}/.m2/repository/io/swagger/core/v3/swagger-models/2.1.7/swagger-models-2.1.7.jar",
+            "${homePath}/.m2/repository/io/swagger/parser/v3/swagger-parser-core/2.0.26/swagger-parser-core-2.0.26.jar",
+            "${homePath}/.m2/repository/io/swagger/parser/v3/swagger-parser-v3/2.0.26/swagger-parser-v3-2.0.26.jar",
+            "${homePath}/.m2/repository/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar",
+            "${homePath}/.m2/repository/org/commonmark/commonmark-ext-gfm-tables/0.17.0/commonmark-ext-gfm-tables-0.17.0.jar",
+            "${homePath}/.m2/repository/org/commonmark/commonmark/0.17.0/commonmark-0.17.0.jar",
+            "${homePath}/.m2/repository/org/jetbrains/annotations/18.0.0/annotations-18.0.0.jar",
+            "${homePath}/.m2/repository/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar",
+        ),
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/swagger/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverter.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/swagger/ApiSpecificationStaticHtml2Codegen.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/schema/SchemaHelper.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/MarkdownHelper.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/schema/IndentationHelper.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/TemplateRenderingException.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/schema/ContextModelsStack.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/IfNotNullHelper.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/schema/IfRequiredHelper.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/EnumHelper.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/schema/TypeAnyHelper.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/schema/SchemaRenderingException.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/schema/JacksonPrettyJsonHelper.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/schema/TypeAnySanitisingHelper.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/VariableValueHelper.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/BorderHelper.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/UuidHelper.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/schema/ContextModelsStack.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/schema/UniqueModelStackExtractor.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/HasOneItemHelper.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/IsAnyTrueHelper.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/HeadingsHyperlinksFromMarkdownHelper.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/handlebars/StringBooleanVariableHelper.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/swagger/model/BodyWithMediaTypesExtractor.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/CodegenParameterExampleHtmlRenderer.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/CodegenParamDefinition.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/CodegenParamSchema.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/ParamExample.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/commonmark/CommonmarkMarkdownConverter.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/commonmark/TableSortOffAttributeProvider.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/commonmark/HeadingAttributeProvider.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/commonmark/CodeAttributeProvider.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/commonmark/MarkdownConversionException.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/swagger/request/bodyextractor/ToPrettyJsonStringDeserializer.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/OpenApiSpecificationJsonToHtmlConverter.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/CodegenParamDefinition.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/swagger/model/BodyWithMediaTypeObjects.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/swagger/model/MediaTypeObjects.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/swagger/model/MediaTypeObject.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/swagger/model/ExampleObject.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/swagger/model/SchemaObject.java",
+                "../../cms/src/main/java/uk/nhs/digital/ExceptionUtils.java",
+                "../../repository-data/local/src/main/resources/hcm-config/configuration/update/ApiSpecificationRenderer/CodegenRunner.java",
+        ].stream().collect(Collectors.joining(" "))
+
+        log.info("COMPILATION COMMAND: ${command}")
+
+        def stderr = new StringBuilder()
+        def stdout = new StringBuilder()
+
+        def process = command.execute()
+        process.consumeProcessOutputStream(stdout)
+        process.consumeProcessErrorStream(stderr)
+        process.waitFor()
+
+        log.info("COMPILATION STDOUT: $stdout")
+        log.info("COMPILATION STDERR: $stderr")
+
+        log.info("COMPILATION DONE")
+    }
+
+    String generateHtml() {
+
+        log.info("RENDERING...")
+
+        final command = [
+                "java",
+                "-classpath", String.join(":",
+                CLASSES_DIR,
+            "${homePath}/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.12.2/jackson-annotations-2.12.2.jar",
+            "${homePath}/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.12.2/jackson-core-2.12.2.jar",
+            "${homePath}/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.12.2/jackson-databind-2.12.2.jar",
+            "${homePath}/.m2/repository/com/github/jknack/handlebars-helpers/4.2.0/handlebars-helpers-4.2.0.jar",
+            "${homePath}/.m2/repository/com/github/jknack/handlebars/4.2.0/handlebars-4.2.0.jar",
+            "${homePath}/.m2/repository/commons-io/commons-io/2.8.0/commons-io-2.8.0.jar",
+            "${homePath}/.m2/repository/commons-lang/commons-lang/2.6/commons-lang-2.6.jar",
+            "${homePath}/.m2/repository/io/swagger/codegen/v3/swagger-codegen-generators/1.0.26/swagger-codegen-generators-1.0.26.jar",
+            "${homePath}/.m2/repository/io/swagger/codegen/v3/swagger-codegen/3.0.26/swagger-codegen-3.0.26.jar",
+            "${homePath}/.m2/repository/io/swagger/core/v3/swagger-models/2.1.7/swagger-models-2.1.7.jar",
+            "${homePath}/.m2/repository/io/swagger/parser/v3/swagger-parser-core/2.0.26/swagger-parser-core-2.0.26.jar",
+            "${homePath}/.m2/repository/io/swagger/parser/v3/swagger-parser-v3/2.0.26/swagger-parser-v3-2.0.26.jar",
+            "${homePath}/.m2/repository/org/apache/commons/commons-lang3/3.12.0/commons-lang3-3.12.0.jar",
+            "${homePath}/.m2/repository/org/commonmark/commonmark-ext-gfm-tables/0.17.0/commonmark-ext-gfm-tables-0.17.0.jar",
+            "${homePath}/.m2/repository/org/commonmark/commonmark/0.17.0/commonmark-0.17.0.jar",
+            "${homePath}/.m2/repository/org/jetbrains/annotations/18.0.0/annotations-18.0.0.jar",
+            "${homePath}/.m2/repository/org/slf4j/slf4j-api/1.7.30/slf4j-api-1.7.30.jar",
+            "${homePath}/.m2/repository/com/fasterxml/jackson/dataformat/jackson-dataformat-yaml/2.12.2/jackson-dataformat-yaml-2.12.2.jar",
+            "${homePath}/.m2/repository/org/yaml/snakeyaml/1.28/snakeyaml-1.28.jar",
+            "${homePath}/.m2/repository/io/swagger/core/v3/swagger-core/2.1.4/swagger-core-2.1.4.jar",
+            "${homePath}/.m2/repository/com/fasterxml/jackson/datatype/jackson-datatype-jsr310/2.12.1/jackson-datatype-jsr310-2.12.1.jar",
+            "../../cms/src/main/resources"
+        ),
+                "CodegenRunner",
+                specificationJsonFileToRender,
+        ].stream().collect(Collectors.joining(" "))
+
+        log.info("RENDERING COMMAND: ${command}")
+
+        def stderr = new StringBuilder()
+        def stdout = new StringBuilder()
+
+        def process = command.execute()
+        process.consumeProcessOutputStream(stdout)
+        process.consumeProcessErrorStream(stderr)
+        process.waitFor()
+
+        log.info("RENDERING STDOUT: $stdout")
+        log.info("RENDERING STDERR: $stderr")
+
+        log.info("RENDERING DONE")
+
+        return stdout
+    }
+
+}

--- a/repository-data/local/src/main/resources/hcm-config/configuration/update/ApiSpecificationRenderer/ApiSpecificationRenderer.yaml
+++ b/repository-data/local/src/main/resources/hcm-config/configuration/update/ApiSpecificationRenderer/ApiSpecificationRenderer.yaml
@@ -1,0 +1,23 @@
+---
+definitions:
+  config:
+    /hippo:configuration/hippo:update/hippo:registry/ApiSpecificationRenderer:
+      hipposys:batchsize: 10
+      hipposys:description: |
+        To be used during development of rendering of OpenAPI specifications to shorten feedback cycle - change the rendering logic
+        (Java code, *.mustache templates) and run this updater to quickly see the effect of your changes on the rendered HTML.
+        Renders OpenAPI specification given by specificationJsonFile parameter (which you can override via 'Parameters' field)
+        and saves it in a document ready to be displayed at http://localhost:8080/site/developer/api-catalogue/doc-with-mapped-taxonomy-tags-a
+        Compiles all the code necessary to convert OAS JSON to HTML, and uses the latest *.mustache templates so that any changes
+        to the rendering logic can be tested immediately, without having to rebuild and restart the application.
+        TO BE ONLY USED IN DEVELOPMENT ON LOCAL MACHINE!
+      hipposys:dryrun: false
+      hipposys:loglevel: DEBUG
+      hipposys:parameters: '{ "specificationJsonFile": "../../../hippo/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/oasV3_complete.json"
+        }'
+      hipposys:query: /jcr:root/content/documents/corporate-website/developer/api-catalogue/doc-with-mapped-taxonomy-tags-a/doc-with-mapped-taxonomy-tags-a
+      hipposys:script:
+        resource: /configuration/update/ApiSpecificationRenderer/ApiSpecificationRenderer.groovy
+        type: string
+      hipposys:throttle: 1000
+      jcr:primaryType: hipposys:updaterinfo

--- a/repository-data/local/src/main/resources/hcm-config/configuration/update/ApiSpecificationRenderer/CodegenRunner.java
+++ b/repository-data/local/src/main/resources/hcm-config/configuration/update/ApiSpecificationRenderer/CodegenRunner.java
@@ -1,0 +1,30 @@
+import org.apache.commons.io.FileUtils;
+import uk.nhs.digital.apispecs.swagger.SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverter;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+class CodegenRunner {
+
+    public static void main(String[] args) {
+
+        final SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverter converter =
+            new SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverter();
+
+        final String pathToSpecJsonFile = args[0];
+
+        final String json = getJson(pathToSpecJsonFile);
+
+        final String html = converter.htmlFrom(json);
+
+        System.out.println(html);
+    }
+
+    private static String getJson(final String specJsonFilePath) {
+        try {
+            return FileUtils.readFileToString(new File(specJsonFilePath), "UTF-8");
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read spec JSON from " + specJsonFilePath, e);
+        }
+    }
+}


### PR DESCRIPTION
We have implemented a solution to automate a manual process. 
The updater editor allows developers to run Groovy updater scripts against a running repository from within the CMS UI. This allows us to update the "frontend" code without restart the server. 

To test run it locally and go to: http://localhost:8080/cms/systemupdater 
Select rerenderScpecs from the list. Update two variables with your local paths and click execute. 
