### PR TITLE
[ADZ-769] ADZ-769 implementing mechanism for ordering endpoint headings

### DIFF
--- a/cms/src/main/java/uk/nhs/digital/apispecs/swagger/CodegenDefaultGenerator.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/swagger/CodegenDefaultGenerator.java
@@ -1,0 +1,51 @@
+package uk.nhs.digital.apispecs.swagger;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+
+import io.swagger.codegen.v3.CodegenOperation;
+import io.swagger.codegen.v3.DefaultGenerator;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.tags.Tag;
+
+import java.util.*;
+
+/**
+ * Some producer teams require ordering their endpoints in a non-lexographical order.
+ * This requires a custom extension of the DefaultGenerator provided by CodeGen.
+ *
+ * This class CodegenDefaultGenerator extends DefaultGenerator class and sorts CodegenOperations before returning them.
+ * See the method orderedByDeclaredTags.
+ */
+public class CodegenDefaultGenerator extends DefaultGenerator {
+
+    @Override
+    public Map<String, List<CodegenOperation>> processPaths(Paths paths) {
+        Map<String, List<CodegenOperation>> ops = super.processPaths(paths);
+        return orderedByDeclaredTags(ops);
+    }
+
+    private Map<String, List<CodegenOperation>> orderedByDeclaredTags(final Map<String, List<CodegenOperation>> operationsByTags) {
+        final List<String> declaredTagNames = operationsByTags.containsKey("Default")
+            ? new ArrayList<>(singletonList("Default"))
+            : new ArrayList<>(operationsByTags.size());
+
+        declaredTagNames.addAll(
+            Optional.ofNullable(openAPI.getTags())
+                .orElse(Collections.emptyList())
+                .stream()
+                .map(Tag::getName)
+                .map(config::sanitizeTag)
+                .collect(toList())
+        );
+
+        final Map<String, List<CodegenOperation>> orderedOperationsByTags = new LinkedHashMap<>(operationsByTags.size());
+
+        declaredTagNames.stream()
+            .filter(operationsByTags::containsKey)
+            .forEachOrdered(tagName -> orderedOperationsByTags.put(tagName, operationsByTags.get(tagName)));
+
+        return orderedOperationsByTags;
+    }
+
+}

--- a/cms/src/main/java/uk/nhs/digital/apispecs/swagger/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverter.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/swagger/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverter.java
@@ -85,7 +85,7 @@ public class SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverter implements Op
             .config(codegenConfig)
             .setOpenAPI(openApiModel);
 
-        return new DefaultGenerator().opts(clientOptInput);
+        return new CodegenDefaultGenerator().opts(clientOptInput);
     }
 
     private String filesystemPathFromClassPathResource(final String resourceClassPath) {

--- a/cms/src/test/java/uk/nhs/digital/apispecs/handlebars/HeadingsHyperlinksFromMarkdownHelperTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/handlebars/HeadingsHyperlinksFromMarkdownHelperTest.java
@@ -27,7 +27,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import uk.nhs.digital.apispecs.handlebars.HeadingsHyperlinksFromMarkdownHelper.HeadingModel;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.stream.IntStream;
 

--- a/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/oasV3_operationIdsInVariousFormats.html
+++ b/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/oasV3_operationIdsInVariousFormats.html
@@ -10,16 +10,6 @@
                         Top of page
                     </a>
                 </li>
-                <li class="nhsd-m-sticky-navigation__item" data-nav-content="api-">
-                    <a class="nhsd-a-link" href="#api-">
-                        Endpoints:
-                    </a>
-                </li>
-                <li class="nhsd-m-sticky-navigation__item nhsd-m-sticky-navigation__item--nested" data-nav-content="api--snake_case">
-                    <a class="nhsd-a-link" href="#api--snake_case">
-                        Get snake_case operation
-                    </a>
-                </li>
                 <li class="nhsd-m-sticky-navigation__item" data-nav-content="api-endpoints">
                     <a class="nhsd-a-link" href="#api-endpoints">
                         Endpoints
@@ -71,31 +61,6 @@
         <p class="nhsd-t-body">A sample swagger server</p>
     </div>
     <hr class="nhsd-a-horizontal-rule">
-    <h2 id="api-" class="nhsd-t-heading-xl">Endpoints: </h2>
-    <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-    <h3 id="api--snake_case" class="nhsd-t-heading-l">Get snake_case operation</h3>
-    <div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
-        <div class="nhsd-t-row">
-            <div class="nhsd-t-col-xs-12 nhsd-t-col-s-9 nhsd-t-heading-s nhsd-t-flex nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3">
-                <span class="nhsd-!t-col-white nhsd-t-heading-l nhsd-t-display-contents nhsd-t-text-transform-uppercase">get</span>
-                <span class="nhsd-!t-col-white nhsd-t-heading-s nhsd-t-display-contents"><pre class="nshd-t-wrap-text-pre nhsd-t-overflow-wrap-text nhsd-t-display-contents">/path-b</pre></span>
-            </div>
-            <div class="nhsd-t-col-xs-12 nhsd-t-col-s-3">
-                <div class="nhsd-t-float-right nhsd-api-spec__try-this-api__button nhsd-!t-display-hide">
-                    <button class="nhsd-a-button nhsd-a-button--outline nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3 nhsd-t-width-full" type="button"
-                            onclick="tryEndpointNow('//snake_case')">
-                        <span class="nhsd-a-button__label">Try this API</span>
-                        <span class="nhsd-a-icon nhsd-a-icon--size-m">
-<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
-<path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
-</svg>
-</span>
-                    </button>
-                </div>
-            </div>
-        </div>
-    </div>
-    <hr class="nhsd-a-horizontal-rule">
     <h2 id="api-endpoints" class="nhsd-t-heading-xl">Endpoints</h2>
     <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
     <h3 id="api-Default-12345" class="nhsd-t-heading-l">Pu numbers operation</h3>
@@ -111,10 +76,10 @@
                             onclick="tryEndpointNow('/default/12345')">
                         <span class="nhsd-a-button__label">Try this API</span>
                         <span class="nhsd-a-icon nhsd-a-icon--size-m">
-<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
-<path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
-</svg>
-</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
+                                <path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
+                            </svg>
+                        </span>
                     </button>
                 </div>
             </div>
@@ -134,10 +99,10 @@
                             onclick="tryEndpointNow('/default/ALLCAPS')">
                         <span class="nhsd-a-button__label">Try this API</span>
                         <span class="nhsd-a-icon nhsd-a-icon--size-m">
-<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
-<path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
-</svg>
-</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
+                                <path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
+                            </svg>
+                        </span>
                     </button>
                 </div>
             </div>
@@ -157,10 +122,10 @@
                             onclick="tryEndpointNow('/default/kebab-case')">
                         <span class="nhsd-a-button__label">Try this API</span>
                         <span class="nhsd-a-icon nhsd-a-icon--size-m">
-<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
-<path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
-</svg>
-</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
+                                <path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
+                            </svg>
+                        </span>
                     </button>
                 </div>
             </div>
@@ -180,10 +145,10 @@
                             onclick="tryEndpointNow('/default/mixed123withNubmers')">
                         <span class="nhsd-a-button__label">Try this API</span>
                         <span class="nhsd-a-icon nhsd-a-icon--size-m">
-<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
-<path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
-</svg>
-</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
+                                <path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
+                            </svg>
+                        </span>
                     </button>
                 </div>
             </div>
@@ -203,10 +168,10 @@
                             onclick="tryEndpointNow('/default/with_space')">
                         <span class="nhsd-a-button__label">Try this API</span>
                         <span class="nhsd-a-icon nhsd-a-icon--size-m">
-<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
-<path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
-</svg>
-</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
+                                <path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
+                            </svg>
+                        </span>
                     </button>
                 </div>
             </div>
@@ -228,10 +193,10 @@
                             onclick="tryEndpointNow('/Patients/camelCase')">
                         <span class="nhsd-a-button__label">Try this API</span>
                         <span class="nhsd-a-icon nhsd-a-icon--size-m">
-<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
-<path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
-</svg>
-</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
+                                <path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
+                            </svg>
+                        </span>
                     </button>
                 </div>
             </div>

--- a/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/oasV3_operation_with_no_own_parameters.html
+++ b/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/oasV3_operation_with_no_own_parameters.html
@@ -1,412 +1,412 @@
 <div class="nhsd-t-col-xs-12 nhsd-t-col-s-4">
-    <!-- start sticky-nav -->
-    <div class="nhsd-m-sticky-navigation nhsd-!t-display-sticky nhsd-!t-display-sticky--offset-2 nhsd-!t-margin-bottom-6">
-        <span id="sticky-nav-header" class="nhsd-t-heading-xs nhsd-!t-margin-bottom-2">Page content</span>
-        <hr class="nhsd-a-horizontal-rule nhsd-a-horizontal-rule--size-xs nhsd-!t-margin-bottom-2"/>
-        <nav aria-labelledby="sticky-nav-header" class="nhsd-m-sticky-navigation__scrollable">
-            <ul>
-                <li class="nhsd-m-sticky-navigation__item" data-nav-content="Top of page">
-                    <a class="nhsd-a-link" href="#top">
-                        Top of page
-                    </a>
-                </li>
-                <li class="nhsd-m-sticky-navigation__item" data-nav-content="api-endpoints">
-                    <a class="nhsd-a-link" href="#api-endpoints">
-                        Endpoints
-                    </a>
-                </li>
-                <li class="nhsd-m-sticky-navigation__item nhsd-m-sticky-navigation__item--nested" data-nav-content="api-Default-path-with-no-params--operation-with-no-params">
-                    <a class="nhsd-a-link" href="#api-Default-path-with-no-params--operation-with-no-params">
-                        Path with no params: Operation with no parameters.
-                    </a>
-                </li>
-                <li class="nhsd-m-sticky-navigation__item nhsd-m-sticky-navigation__item--nested" data-nav-content="api-Default-path-with-no-params--operation-with-own-params-no-overlap-with-path">
-                    <a class="nhsd-a-link" href="#api-Default-path-with-no-params--operation-with-own-params-no-overlap-with-path">
-                        Path with no params: Operation with parameters.
-                    </a>
-                </li>
-                <li class="nhsd-m-sticky-navigation__item nhsd-m-sticky-navigation__item--nested" data-nav-content="api-Default-path-with-params--operation-with-no-params">
-                    <a class="nhsd-a-link" href="#api-Default-path-with-params--operation-with-no-params">
-                        Path with params: Operation with no parameters.
-                    </a>
-                </li>
-                <li class="nhsd-m-sticky-navigation__item nhsd-m-sticky-navigation__item--nested" data-nav-content="api-Default-path-with-params--operation-with-own-params-no-overlap-with-path">
-                    <a class="nhsd-a-link" href="#api-Default-path-with-params--operation-with-own-params-no-overlap-with-path">
-                        Path with params: Operation with non-overlapping parameters.
-                    </a>
-                </li>
-                <li class="nhsd-m-sticky-navigation__item nhsd-m-sticky-navigation__item--nested" data-nav-content="api-Default-path-with-params--operation-with-own-params-some-overriding-path">
-                    <a class="nhsd-a-link" href="#api-Default-path-with-params--operation-with-own-params-some-overriding-path">
-                        Path with params: Operation with overlapping parameters.
-                    </a>
-                </li>
-            </ul>
-        </nav>
-    </div>
-    <!-- end sticky-nav -->
+<!-- start sticky-nav -->
+<div class="nhsd-m-sticky-navigation nhsd-!t-display-sticky nhsd-!t-display-sticky--offset-2 nhsd-!t-margin-bottom-6">
+<span id="sticky-nav-header" class="nhsd-t-heading-xs nhsd-!t-margin-bottom-2">Page content</span>
+<hr class="nhsd-a-horizontal-rule nhsd-a-horizontal-rule--size-xs nhsd-!t-margin-bottom-2"/>
+<nav aria-labelledby="sticky-nav-header" class="nhsd-m-sticky-navigation__scrollable">
+    <ul>
+        <li class="nhsd-m-sticky-navigation__item" data-nav-content="Top of page">
+        <a class="nhsd-a-link" href="#top">
+            Top of page
+        </a>
+        </li>
+        <li class="nhsd-m-sticky-navigation__item" data-nav-content="api-endpoints">
+            <a class="nhsd-a-link" href="#api-endpoints">
+                Endpoints
+            </a>
+        </li>
+        <li class="nhsd-m-sticky-navigation__item nhsd-m-sticky-navigation__item--nested" data-nav-content="api-Default-path-with-no-params--operation-with-no-params">
+        <a class="nhsd-a-link" href="#api-Default-path-with-no-params--operation-with-no-params">
+            Path with no params: Operation with no parameters.
+        </a>
+        </li>
+        <li class="nhsd-m-sticky-navigation__item nhsd-m-sticky-navigation__item--nested" data-nav-content="api-Default-path-with-no-params--operation-with-own-params-no-overlap-with-path">
+        <a class="nhsd-a-link" href="#api-Default-path-with-no-params--operation-with-own-params-no-overlap-with-path">
+            Path with no params: Operation with parameters.
+        </a>
+        </li>
+        <li class="nhsd-m-sticky-navigation__item nhsd-m-sticky-navigation__item--nested" data-nav-content="api-Default-path-with-params--operation-with-no-params">
+        <a class="nhsd-a-link" href="#api-Default-path-with-params--operation-with-no-params">
+            Path with params: Operation with no parameters.
+        </a>
+        </li>
+        <li class="nhsd-m-sticky-navigation__item nhsd-m-sticky-navigation__item--nested" data-nav-content="api-Default-path-with-params--operation-with-own-params-no-overlap-with-path">
+        <a class="nhsd-a-link" href="#api-Default-path-with-params--operation-with-own-params-no-overlap-with-path">
+            Path with params: Operation with non-overlapping parameters.
+        </a>
+        </li>
+        <li class="nhsd-m-sticky-navigation__item nhsd-m-sticky-navigation__item--nested" data-nav-content="api-Default-path-with-params--operation-with-own-params-some-overriding-path">
+        <a class="nhsd-a-link" href="#api-Default-path-with-params--operation-with-own-params-some-overriding-path">
+            Path with params: Operation with overlapping parameters.
+        </a>
+        </li>
+    </ul>
+</nav>
+</div>
+<!-- end sticky-nav -->
 </div>
 <div id="content" class="nhsd-t-col-xs-12 nhsd-t-col-s-8" aria-label="Document content">
-    <!-- API Title: Minimal test specification -->
-    <div id="api-description">
-        <p class="nhsd-t-body">Specification where some operations do not define request parameters of their own, and where it's expected that all operations will 'inherit' parameters from their respective Path Objects.
-            See https://spec.openapis.org/oas/v3.0.3#parameter-object</p>
-    </div>
-    <hr class="nhsd-a-horizontal-rule">
-    <h2 id="api-endpoints" class="nhsd-t-heading-xl">Endpoints</h2>
-    <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-    <h3 id="api-Default-path-with-no-params--operation-with-no-params" class="nhsd-t-heading-l">Path with no params: Operation with no parameters.</h3>
-    <div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
-        <div class="nhsd-t-row">
-            <div class="nhsd-t-col-xs-12 nhsd-t-col-s-9 nhsd-t-heading-s nhsd-t-flex nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3">
-                <span class="nhsd-!t-col-white nhsd-t-heading-l nhsd-t-display-contents nhsd-t-text-transform-uppercase">get</span>
-                <span class="nhsd-!t-col-white nhsd-t-heading-s nhsd-t-display-contents"><pre class="nshd-t-wrap-text-pre nhsd-t-overflow-wrap-text nhsd-t-display-contents">/path-with-no-params/{PathPathParam}</pre></span>
-            </div>
-            <div class="nhsd-t-col-xs-12 nhsd-t-col-s-3">
-                <div class="nhsd-t-float-right nhsd-api-spec__try-this-api__button nhsd-!t-display-hide">
-                    <button class="nhsd-a-button nhsd-a-button--outline nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3 nhsd-t-width-full" type="button"
-                            onclick="tryEndpointNow('/default/path-with-no-params--operation-with-no-params')">
-                        <span class="nhsd-a-button__label">Try this API</span>
-                        <span class="nhsd-a-icon nhsd-a-icon--size-m">
+<!-- API Title: Minimal test specification -->
+<div id="api-description">
+    <p class="nhsd-t-body">Specification where some operations do not define request parameters of their own, and where it's expected that all operations will 'inherit' parameters from their respective Path Objects.
+        See https://spec.openapis.org/oas/v3.0.3#parameter-object</p>
+</div>
+<hr class="nhsd-a-horizontal-rule">
+<h2 id="api-endpoints" class="nhsd-t-heading-xl">Endpoints</h2>
+<!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+<h3 id="api-Default-path-with-no-params--operation-with-no-params" class="nhsd-t-heading-l">Path with no params: Operation with no parameters.</h3>
+<div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
+<div class="nhsd-t-row">
+    <div class="nhsd-t-col-xs-12 nhsd-t-col-s-9 nhsd-t-heading-s nhsd-t-flex nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3">
+    <span class="nhsd-!t-col-white nhsd-t-heading-l nhsd-t-display-contents nhsd-t-text-transform-uppercase">get</span>
+    <span class="nhsd-!t-col-white nhsd-t-heading-s nhsd-t-display-contents"><pre class="nshd-t-wrap-text-pre nhsd-t-overflow-wrap-text nhsd-t-display-contents">/path-with-no-params/{PathPathParam}</pre></span>
+</div>
+<div class="nhsd-t-col-xs-12 nhsd-t-col-s-3">
+<div class="nhsd-t-float-right nhsd-api-spec__try-this-api__button nhsd-!t-display-hide">
+<button class="nhsd-a-button nhsd-a-button--outline nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3 nhsd-t-width-full" type="button"
+onclick="tryEndpointNow('/default/path-with-no-params--operation-with-no-params')">
+<span class="nhsd-a-button__label">Try this API</span>
+<span class="nhsd-a-icon nhsd-a-icon--size-m">
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
 <path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
 </svg>
 </span>
-                    </button>
-                </div>
-            </div>
-        </div>
-    </div>
-    <p class="nhsd-t-body">Operation with no parameters of its own. Expectation: result should contain no parameters.</p>
-    <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-    <h3 id="api-Default-path-with-no-params--operation-with-own-params-no-overlap-with-path" class="nhsd-t-heading-l">Path with no params: Operation with parameters.</h3>
-    <div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
-        <div class="nhsd-t-row">
-            <div class="nhsd-t-col-xs-12 nhsd-t-col-s-9 nhsd-t-heading-s nhsd-t-flex nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3">
-                <span class="nhsd-!t-col-white nhsd-t-heading-l nhsd-t-display-contents nhsd-t-text-transform-uppercase">post</span>
-                <span class="nhsd-!t-col-white nhsd-t-heading-s nhsd-t-display-contents"><pre class="nshd-t-wrap-text-pre nhsd-t-overflow-wrap-text nhsd-t-display-contents">/path-with-no-params/{PathPathParam}</pre></span>
-            </div>
-            <div class="nhsd-t-col-xs-12 nhsd-t-col-s-3">
-                <div class="nhsd-t-float-right nhsd-api-spec__try-this-api__button nhsd-!t-display-hide">
-                    <button class="nhsd-a-button nhsd-a-button--outline nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3 nhsd-t-width-full" type="button"
-                            onclick="tryEndpointNow('/default/path-with-no-params--operation-with-own-params-no-overlap-with-path')">
-                        <span class="nhsd-a-button__label">Try this API</span>
-                        <span class="nhsd-a-icon nhsd-a-icon--size-m">
+</button>
+</div>
+</div>
+</div>
+</div>
+<p class="nhsd-t-body">Operation with no parameters of its own. Expectation: result should contain no parameters.</p>
+<!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+<h3 id="api-Default-path-with-no-params--operation-with-own-params-no-overlap-with-path" class="nhsd-t-heading-l">Path with no params: Operation with parameters.</h3>
+<div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
+<div class="nhsd-t-row">
+    <div class="nhsd-t-col-xs-12 nhsd-t-col-s-9 nhsd-t-heading-s nhsd-t-flex nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3">
+    <span class="nhsd-!t-col-white nhsd-t-heading-l nhsd-t-display-contents nhsd-t-text-transform-uppercase">post</span>
+    <span class="nhsd-!t-col-white nhsd-t-heading-s nhsd-t-display-contents"><pre class="nshd-t-wrap-text-pre nhsd-t-overflow-wrap-text nhsd-t-display-contents">/path-with-no-params/{PathPathParam}</pre></span>
+</div>
+<div class="nhsd-t-col-xs-12 nhsd-t-col-s-3">
+<div class="nhsd-t-float-right nhsd-api-spec__try-this-api__button nhsd-!t-display-hide">
+<button class="nhsd-a-button nhsd-a-button--outline nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3 nhsd-t-width-full" type="button"
+onclick="tryEndpointNow('/default/path-with-no-params--operation-with-own-params-no-overlap-with-path')">
+<span class="nhsd-a-button__label">Try this API</span>
+<span class="nhsd-a-icon nhsd-a-icon--size-m">
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
 <path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
 </svg>
 </span>
-                    </button>
-                </div>
-            </div>
-        </div>
-    </div>
-    <p class="nhsd-t-body">Operation with some parameters of its own. Expectation: result should contain all operation's parameters.</p>
-    <h4 class="nhsd-t-heading-m">Request</h4>
-    <h5 class="nhsd-t-heading-s">Path parameters</h5>
-    <div class="nhsd-m-table nhsd-t-body">
-        <table data-responsive data-no-sort>
-            <thead>
-            <tr>
-                <th class="nhsd-t-width-200">Name</th>
-                <th>Description</th>
-            </tr>
-            </thead>
-            <tr>
-                <td><code class="nhsd-!t-font-family-mono">PathPathParam</code></td>
-                <td>
-                    <p class="nhsd-t-body">Path parameter defined as path variable.</p>
-                    <div class="nhsd-!t-col-red">Required</div>
-                </td>
-            </tr>
-        </table>
-    </div>
-    <h5 class="nhsd-t-heading-s">Query parameters</h5>
-    <div class="nhsd-m-table nhsd-t-body">
-        <table data-responsive data-no-sort>
-            <thead>
-            <tr>
-                <th class="nhsd-t-width-200">Name</th>
-                <th>Description</th>
-            </tr>
-            </thead>
-            <tr>
-                <td><code class="nhsd-!t-font-family-mono">OperationQueryParamPost</code></td>
-                <td>
-                    <p class="nhsd-t-body">Operation parameter expected as a query parameter.</p>
-                </td>
-            </tr>
-        </table>
-    </div>
-    <h5 class="nhsd-t-heading-s">Headers</h5>
-    <div class="nhsd-m-table nhsd-t-body">
-        <table data-responsive data-no-sort>
-            <thead>
-            <tr>
-                <th class="nhsd-t-width-200">Name</th>
-                <th>Description</th>
-            </tr>
-            </thead>
-            <tr>
-                <td><code class="nhsd-!t-font-family-mono">OperationHeaderParamPost</code></td>
-                <td>
-                    <p class="nhsd-t-body">Operation parameter expected as a header.</p>
-                </td>
-            </tr>
-        </table>
-    </div>
-    <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-    <h3 id="api-Default-path-with-params--operation-with-no-params" class="nhsd-t-heading-l">Path with params: Operation with no parameters.</h3>
-    <div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
-        <div class="nhsd-t-row">
-            <div class="nhsd-t-col-xs-12 nhsd-t-col-s-9 nhsd-t-heading-s nhsd-t-flex nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3">
-                <span class="nhsd-!t-col-white nhsd-t-heading-l nhsd-t-display-contents nhsd-t-text-transform-uppercase">get</span>
-                <span class="nhsd-!t-col-white nhsd-t-heading-s nhsd-t-display-contents"><pre class="nshd-t-wrap-text-pre nhsd-t-overflow-wrap-text nhsd-t-display-contents">/path-with-params/{PathPathParam}</pre></span>
-            </div>
-            <div class="nhsd-t-col-xs-12 nhsd-t-col-s-3">
-                <div class="nhsd-t-float-right nhsd-api-spec__try-this-api__button nhsd-!t-display-hide">
-                    <button class="nhsd-a-button nhsd-a-button--outline nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3 nhsd-t-width-full" type="button"
-                            onclick="tryEndpointNow('/default/path-with-params--operation-with-no-params')">
-                        <span class="nhsd-a-button__label">Try this API</span>
-                        <span class="nhsd-a-icon nhsd-a-icon--size-m">
+</button>
+</div>
+</div>
+</div>
+</div>
+<p class="nhsd-t-body">Operation with some parameters of its own. Expectation: result should contain all operation's parameters.</p>
+<h4 class="nhsd-t-heading-m">Request</h4>
+<h5 class="nhsd-t-heading-s">Path parameters</h5>
+<div class="nhsd-m-table nhsd-t-body">
+<table data-responsive data-no-sort>
+    <thead>
+    <tr>
+        <th class="nhsd-t-width-200">Name</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tr>
+        <td><code class="nhsd-!t-font-family-mono">PathPathParam</code></td>
+        <td>
+            <p class="nhsd-t-body">Path parameter defined as path variable.</p>
+            <div class="nhsd-!t-col-red">Required</div>
+        </td>
+    </tr>
+</table>
+</div>
+<h5 class="nhsd-t-heading-s">Query parameters</h5>
+<div class="nhsd-m-table nhsd-t-body">
+<table data-responsive data-no-sort>
+    <thead>
+    <tr>
+        <th class="nhsd-t-width-200">Name</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tr>
+        <td><code class="nhsd-!t-font-family-mono">OperationQueryParamPost</code></td>
+        <td>
+            <p class="nhsd-t-body">Operation parameter expected as a query parameter.</p>
+        </td>
+    </tr>
+</table>
+</div>
+<h5 class="nhsd-t-heading-s">Headers</h5>
+<div class="nhsd-m-table nhsd-t-body">
+<table data-responsive data-no-sort>
+    <thead>
+    <tr>
+        <th class="nhsd-t-width-200">Name</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tr>
+        <td><code class="nhsd-!t-font-family-mono">OperationHeaderParamPost</code></td>
+        <td>
+            <p class="nhsd-t-body">Operation parameter expected as a header.</p>
+        </td>
+    </tr>
+</table>
+</div>
+<!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+<h3 id="api-Default-path-with-params--operation-with-no-params" class="nhsd-t-heading-l">Path with params: Operation with no parameters.</h3>
+<div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
+<div class="nhsd-t-row">
+    <div class="nhsd-t-col-xs-12 nhsd-t-col-s-9 nhsd-t-heading-s nhsd-t-flex nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3">
+    <span class="nhsd-!t-col-white nhsd-t-heading-l nhsd-t-display-contents nhsd-t-text-transform-uppercase">get</span>
+    <span class="nhsd-!t-col-white nhsd-t-heading-s nhsd-t-display-contents"><pre class="nshd-t-wrap-text-pre nhsd-t-overflow-wrap-text nhsd-t-display-contents">/path-with-params/{PathPathParam}</pre></span>
+</div>
+<div class="nhsd-t-col-xs-12 nhsd-t-col-s-3">
+<div class="nhsd-t-float-right nhsd-api-spec__try-this-api__button nhsd-!t-display-hide">
+<button class="nhsd-a-button nhsd-a-button--outline nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3 nhsd-t-width-full" type="button"
+onclick="tryEndpointNow('/default/path-with-params--operation-with-no-params')">
+<span class="nhsd-a-button__label">Try this API</span>
+<span class="nhsd-a-icon nhsd-a-icon--size-m">
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
 <path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
 </svg>
 </span>
-                    </button>
-                </div>
-            </div>
-        </div>
-    </div>
-    <p class="nhsd-t-body">Operation with no parameters of its own. Expectation: result should contain just path's parameters.</p>
-    <h4 class="nhsd-t-heading-m">Request</h4>
-    <h5 class="nhsd-t-heading-s">Path parameters</h5>
-    <div class="nhsd-m-table nhsd-t-body">
-        <table data-responsive data-no-sort>
-            <thead>
-            <tr>
-                <th class="nhsd-t-width-200">Name</th>
-                <th>Description</th>
-            </tr>
-            </thead>
-            <tr>
-                <td><code class="nhsd-!t-font-family-mono">PathPathParam</code></td>
-                <td>
-                    <p class="nhsd-t-body">Path parameter defined as path variable.</p>
-                    <div class="nhsd-!t-col-red">Required</div>
-                </td>
-            </tr>
-        </table>
-    </div>
-    <h5 class="nhsd-t-heading-s">Query parameters</h5>
-    <div class="nhsd-m-table nhsd-t-body">
-        <table data-responsive data-no-sort>
-            <thead>
-            <tr>
-                <th class="nhsd-t-width-200">Name</th>
-                <th>Description</th>
-            </tr>
-            </thead>
-            <tr>
-                <td><code class="nhsd-!t-font-family-mono">PathQueryParam</code></td>
-                <td>
-                    <p class="nhsd-t-body">Path parameter expected as a query parameter.</p>
-                </td>
-            </tr>
-        </table>
-    </div>
-    <h5 class="nhsd-t-heading-s">Headers</h5>
-    <div class="nhsd-m-table nhsd-t-body">
-        <table data-responsive data-no-sort>
-            <thead>
-            <tr>
-                <th class="nhsd-t-width-200">Name</th>
-                <th>Description</th>
-            </tr>
-            </thead>
-            <tr>
-                <td><code class="nhsd-!t-font-family-mono">PathHeaderParam</code></td>
-                <td>
-                    <p class="nhsd-t-body">Path parameter expected as a header.</p>
-                </td>
-            </tr>
-        </table>
-    </div>
-    <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-    <h3 id="api-Default-path-with-params--operation-with-own-params-no-overlap-with-path" class="nhsd-t-heading-l">Path with params: Operation with non-overlapping parameters.</h3>
-    <div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
-        <div class="nhsd-t-row">
-            <div class="nhsd-t-col-xs-12 nhsd-t-col-s-9 nhsd-t-heading-s nhsd-t-flex nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3">
-                <span class="nhsd-!t-col-white nhsd-t-heading-l nhsd-t-display-contents nhsd-t-text-transform-uppercase">post</span>
-                <span class="nhsd-!t-col-white nhsd-t-heading-s nhsd-t-display-contents"><pre class="nshd-t-wrap-text-pre nhsd-t-overflow-wrap-text nhsd-t-display-contents">/path-with-params/{PathPathParam}</pre></span>
-            </div>
-            <div class="nhsd-t-col-xs-12 nhsd-t-col-s-3">
-                <div class="nhsd-t-float-right nhsd-api-spec__try-this-api__button nhsd-!t-display-hide">
-                    <button class="nhsd-a-button nhsd-a-button--outline nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3 nhsd-t-width-full" type="button"
-                            onclick="tryEndpointNow('/default/path-with-params--operation-with-own-params-no-overlap-with-path')">
-                        <span class="nhsd-a-button__label">Try this API</span>
-                        <span class="nhsd-a-icon nhsd-a-icon--size-m">
+</button>
+</div>
+</div>
+</div>
+</div>
+<p class="nhsd-t-body">Operation with no parameters of its own. Expectation: result should contain just path's parameters.</p>
+<h4 class="nhsd-t-heading-m">Request</h4>
+<h5 class="nhsd-t-heading-s">Path parameters</h5>
+<div class="nhsd-m-table nhsd-t-body">
+<table data-responsive data-no-sort>
+    <thead>
+    <tr>
+        <th class="nhsd-t-width-200">Name</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tr>
+        <td><code class="nhsd-!t-font-family-mono">PathPathParam</code></td>
+        <td>
+            <p class="nhsd-t-body">Path parameter defined as path variable.</p>
+            <div class="nhsd-!t-col-red">Required</div>
+        </td>
+    </tr>
+</table>
+</div>
+<h5 class="nhsd-t-heading-s">Query parameters</h5>
+<div class="nhsd-m-table nhsd-t-body">
+<table data-responsive data-no-sort>
+    <thead>
+    <tr>
+        <th class="nhsd-t-width-200">Name</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tr>
+        <td><code class="nhsd-!t-font-family-mono">PathQueryParam</code></td>
+        <td>
+            <p class="nhsd-t-body">Path parameter expected as a query parameter.</p>
+        </td>
+    </tr>
+</table>
+</div>
+<h5 class="nhsd-t-heading-s">Headers</h5>
+<div class="nhsd-m-table nhsd-t-body">
+<table data-responsive data-no-sort>
+    <thead>
+    <tr>
+        <th class="nhsd-t-width-200">Name</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tr>
+        <td><code class="nhsd-!t-font-family-mono">PathHeaderParam</code></td>
+        <td>
+            <p class="nhsd-t-body">Path parameter expected as a header.</p>
+        </td>
+    </tr>
+</table>
+</div>
+<!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+<h3 id="api-Default-path-with-params--operation-with-own-params-no-overlap-with-path" class="nhsd-t-heading-l">Path with params: Operation with non-overlapping parameters.</h3>
+<div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
+<div class="nhsd-t-row">
+    <div class="nhsd-t-col-xs-12 nhsd-t-col-s-9 nhsd-t-heading-s nhsd-t-flex nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3">
+    <span class="nhsd-!t-col-white nhsd-t-heading-l nhsd-t-display-contents nhsd-t-text-transform-uppercase">post</span>
+    <span class="nhsd-!t-col-white nhsd-t-heading-s nhsd-t-display-contents"><pre class="nshd-t-wrap-text-pre nhsd-t-overflow-wrap-text nhsd-t-display-contents">/path-with-params/{PathPathParam}</pre></span>
+</div>
+<div class="nhsd-t-col-xs-12 nhsd-t-col-s-3">
+<div class="nhsd-t-float-right nhsd-api-spec__try-this-api__button nhsd-!t-display-hide">
+<button class="nhsd-a-button nhsd-a-button--outline nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3 nhsd-t-width-full" type="button"
+onclick="tryEndpointNow('/default/path-with-params--operation-with-own-params-no-overlap-with-path')">
+<span class="nhsd-a-button__label">Try this API</span>
+<span class="nhsd-a-icon nhsd-a-icon--size-m">
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
 <path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
 </svg>
 </span>
-                    </button>
-                </div>
-            </div>
-        </div>
-    </div>
-    <p class="nhsd-t-body">Operation with some parameters of its own, none overlapping with the path one. Expectation: result should contain all path's and operation's parameters.</p>
-    <h4 class="nhsd-t-heading-m">Request</h4>
-    <h5 class="nhsd-t-heading-s">Path parameters</h5>
-    <div class="nhsd-m-table nhsd-t-body">
-        <table data-responsive data-no-sort>
-            <thead>
-            <tr>
-                <th class="nhsd-t-width-200">Name</th>
-                <th>Description</th>
-            </tr>
-            </thead>
-            <tr>
-                <td><code class="nhsd-!t-font-family-mono">PathPathParam</code></td>
-                <td>
-                    <p class="nhsd-t-body">Path parameter defined as path variable.</p>
-                    <div class="nhsd-!t-col-red">Required</div>
-                </td>
-            </tr>
-        </table>
-    </div>
-    <h5 class="nhsd-t-heading-s">Query parameters</h5>
-    <div class="nhsd-m-table nhsd-t-body">
-        <table data-responsive data-no-sort>
-            <thead>
-            <tr>
-                <th class="nhsd-t-width-200">Name</th>
-                <th>Description</th>
-            </tr>
-            </thead>
-            <tr>
-                <td><code class="nhsd-!t-font-family-mono">PathQueryParam</code></td>
-                <td>
-                    <p class="nhsd-t-body">Path parameter expected as a query parameter.</p>
-                </td>
-            </tr>
-            <tr>
-                <td><code class="nhsd-!t-font-family-mono">OperationQueryParamPost</code></td>
-                <td>
-                    <p class="nhsd-t-body">Operation parameter expected as a query parameter.</p>
-                </td>
-            </tr>
-        </table>
-    </div>
-    <h5 class="nhsd-t-heading-s">Headers</h5>
-    <div class="nhsd-m-table nhsd-t-body">
-        <table data-responsive data-no-sort>
-            <thead>
-            <tr>
-                <th class="nhsd-t-width-200">Name</th>
-                <th>Description</th>
-            </tr>
-            </thead>
-            <tr>
-                <td><code class="nhsd-!t-font-family-mono">PathHeaderParam</code></td>
-                <td>
-                    <p class="nhsd-t-body">Path parameter expected as a header.</p>
-                </td>
-            </tr>
-            <tr>
-                <td><code class="nhsd-!t-font-family-mono">OperationHeaderParamPost</code></td>
-                <td>
-                    <p class="nhsd-t-body">Operation parameter expected as a header.</p>
-                </td>
-            </tr>
-        </table>
-    </div>
-    <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-    <h3 id="api-Default-path-with-params--operation-with-own-params-some-overriding-path" class="nhsd-t-heading-l">Path with params: Operation with overlapping parameters.</h3>
-    <div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
-        <div class="nhsd-t-row">
-            <div class="nhsd-t-col-xs-12 nhsd-t-col-s-9 nhsd-t-heading-s nhsd-t-flex nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3">
-                <span class="nhsd-!t-col-white nhsd-t-heading-l nhsd-t-display-contents nhsd-t-text-transform-uppercase">put</span>
-                <span class="nhsd-!t-col-white nhsd-t-heading-s nhsd-t-display-contents"><pre class="nshd-t-wrap-text-pre nhsd-t-overflow-wrap-text nhsd-t-display-contents">/path-with-params/{PathPathParam}</pre></span>
-            </div>
-            <div class="nhsd-t-col-xs-12 nhsd-t-col-s-3">
-                <div class="nhsd-t-float-right nhsd-api-spec__try-this-api__button nhsd-!t-display-hide">
-                    <button class="nhsd-a-button nhsd-a-button--outline nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3 nhsd-t-width-full" type="button"
-                            onclick="tryEndpointNow('/default/path-with-params--operation-with-own-params-some-overriding-path')">
-                        <span class="nhsd-a-button__label">Try this API</span>
-                        <span class="nhsd-a-icon nhsd-a-icon--size-m">
+</button>
+</div>
+</div>
+</div>
+</div>
+<p class="nhsd-t-body">Operation with some parameters of its own, none overlapping with the path one. Expectation: result should contain all path's and operation's parameters.</p>
+<h4 class="nhsd-t-heading-m">Request</h4>
+<h5 class="nhsd-t-heading-s">Path parameters</h5>
+<div class="nhsd-m-table nhsd-t-body">
+<table data-responsive data-no-sort>
+    <thead>
+    <tr>
+        <th class="nhsd-t-width-200">Name</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tr>
+        <td><code class="nhsd-!t-font-family-mono">PathPathParam</code></td>
+        <td>
+            <p class="nhsd-t-body">Path parameter defined as path variable.</p>
+            <div class="nhsd-!t-col-red">Required</div>
+        </td>
+    </tr>
+</table>
+</div>
+<h5 class="nhsd-t-heading-s">Query parameters</h5>
+<div class="nhsd-m-table nhsd-t-body">
+<table data-responsive data-no-sort>
+    <thead>
+    <tr>
+        <th class="nhsd-t-width-200">Name</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tr>
+        <td><code class="nhsd-!t-font-family-mono">PathQueryParam</code></td>
+        <td>
+            <p class="nhsd-t-body">Path parameter expected as a query parameter.</p>
+        </td>
+    </tr>
+    <tr>
+        <td><code class="nhsd-!t-font-family-mono">OperationQueryParamPost</code></td>
+        <td>
+            <p class="nhsd-t-body">Operation parameter expected as a query parameter.</p>
+        </td>
+    </tr>
+</table>
+</div>
+<h5 class="nhsd-t-heading-s">Headers</h5>
+<div class="nhsd-m-table nhsd-t-body">
+<table data-responsive data-no-sort>
+    <thead>
+    <tr>
+        <th class="nhsd-t-width-200">Name</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tr>
+        <td><code class="nhsd-!t-font-family-mono">PathHeaderParam</code></td>
+        <td>
+            <p class="nhsd-t-body">Path parameter expected as a header.</p>
+        </td>
+    </tr>
+    <tr>
+        <td><code class="nhsd-!t-font-family-mono">OperationHeaderParamPost</code></td>
+        <td>
+            <p class="nhsd-t-body">Operation parameter expected as a header.</p>
+        </td>
+    </tr>
+</table>
+</div>
+<!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+<h3 id="api-Default-path-with-params--operation-with-own-params-some-overriding-path" class="nhsd-t-heading-l">Path with params: Operation with overlapping parameters.</h3>
+<div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
+<div class="nhsd-t-row">
+    <div class="nhsd-t-col-xs-12 nhsd-t-col-s-9 nhsd-t-heading-s nhsd-t-flex nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3">
+    <span class="nhsd-!t-col-white nhsd-t-heading-l nhsd-t-display-contents nhsd-t-text-transform-uppercase">put</span>
+    <span class="nhsd-!t-col-white nhsd-t-heading-s nhsd-t-display-contents"><pre class="nshd-t-wrap-text-pre nhsd-t-overflow-wrap-text nhsd-t-display-contents">/path-with-params/{PathPathParam}</pre></span>
+</div>
+<div class="nhsd-t-col-xs-12 nhsd-t-col-s-3">
+<div class="nhsd-t-float-right nhsd-api-spec__try-this-api__button nhsd-!t-display-hide">
+<button class="nhsd-a-button nhsd-a-button--outline nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3 nhsd-t-width-full" type="button"
+onclick="tryEndpointNow('/default/path-with-params--operation-with-own-params-some-overriding-path')">
+<span class="nhsd-a-button__label">Try this API</span>
+<span class="nhsd-a-icon nhsd-a-icon--size-m">
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
 <path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
 </svg>
 </span>
-                    </button>
-                </div>
-            </div>
-        </div>
-    </div>
-    <p class="nhsd-t-body">Operation with some parameters of its own but also with params overriding the path ones. Expectation: result should contain all path's and operation's parameters, with definitions at the operation levels winning over their counterparts at the path level.</p>
-    <h4 class="nhsd-t-heading-m">Request</h4>
-    <h5 class="nhsd-t-heading-s">Path parameters</h5>
-    <div class="nhsd-m-table nhsd-t-body">
-        <table data-responsive data-no-sort>
-            <thead>
-            <tr>
-                <th class="nhsd-t-width-200">Name</th>
-                <th>Description</th>
-            </tr>
-            </thead>
-            <tr>
-                <td><code class="nhsd-!t-font-family-mono">PathPathParam</code></td>
-                <td>
-                    <p class="nhsd-t-body">Path parameter defined as path variable - re-defined in the operation.</p>
-                    <div class="nhsd-!t-col-red">Required</div>
-                </td>
-            </tr>
-        </table>
-    </div>
-    <h5 class="nhsd-t-heading-s">Query parameters</h5>
-    <div class="nhsd-m-table nhsd-t-body">
-        <table data-responsive data-no-sort>
-            <thead>
-            <tr>
-                <th class="nhsd-t-width-200">Name</th>
-                <th>Description</th>
-            </tr>
-            </thead>
-            <tr>
-                <td><code class="nhsd-!t-font-family-mono">PathQueryParam</code></td>
-                <td>
-                    <p class="nhsd-t-body">Path parameter expected as a query parameter - re-defined in the operation.</p>
-                </td>
-            </tr>
-            <tr>
-                <td><code class="nhsd-!t-font-family-mono">OperationQueryParamPut</code></td>
-                <td>
-                    <p class="nhsd-t-body">Operation parameter expected as a query parameter.</p>
-                </td>
-            </tr>
-        </table>
-    </div>
-    <h5 class="nhsd-t-heading-s">Headers</h5>
-    <div class="nhsd-m-table nhsd-t-body">
-        <table data-responsive data-no-sort>
-            <thead>
-            <tr>
-                <th class="nhsd-t-width-200">Name</th>
-                <th>Description</th>
-            </tr>
-            </thead>
-            <tr>
-                <td><code class="nhsd-!t-font-family-mono">PathHeaderParam</code></td>
-                <td>
-                    <p class="nhsd-t-body">Path parameter expected as a header - re-defined in the operation.</p>
-                </td>
-            </tr>
-            <tr>
-                <td><code class="nhsd-!t-font-family-mono">OperationHeaderParamPut</code></td>
-                <td>
-                    <p class="nhsd-t-body">Operation parameter expected as a header.</p>
-                </td>
-            </tr>
-        </table>
-    </div>
+</button>
+</div>
+</div>
+</div>
+</div>
+<p class="nhsd-t-body">Operation with some parameters of its own but also with params overriding the path ones. Expectation: result should contain all path's and operation's parameters, with definitions at the operation levels winning over their counterparts at the path level.</p>
+<h4 class="nhsd-t-heading-m">Request</h4>
+<h5 class="nhsd-t-heading-s">Path parameters</h5>
+<div class="nhsd-m-table nhsd-t-body">
+<table data-responsive data-no-sort>
+    <thead>
+    <tr>
+        <th class="nhsd-t-width-200">Name</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tr>
+        <td><code class="nhsd-!t-font-family-mono">PathPathParam</code></td>
+        <td>
+            <p class="nhsd-t-body">Path parameter defined as path variable - re-defined in the operation.</p>
+            <div class="nhsd-!t-col-red">Required</div>
+        </td>
+    </tr>
+</table>
+</div>
+<h5 class="nhsd-t-heading-s">Query parameters</h5>
+<div class="nhsd-m-table nhsd-t-body">
+<table data-responsive data-no-sort>
+    <thead>
+    <tr>
+        <th class="nhsd-t-width-200">Name</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tr>
+        <td><code class="nhsd-!t-font-family-mono">PathQueryParam</code></td>
+        <td>
+            <p class="nhsd-t-body">Path parameter expected as a query parameter - re-defined in the operation.</p>
+        </td>
+    </tr>
+    <tr>
+        <td><code class="nhsd-!t-font-family-mono">OperationQueryParamPut</code></td>
+        <td>
+            <p class="nhsd-t-body">Operation parameter expected as a query parameter.</p>
+        </td>
+    </tr>
+</table>
+</div>
+<h5 class="nhsd-t-heading-s">Headers</h5>
+<div class="nhsd-m-table nhsd-t-body">
+<table data-responsive data-no-sort>
+    <thead>
+    <tr>
+        <th class="nhsd-t-width-200">Name</th>
+        <th>Description</th>
+    </tr>
+    </thead>
+    <tr>
+        <td><code class="nhsd-!t-font-family-mono">PathHeaderParam</code></td>
+        <td>
+            <p class="nhsd-t-body">Path parameter expected as a header - re-defined in the operation.</p>
+        </td>
+    </tr>
+    <tr>
+        <td><code class="nhsd-!t-font-family-mono">OperationHeaderParamPut</code></td>
+        <td>
+            <p class="nhsd-t-body">Operation parameter expected as a header.</p>
+        </td>
+    </tr>
+</table>
+</div>
 </div>

--- a/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/oasV3_operationsTagged.html
+++ b/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/oasV3_operationsTagged.html
@@ -1,156 +1,156 @@
 <div class="nhsd-t-col-xs-12 nhsd-t-col-s-4">
-    <!-- start sticky-nav -->
-    <div class="nhsd-m-sticky-navigation nhsd-!t-display-sticky nhsd-!t-display-sticky--offset-2 nhsd-!t-margin-bottom-6">
-        <span id="sticky-nav-header" class="nhsd-t-heading-xs nhsd-!t-margin-bottom-2">Page content</span>
-        <hr class="nhsd-a-horizontal-rule nhsd-a-horizontal-rule--size-xs nhsd-!t-margin-bottom-2"/>
-        <nav aria-labelledby="sticky-nav-header" class="nhsd-m-sticky-navigation__scrollable">
-            <ul>
-                <li class="nhsd-m-sticky-navigation__item" data-nav-content="Top of page">
-                    <a class="nhsd-a-link" href="#top">
-                        Top of page
-                    </a>
-                </li>
-                <li class="nhsd-m-sticky-navigation__item" data-nav-content="api-endpoints">
-                    <a class="nhsd-a-link" href="#api-endpoints">
-                        Endpoints
-                    </a>
-                </li>
-                <li class="nhsd-m-sticky-navigation__item nhsd-m-sticky-navigation__item--nested" data-nav-content="api-Default-path_bPost">
-                    <a class="nhsd-a-link" href="#api-Default-path_bPost">
-                        Post operation B
-                    </a>
-                </li>
-                <li class="nhsd-m-sticky-navigation__item" data-nav-content="api-ResourceA">
-                    <a class="nhsd-a-link" href="#api-ResourceA">
-                        Endpoints: ResourceA
-                    </a>
-                </li>
-                <li class="nhsd-m-sticky-navigation__item nhsd-m-sticky-navigation__item--nested" data-nav-content="api-ResourceA-path_aGet">
-                    <a class="nhsd-a-link" href="#api-ResourceA-path_aGet">
-                        Get operation A
-                    </a>
-                </li>
-                <li class="nhsd-m-sticky-navigation__item nhsd-m-sticky-navigation__item--nested" data-nav-content="api-ResourceA-path_aPost">
-                    <a class="nhsd-a-link" href="#api-ResourceA-path_aPost">
-                        Post operation A
-                    </a>
-                </li>
-                <li class="nhsd-m-sticky-navigation__item" data-nav-content="api-ResourceB">
-                    <a class="nhsd-a-link" href="#api-ResourceB">
-                        Endpoints: ResourceB
-                    </a>
-                </li>
-                <li class="nhsd-m-sticky-navigation__item nhsd-m-sticky-navigation__item--nested" data-nav-content="api-ResourceB-path_bGet">
-                    <a class="nhsd-a-link" href="#api-ResourceB-path_bGet">
-                        Get operation B
-                    </a>
-                </li>
-            </ul>
-        </nav>
-    </div>
-    <!-- end sticky-nav -->
+<!-- start sticky-nav -->
+<div class="nhsd-m-sticky-navigation nhsd-!t-display-sticky nhsd-!t-display-sticky--offset-2 nhsd-!t-margin-bottom-6">
+<span id="sticky-nav-header" class="nhsd-t-heading-xs nhsd-!t-margin-bottom-2">Page content</span>
+<hr class="nhsd-a-horizontal-rule nhsd-a-horizontal-rule--size-xs nhsd-!t-margin-bottom-2"/>
+<nav aria-labelledby="sticky-nav-header" class="nhsd-m-sticky-navigation__scrollable">
+    <ul>
+        <li class="nhsd-m-sticky-navigation__item" data-nav-content="Top of page">
+        <a class="nhsd-a-link" href="#top">
+            Top of page
+        </a>
+        </li>
+        <li class="nhsd-m-sticky-navigation__item" data-nav-content="api-endpoints">
+            <a class="nhsd-a-link" href="#api-endpoints">
+                Endpoints
+            </a>
+        </li>
+        <li class="nhsd-m-sticky-navigation__item nhsd-m-sticky-navigation__item--nested" data-nav-content="api-Default-path_bPost">
+        <a class="nhsd-a-link" href="#api-Default-path_bPost">
+            Post operation B
+        </a>
+        </li>
+        <li class="nhsd-m-sticky-navigation__item" data-nav-content="api-ResourceB">
+            <a class="nhsd-a-link" href="#api-ResourceB">
+                Endpoints: ResourceB
+            </a>
+        </li>
+        <li class="nhsd-m-sticky-navigation__item nhsd-m-sticky-navigation__item--nested" data-nav-content="api-ResourceB-path_bGet">
+        <a class="nhsd-a-link" href="#api-ResourceB-path_bGet">
+            Get operation B
+        </a>
+        </li>
+        <li class="nhsd-m-sticky-navigation__item" data-nav-content="api-ResourceA">
+            <a class="nhsd-a-link" href="#api-ResourceA">
+                Endpoints: ResourceA
+            </a>
+        </li>
+        <li class="nhsd-m-sticky-navigation__item nhsd-m-sticky-navigation__item--nested" data-nav-content="api-ResourceA-path_aGet">
+        <a class="nhsd-a-link" href="#api-ResourceA-path_aGet">
+            Get operation A
+        </a>
+        </li>
+        <li class="nhsd-m-sticky-navigation__item nhsd-m-sticky-navigation__item--nested" data-nav-content="api-ResourceA-path_aPost">
+        <a class="nhsd-a-link" href="#api-ResourceA-path_aPost">
+            Post operation A
+        </a>
+        </li>
+    </ul>
+</nav>
+</div>
+<!-- end sticky-nav -->
 </div>
 <div id="content" class="nhsd-t-col-xs-12 nhsd-t-col-s-8" aria-label="Document content">
-    <!-- API Title: Swagger Sample -->
-    <div id="api-description">
-        <p class="nhsd-t-body">A sample swagger server</p>
-    </div>
-    <hr class="nhsd-a-horizontal-rule">
-    <h2 id="api-endpoints" class="nhsd-t-heading-xl">Endpoints</h2>
-    <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-    <h3 id="api-Default-path_bPost" class="nhsd-t-heading-l">Post operation B</h3>
-    <div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
-        <div class="nhsd-t-row">
-            <div class="nhsd-t-col-xs-12 nhsd-t-col-s-9 nhsd-t-heading-s nhsd-t-flex nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3">
-                <span class="nhsd-!t-col-white nhsd-t-heading-l nhsd-t-display-contents nhsd-t-text-transform-uppercase">post</span>
-                <span class="nhsd-!t-col-white nhsd-t-heading-s nhsd-t-display-contents"><pre class="nshd-t-wrap-text-pre nhsd-t-overflow-wrap-text nhsd-t-display-contents">/path-b</pre></span>
-            </div>
-            <div class="nhsd-t-col-xs-12 nhsd-t-col-s-3">
-                <div class="nhsd-t-float-right nhsd-api-spec__try-this-api__button nhsd-!t-display-hide">
-                    <button class="nhsd-a-button nhsd-a-button--outline nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3 nhsd-t-width-full" type="button"
-                            onclick="tryEndpointNow('/default/path_bPost')">
-                        <span class="nhsd-a-button__label">Try this API</span>
-                        <span class="nhsd-a-icon nhsd-a-icon--size-m">
+<!-- API Title: Swagger Sample -->
+<div id="api-description">
+    <p class="nhsd-t-body">A sample swagger server</p>
+</div>
+<hr class="nhsd-a-horizontal-rule">
+<h2 id="api-endpoints" class="nhsd-t-heading-xl">Endpoints</h2>
+<!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+<h3 id="api-Default-path_bPost" class="nhsd-t-heading-l">Post operation B</h3>
+<div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
+<div class="nhsd-t-row">
+    <div class="nhsd-t-col-xs-12 nhsd-t-col-s-9 nhsd-t-heading-s nhsd-t-flex nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3">
+    <span class="nhsd-!t-col-white nhsd-t-heading-l nhsd-t-display-contents nhsd-t-text-transform-uppercase">post</span>
+    <span class="nhsd-!t-col-white nhsd-t-heading-s nhsd-t-display-contents"><pre class="nshd-t-wrap-text-pre nhsd-t-overflow-wrap-text nhsd-t-display-contents">/path-b</pre></span>
+</div>
+<div class="nhsd-t-col-xs-12 nhsd-t-col-s-3">
+<div class="nhsd-t-float-right nhsd-api-spec__try-this-api__button nhsd-!t-display-hide">
+<button class="nhsd-a-button nhsd-a-button--outline nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3 nhsd-t-width-full" type="button"
+onclick="tryEndpointNow('/default/path_bPost')">
+<span class="nhsd-a-button__label">Try this API</span>
+<span class="nhsd-a-icon nhsd-a-icon--size-m">
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
 <path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
 </svg>
 </span>
-                    </button>
-                </div>
-            </div>
-        </div>
-    </div>
-    <hr class="nhsd-a-horizontal-rule">
-    <h2 id="api-ResourceA" class="nhsd-t-heading-xl">Endpoints: ResourceA</h2>
-    <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-    <h3 id="api-ResourceA-path_aGet" class="nhsd-t-heading-l">Get operation A</h3>
-    <div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
-        <div class="nhsd-t-row">
-            <div class="nhsd-t-col-xs-12 nhsd-t-col-s-9 nhsd-t-heading-s nhsd-t-flex nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3">
-                <span class="nhsd-!t-col-white nhsd-t-heading-l nhsd-t-display-contents nhsd-t-text-transform-uppercase">get</span>
-                <span class="nhsd-!t-col-white nhsd-t-heading-s nhsd-t-display-contents"><pre class="nshd-t-wrap-text-pre nhsd-t-overflow-wrap-text nhsd-t-display-contents">/path-a</pre></span>
-            </div>
-            <div class="nhsd-t-col-xs-12 nhsd-t-col-s-3">
-                <div class="nhsd-t-float-right nhsd-api-spec__try-this-api__button nhsd-!t-display-hide">
-                    <button class="nhsd-a-button nhsd-a-button--outline nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3 nhsd-t-width-full" type="button"
-                            onclick="tryEndpointNow('/ResourceA/path_aGet')">
-                        <span class="nhsd-a-button__label">Try this API</span>
-                        <span class="nhsd-a-icon nhsd-a-icon--size-m">
+</button>
+</div>
+</div>
+</div>
+</div>
+<hr class="nhsd-a-horizontal-rule">
+<h2 id="api-ResourceB" class="nhsd-t-heading-xl">Endpoints: ResourceB</h2>
+<!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+<h3 id="api-ResourceB-path_bGet" class="nhsd-t-heading-l">Get operation B</h3>
+<div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
+<div class="nhsd-t-row">
+    <div class="nhsd-t-col-xs-12 nhsd-t-col-s-9 nhsd-t-heading-s nhsd-t-flex nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3">
+    <span class="nhsd-!t-col-white nhsd-t-heading-l nhsd-t-display-contents nhsd-t-text-transform-uppercase">get</span>
+    <span class="nhsd-!t-col-white nhsd-t-heading-s nhsd-t-display-contents"><pre class="nshd-t-wrap-text-pre nhsd-t-overflow-wrap-text nhsd-t-display-contents">/path-b</pre></span>
+</div>
+<div class="nhsd-t-col-xs-12 nhsd-t-col-s-3">
+<div class="nhsd-t-float-right nhsd-api-spec__try-this-api__button nhsd-!t-display-hide">
+<button class="nhsd-a-button nhsd-a-button--outline nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3 nhsd-t-width-full" type="button"
+onclick="tryEndpointNow('/ResourceB/path_bGet')">
+<span class="nhsd-a-button__label">Try this API</span>
+<span class="nhsd-a-icon nhsd-a-icon--size-m">
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
 <path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
 </svg>
 </span>
-                    </button>
-                </div>
-            </div>
-        </div>
-    </div>
-    <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-    <h3 id="api-ResourceA-path_aPost" class="nhsd-t-heading-l">Post operation A</h3>
-    <div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
-        <div class="nhsd-t-row">
-            <div class="nhsd-t-col-xs-12 nhsd-t-col-s-9 nhsd-t-heading-s nhsd-t-flex nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3">
-                <span class="nhsd-!t-col-white nhsd-t-heading-l nhsd-t-display-contents nhsd-t-text-transform-uppercase">post</span>
-                <span class="nhsd-!t-col-white nhsd-t-heading-s nhsd-t-display-contents"><pre class="nshd-t-wrap-text-pre nhsd-t-overflow-wrap-text nhsd-t-display-contents">/path-a</pre></span>
-            </div>
-            <div class="nhsd-t-col-xs-12 nhsd-t-col-s-3">
-                <div class="nhsd-t-float-right nhsd-api-spec__try-this-api__button nhsd-!t-display-hide">
-                    <button class="nhsd-a-button nhsd-a-button--outline nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3 nhsd-t-width-full" type="button"
-                            onclick="tryEndpointNow('/ResourceA/path_aPost')">
-                        <span class="nhsd-a-button__label">Try this API</span>
-                        <span class="nhsd-a-icon nhsd-a-icon--size-m">
+</button>
+</div>
+</div>
+</div>
+</div>
+<hr class="nhsd-a-horizontal-rule">
+<h2 id="api-ResourceA" class="nhsd-t-heading-xl">Endpoints: ResourceA</h2>
+<!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+<h3 id="api-ResourceA-path_aGet" class="nhsd-t-heading-l">Get operation A</h3>
+<div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
+<div class="nhsd-t-row">
+    <div class="nhsd-t-col-xs-12 nhsd-t-col-s-9 nhsd-t-heading-s nhsd-t-flex nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3">
+    <span class="nhsd-!t-col-white nhsd-t-heading-l nhsd-t-display-contents nhsd-t-text-transform-uppercase">get</span>
+    <span class="nhsd-!t-col-white nhsd-t-heading-s nhsd-t-display-contents"><pre class="nshd-t-wrap-text-pre nhsd-t-overflow-wrap-text nhsd-t-display-contents">/path-a</pre></span>
+</div>
+<div class="nhsd-t-col-xs-12 nhsd-t-col-s-3">
+<div class="nhsd-t-float-right nhsd-api-spec__try-this-api__button nhsd-!t-display-hide">
+<button class="nhsd-a-button nhsd-a-button--outline nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3 nhsd-t-width-full" type="button"
+onclick="tryEndpointNow('/ResourceA/path_aGet')">
+<span class="nhsd-a-button__label">Try this API</span>
+<span class="nhsd-a-icon nhsd-a-icon--size-m">
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
 <path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
 </svg>
 </span>
-                    </button>
-                </div>
-            </div>
-        </div>
-    </div>
-    <hr class="nhsd-a-horizontal-rule">
-    <h2 id="api-ResourceB" class="nhsd-t-heading-xl">Endpoints: ResourceB</h2>
-    <!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
-    <h3 id="api-ResourceB-path_bGet" class="nhsd-t-heading-l">Get operation B</h3>
-    <div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
-        <div class="nhsd-t-row">
-            <div class="nhsd-t-col-xs-12 nhsd-t-col-s-9 nhsd-t-heading-s nhsd-t-flex nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3">
-                <span class="nhsd-!t-col-white nhsd-t-heading-l nhsd-t-display-contents nhsd-t-text-transform-uppercase">get</span>
-                <span class="nhsd-!t-col-white nhsd-t-heading-s nhsd-t-display-contents"><pre class="nshd-t-wrap-text-pre nhsd-t-overflow-wrap-text nhsd-t-display-contents">/path-b</pre></span>
-            </div>
-            <div class="nhsd-t-col-xs-12 nhsd-t-col-s-3">
-                <div class="nhsd-t-float-right nhsd-api-spec__try-this-api__button nhsd-!t-display-hide">
-                    <button class="nhsd-a-button nhsd-a-button--outline nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3 nhsd-t-width-full" type="button"
-                            onclick="tryEndpointNow('/ResourceB/path_bGet')">
-                        <span class="nhsd-a-button__label">Try this API</span>
-                        <span class="nhsd-a-icon nhsd-a-icon--size-m">
+</button>
+</div>
+</div>
+</div>
+</div>
+<!-- https://digital.nhs.uk/about-nhs-digital/corporate-information-and-documents/nhs-digital-style-guidelines/features-of-the-nhs-digital-website-cms/call-to-action-cta-buttons -->
+<h3 id="api-ResourceA-path_aPost" class="nhsd-t-heading-l">Post operation A</h3>
+<div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
+<div class="nhsd-t-row">
+    <div class="nhsd-t-col-xs-12 nhsd-t-col-s-9 nhsd-t-heading-s nhsd-t-flex nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3">
+    <span class="nhsd-!t-col-white nhsd-t-heading-l nhsd-t-display-contents nhsd-t-text-transform-uppercase">post</span>
+    <span class="nhsd-!t-col-white nhsd-t-heading-s nhsd-t-display-contents"><pre class="nshd-t-wrap-text-pre nhsd-t-overflow-wrap-text nhsd-t-display-contents">/path-a</pre></span>
+</div>
+<div class="nhsd-t-col-xs-12 nhsd-t-col-s-3">
+<div class="nhsd-t-float-right nhsd-api-spec__try-this-api__button nhsd-!t-display-hide">
+<button class="nhsd-a-button nhsd-a-button--outline nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-3 nhsd-t-width-full" type="button"
+onclick="tryEndpointNow('/ResourceA/path_aPost')">
+<span class="nhsd-a-button__label">Try this API</span>
+<span class="nhsd-a-icon nhsd-a-icon--size-m">
 <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
 <path d="M8.5,15L15,8L8.5,1L7,2.5L11.2,7H1v2h10.2L7,13.5L8.5,15z"></path>
 </svg>
 </span>
-                    </button>
-                </div>
-            </div>
-        </div>
-    </div>
+</button>
+</div>
+</div>
+</div>
+</div>
 </div>

--- a/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/oasV3_operationsTagged.json
+++ b/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/oasV3_operationsTagged.json
@@ -1,5 +1,13 @@
 {
     "openapi": "3.0.0",
+    "tags": [
+        {
+            "name": "Resource-b"
+        },
+        {
+            "name": "Resource-a"
+        }
+    ],
     "paths": {
         "/path-a": {
             "get": {

--- a/repository-data/local/src/main/resources/hcm-config/configuration/update/ApiSpecificationRenderer/ApiSpecificationRenderer.groovy
+++ b/repository-data/local/src/main/resources/hcm-config/configuration/update/ApiSpecificationRenderer/ApiSpecificationRenderer.groovy
@@ -135,6 +135,7 @@ class ApiSpecificationRenderer extends BaseNodeUpdateVisitor {
                 "../../cms/src/main/java/uk/nhs/digital/apispecs/commonmark/MarkdownConversionException.java",
                 "../../cms/src/main/java/uk/nhs/digital/apispecs/swagger/request/bodyextractor/ToPrettyJsonStringDeserializer.java",
                 "../../cms/src/main/java/uk/nhs/digital/apispecs/OpenApiSpecificationJsonToHtmlConverter.java",
+                "../../cms/src/main/java/uk/nhs/digital/apispecs/swagger/CodegenDefaultGenerator.java",
                 "../../cms/src/main/java/uk/nhs/digital/apispecs/swagger/request/examplerenderer/CodegenParamDefinition.java",
                 "../../cms/src/main/java/uk/nhs/digital/apispecs/swagger/model/BodyWithMediaTypeObjects.java",
                 "../../cms/src/main/java/uk/nhs/digital/apispecs/swagger/model/MediaTypeObjects.java",


### PR DESCRIPTION
Re-introduced CodegenDefaultGenerator.java to allow for custom ordering of CodegenOperations. annoyingly, processOperation is a private method so the generator can't just call the super method

