### PR TITLE
[ADZ-1312] API-Description - Add horizontal line above <h2> headers

### DIFF
--- a/cms/src/main/java/uk/nhs/digital/apispecs/commonmark/HeadingAttributeProvider.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/commonmark/HeadingAttributeProvider.java
@@ -10,29 +10,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-/**
- * <p>
- * When created with {@code headingIdPrefix} other than {@code null},
- * renders {@code id} attribute on the heading element.
- * </p>
- * <p>
- * The attribute {@code id} is populated with value calculated from the heading's text,
- * prepended with provided prefix. Useful as targets for hyperlinks,
- * where the prefix provides additional context and uniqueness to the ids.
- * </p>
- * <p>
- * For example, for '{@code headingIdPrefix}' given as '{@code customPrefix__}' heading:
- * </p>
- * <pre>
- *     ## Legal use
- * </pre>
- * <p>
- * ...will be rendered as:
- * </p>
- * <pre>
- *     &lt;h2 id=&quot;customPrefix__legal-use&quot;&gt;Legal use&lt;/h2&gt;
- * </pre>
- */
 public class HeadingAttributeProvider implements AttributeProvider {
 
     private final String headingIdPrefix;

--- a/cms/src/main/java/uk/nhs/digital/apispecs/commonmark/ThematicBreakAttributeProvider.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/commonmark/ThematicBreakAttributeProvider.java
@@ -1,0 +1,18 @@
+package uk.nhs.digital.apispecs.commonmark;
+
+import org.commonmark.node.Node;
+import org.commonmark.node.ThematicBreak;
+import org.commonmark.renderer.html.AttributeProvider;
+
+import java.util.Map;
+
+public class ThematicBreakAttributeProvider implements AttributeProvider {
+
+    @Override
+    public void setAttributes(final Node node, final String tagName, final Map<String, String> attributes) {
+
+        if (node instanceof ThematicBreak) {
+            attributes.put("class", "nhsd-a-horizontal-rule");
+        }
+    }
+}

--- a/cms/src/test/java/uk/nhs/digital/apispecs/CommonmarkMarkdownConverterTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/CommonmarkMarkdownConverterTest.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.rangeClosed;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -172,16 +173,12 @@ public class CommonmarkMarkdownConverterTest {
             // targetTopHeadingLevel initialHeadingLevels                    expectedHeadingLevels
 
             // no change
-            {0,                      levels(1,   2,   3,   4,   5,   6),     levels(1,   2,   3,   4,   5,   6)},
             {0,                      levels(3,   4,   5               ),     levels(3,   4,   5               )},
-            {0,                      levels(2,   1,   2,   4,   5,   6),     levels(2,   1,   2,   4,   5,   6)},
 
-            {1,                      levels(1,   2,   3,   4,   5,   6),     levels(1,   2,   3,   4,   5,   6)},
             {3,                      levels(3,   4,   3,   5,   6     ),     levels(3,   4,   3,   5,   6     )},
             {6,                      levels(6,   6                    ),     levels(6,   6                    )},
 
             // pushing down
-            {2,                      levels(1,   2,   3,   4,   5,   6),     levels(2,   3,   4,   5,   6,   7)},
             {3,                      levels(1,   2,   3,   4,   5,   6),     levels(3,   4,   5,   6,   7,   8)},
             {4,                      levels(1,   2,   3,   4,   5,   6),     levels(4,   5,   6,   7,   8,   9)},
             {5,                      levels(1,   2,   3,   4,   5,   6),     levels(5,   6,   7,   8,   9,  10)},
@@ -189,10 +186,6 @@ public class CommonmarkMarkdownConverterTest {
             {6,                      levels(6,   5,   4,   3,   2,   1),     levels(11,  10,  9,   8,   7,   6)},
 
             // pulling up
-            {1,                      levels(2,   3,   4,   5,   6     ),     levels(1,   2,   3,   4,   5     )},
-            {1,                      levels(4,   5,   4,   6          ),     levels(1,   2,   1,   3          )},
-            {1,                      levels(3,   4,   4,   6          ),     levels(1,   2,   2,   4          )},
-            {1,                      levels(6,   4,   3               ),     levels(4,   2,   1               )},
             {1,                      levels(6,   6                    ),     levels(1,   1                    )},
 
             {3,                      levels(4,   5,   6               ),     levels(3,   4,   5               )},
@@ -235,13 +228,21 @@ public class CommonmarkMarkdownConverterTest {
 
     private String htmlWithHeadingsAt(final Levels headingsLevels) {
 
-        // for levels 1, 2, 3, returns HTML:
-        // <h1 id="heading">Heading</h1>
-        // <h2 id="heading">Heading</h2>
-        // <h3 id="heading">Heading</h3>
+        // for levels 1, 2, 3, 2, returns HTML:
+        // <h1 class="nhsd-t-heading-xxl">Heading</h1>
+        // <h2 class="nhsd-t-heading-xl">Heading</h2>
+        // <h3 class="nhsd-t-heading-l">Heading</h3>
+        // <hr class="nhsd-a-horizontal-rule"/>
+        // <h2 class="nhsd-t-heading-xl">Heading</h2>
 
         return headingsLevels.stream()
-            .map(level -> format("<h{0} class=\"{1}\">Heading</h{0}>", level, cssClassForHeadingLevel(level)))
+            .map(level -> {
+                final String headingLine = format("<h{0} class=\"{1}\">Heading</h{0}>", level, cssClassForHeadingLevel(level));
+
+                return level == 2
+                    ? "<hr class=\"nhsd-a-horizontal-rule\">\n" + headingLine
+                    : headingLine;
+            })
             .collect(joining("\n"));
     }
 
@@ -254,8 +255,8 @@ public class CommonmarkMarkdownConverterTest {
     private String markdownWithHeadingsAt(final Levels headingsLevels) {
         // for levels 1, 2, 3, returns Markdown:
         // # Heading\n
-        // # Heading\n
-        // # Heading
+        // ## Heading\n
+        // ### Heading
 
         return headingsLevels.stream()
             .map(level -> {

--- a/cms/src/test/java/uk/nhs/digital/apispecs/commonmark/HeadingAttributeProviderTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/commonmark/HeadingAttributeProviderTest.java
@@ -8,7 +8,6 @@ import com.tngtech.java.junit.dataprovider.DataProvider;
 import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import org.commonmark.node.Heading;
-import org.commonmark.node.Node;
 import org.commonmark.node.Text;
 import org.junit.Before;
 import org.junit.Test;

--- a/cms/src/test/java/uk/nhs/digital/apispecs/commonmark/ThematicBreakAttributeProviderTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/commonmark/ThematicBreakAttributeProviderTest.java
@@ -1,0 +1,54 @@
+package uk.nhs.digital.apispecs.commonmark;
+
+import static org.mockito.BDDMockito.then;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import org.commonmark.ext.gfm.tables.TableBlock;
+import org.commonmark.node.Node;
+import org.commonmark.node.ThematicBreak;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import java.util.Map;
+
+
+public class ThematicBreakAttributeProviderTest {
+
+    @Mock
+    private Map<String, String> attributes;
+
+    private ThematicBreakAttributeProvider thematicBreakAttributeProvider = new ThematicBreakAttributeProvider();
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+    }
+
+    @Test
+    public void setsThematicBreakInlineCssClassOnCodeElement() {
+
+        // given
+        final Node thematicBreakNode = new ThematicBreak();
+
+        // when
+        thematicBreakAttributeProvider.setAttributes(thematicBreakNode, "tagName is ignored", attributes);
+
+        // then
+        then(attributes).should().put("class", "nhsd-a-horizontal-rule");
+        then(attributes).shouldHaveNoMoreInteractions();
+    }
+
+    @Test
+    public void ignoresElementOtherThanThematicBreak() {
+
+        // given
+        final Node nodeOtherThanThematicBreak = new TableBlock();
+
+        // when
+        thematicBreakAttributeProvider.setAttributes(nodeOtherThanThematicBreak, "tagName is ignored", attributes);
+
+        // then
+        then(attributes).shouldHaveZeroInteractions();
+    }
+}

--- a/cms/src/test/resources/test-data/api-specifications/ApiSpecSyncFromApigeeJobIntegrationTest/oasV3_complete.html
+++ b/cms/src/test/resources/test-data/api-specifications/ApiSpecSyncFromApigeeJobIntegrationTest/oasV3_complete.html
@@ -63,13 +63,14 @@
     <div id="api-description">
         <h2 class="nhsd-t-heading-xl" id="api-description__overview">Overview</h2>
         <p class="nhsd-t-body">Use this API to access the <a href="https://digital.nhs.uk/services/demographics" class="nhsd-a-link">Personal Demographics Service (PDS)</a></p>
+        <hr class="nhsd-a-horizontal-rule" />
         <h2 class="nhsd-t-heading-xl" id="api-description__legal-use">Legal use</h2>
         <p class="nhsd-t-body">This API can only be used where there is a legal basis.</p>
     </div>
 
     <hr class="nhsd-a-horizontal-rule">
     <h2 id="api-Patients" class="nhsd-t-heading-xl">Endpoints: Patients</h2>
-        <h3 id="api-Patients-get-patient" class="nhsd-t-heading-l">Retrieve a patient&#x27;s resource</h3>
+    <h3 id="api-Patients-get-patient" class="nhsd-t-heading-l">Retrieve a patient&#x27;s resource</h3>
 
     <div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
         <div class="nhsd-t-row">
@@ -249,11 +250,11 @@
             <h4 class="nhsd-t-heading-m nhsd-!t-margin-bottom-0">Schema</h4>
         </div>
         <div class="nhsd-t-col-xs-12 nhsd-t-col-s-8 nhsd-!t-padding-0 nhsd-t-text-align-l-right">
-            <button onclick="collapseAll('ec99e87a-5632-4419-a6c2-7cfb97f54645')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
-            <button onclick="expandAll('ec99e87a-5632-4419-a6c2-7cfb97f54645')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
+            <button onclick="collapseAll('366b2514-ae84-49c7-8b22-e5bf4191f1ba')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
+            <button onclick="expandAll('366b2514-ae84-49c7-8b22-e5bf4191f1ba')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
         </div>
     </div>
-    <div class="nhsd-o-schema" data-schema-uuid="ec99e87a-5632-4419-a6c2-7cfb97f54645">
+    <div class="nhsd-o-schema" data-schema-uuid="366b2514-ae84-49c7-8b22-e5bf4191f1ba">
         <div class="nhsd-m-table nhsd-t-body">
             <table data-no-sort="true">
                 <thead class="nhsd-o-schema__header">
@@ -262,10 +263,10 @@
                 </thead>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="f5a1c1c0-9eaa-4f97-a276-9a5513a496d1" data-indentation="0" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="24cbb256-74f9-472b-9d30-e6404f3aea78" data-indentation="0" colspan="2">
 
                     <td style="padding-left: 0.0em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="f5a1c1c0-9eaa-4f97-a276-9a5513a496d1" onclick="collapseChildren('f5a1c1c0-9eaa-4f97-a276-9a5513a496d1')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="24cbb256-74f9-472b-9d30-e6404f3aea78" onclick="collapseChildren('24cbb256-74f9-472b-9d30-e6404f3aea78')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
 
                         <div>
@@ -308,7 +309,7 @@
                 </tr>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="8b54ca35-9a72-47d6-96f1-95fb62e06441" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="4733f7df-a07a-4608-b844-cb3072f55970" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
@@ -358,7 +359,7 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="fc5b9b18-b6cb-4d00-b934-369b2482fff5" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="f9a4b0e2-a05e-4b5a-bdb3-c919061f074b" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
@@ -457,11 +458,11 @@
             <h4 class="nhsd-t-heading-m nhsd-!t-margin-bottom-0">Schema</h4>
         </div>
         <div class="nhsd-t-col-xs-12 nhsd-t-col-s-8 nhsd-!t-padding-0 nhsd-t-text-align-l-right">
-            <button onclick="collapseAll('fbe8357a-3140-4685-bd01-9ce8a4e10cf8')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
-            <button onclick="expandAll('fbe8357a-3140-4685-bd01-9ce8a4e10cf8')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
+            <button onclick="collapseAll('97404ee7-fc7d-499d-8472-cba4d7befd2e')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
+            <button onclick="expandAll('97404ee7-fc7d-499d-8472-cba4d7befd2e')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
         </div>
     </div>
-    <div class="nhsd-o-schema" data-schema-uuid="fbe8357a-3140-4685-bd01-9ce8a4e10cf8">
+    <div class="nhsd-o-schema" data-schema-uuid="97404ee7-fc7d-499d-8472-cba4d7befd2e">
         <div class="nhsd-m-table nhsd-t-body">
             <table data-no-sort="true">
                 <thead class="nhsd-o-schema__header">
@@ -470,10 +471,10 @@
                 </thead>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="0e8d0af0-abf1-4f60-a1e0-6f3ec9d425e4" data-indentation="0" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="fb6f2038-3a4f-490c-b3c3-272236fe3dd5" data-indentation="0" colspan="2">
 
                     <td style="padding-left: 0.0em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="0e8d0af0-abf1-4f60-a1e0-6f3ec9d425e4" onclick="collapseChildren('0e8d0af0-abf1-4f60-a1e0-6f3ec9d425e4')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="fb6f2038-3a4f-490c-b3c3-272236fe3dd5" onclick="collapseChildren('fb6f2038-3a4f-490c-b3c3-272236fe3dd5')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
 
                         <div>
@@ -538,7 +539,7 @@
                 </tr>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="bd55da0e-804a-484a-9872-17daf9cf6977" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="c6410946-7406-4943-a49f-fffc607e4c15" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
@@ -588,10 +589,10 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="3d4e1c15-f5c7-4157-bc86-c2a7eb2fd469" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="538740e4-7367-4ad3-bd42-a16604562059" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="3d4e1c15-f5c7-4157-bc86-c2a7eb2fd469" onclick="collapseChildren('3d4e1c15-f5c7-4157-bc86-c2a7eb2fd469')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="538740e4-7367-4ad3-bd42-a16604562059" onclick="collapseChildren('538740e4-7367-4ad3-bd42-a16604562059')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="nhsd-o-schema__border-short-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
                         <div><strong>issue</strong></div>
 
@@ -636,7 +637,7 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="c3cfddbe-71dc-4f47-a193-575b9e68b6b0" data-indentation="2" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="eb10b459-e01e-4fff-8ff5-7cc6599c0302" data-indentation="2" colspan="2">
 
                     <td style="padding-left: 3.0em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span>
@@ -693,7 +694,7 @@
             </table>
         </div>                                                </div>
 
-        <h3 id="api-Patients-search-patient" class="nhsd-t-heading-l">Search for patient</h3>
+    <h3 id="api-Patients-search-patient" class="nhsd-t-heading-l">Search for patient</h3>
 
     <div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
         <div class="nhsd-t-row">
@@ -893,11 +894,11 @@
             <h4 class="nhsd-t-heading-m nhsd-!t-margin-bottom-0">Schema</h4>
         </div>
         <div class="nhsd-t-col-xs-12 nhsd-t-col-s-8 nhsd-!t-padding-0 nhsd-t-text-align-l-right">
-            <button onclick="collapseAll('38c84ccb-b9e5-462e-8827-dcfc39c2c0c2')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
-            <button onclick="expandAll('38c84ccb-b9e5-462e-8827-dcfc39c2c0c2')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
+            <button onclick="collapseAll('7ab7494d-5030-4f4b-9037-f99b7d45ff27')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
+            <button onclick="expandAll('7ab7494d-5030-4f4b-9037-f99b7d45ff27')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
         </div>
     </div>
-    <div class="nhsd-o-schema" data-schema-uuid="38c84ccb-b9e5-462e-8827-dcfc39c2c0c2">
+    <div class="nhsd-o-schema" data-schema-uuid="7ab7494d-5030-4f4b-9037-f99b7d45ff27">
         <div class="nhsd-m-table nhsd-t-body">
             <table data-no-sort="true">
                 <thead class="nhsd-o-schema__header">
@@ -906,10 +907,10 @@
                 </thead>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="bb710af0-ac4e-4dcd-a2fd-a9a9e97e3c00" data-indentation="0" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="dd6f629a-b462-4c7e-9bd6-33face0856c8" data-indentation="0" colspan="2">
 
                     <td style="padding-left: 0.0em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="bb710af0-ac4e-4dcd-a2fd-a9a9e97e3c00" onclick="collapseChildren('bb710af0-ac4e-4dcd-a2fd-a9a9e97e3c00')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="dd6f629a-b462-4c7e-9bd6-33face0856c8" onclick="collapseChildren('dd6f629a-b462-4c7e-9bd6-33face0856c8')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
 
                         <div>
@@ -952,7 +953,7 @@
                 </tr>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="264aec99-7503-4793-8ef5-e8923cc8ab83" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="d7e260ac-3166-434c-b0c6-1e836d7394b1" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
@@ -1002,7 +1003,7 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="204474dd-484c-46d1-ac6f-3349b7a30f57" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="86b00e8c-08fb-4283-8b94-e4037e12a059" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
@@ -1052,7 +1053,7 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="675886e6-3b21-4590-837d-a4fb81938a96" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="65bc0673-f72b-4d95-8186-1c2138771713" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
@@ -1165,11 +1166,11 @@
             <h4 class="nhsd-t-heading-m nhsd-!t-margin-bottom-0">Schema</h4>
         </div>
         <div class="nhsd-t-col-xs-12 nhsd-t-col-s-8 nhsd-!t-padding-0 nhsd-t-text-align-l-right">
-            <button onclick="collapseAll('ff020950-5faf-46e7-a2bb-509d0ad0c444')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
-            <button onclick="expandAll('ff020950-5faf-46e7-a2bb-509d0ad0c444')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
+            <button onclick="collapseAll('29a65a07-dfd5-4d59-93bd-436f3cfade87')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
+            <button onclick="expandAll('29a65a07-dfd5-4d59-93bd-436f3cfade87')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
         </div>
     </div>
-    <div class="nhsd-o-schema" data-schema-uuid="ff020950-5faf-46e7-a2bb-509d0ad0c444">
+    <div class="nhsd-o-schema" data-schema-uuid="29a65a07-dfd5-4d59-93bd-436f3cfade87">
         <div class="nhsd-m-table nhsd-t-body">
             <table data-no-sort="true">
                 <thead class="nhsd-o-schema__header">
@@ -1178,7 +1179,7 @@
                 </thead>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="593358c5-b207-4373-9fc0-5616a97be8f9" data-indentation="0" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="2ea725e0-b14b-47fe-8528-bb3f8fc93322" data-indentation="0" colspan="2">
 
                     <td style="padding-left: 0.0em;" class="nhsd-o-schema__name-column">
 
@@ -1236,7 +1237,7 @@
             </table>
         </div>                                                </div>
 
-        <h3 id="api-Patients-update-patient-partial" class="nhsd-t-heading-l">Update a patient&#x27;s resource</h3>
+    <h3 id="api-Patients-update-patient-partial" class="nhsd-t-heading-l">Update a patient&#x27;s resource</h3>
 
     <div class="nhsd-t-grid nhsd-!t-padding-top-3 nhsd-!t-padding-bottom-3 nhsd-a-box nhsd-a-box--bg-blue nhsd-!t-margin-bottom-4">
         <div class="nhsd-t-row">
@@ -1421,11 +1422,11 @@
             <h4 class="nhsd-t-heading-m nhsd-!t-margin-bottom-0">Schema</h4>
         </div>
         <div class="nhsd-t-col-xs-12 nhsd-t-col-s-8 nhsd-!t-padding-0 nhsd-t-text-align-l-right">
-            <button onclick="collapseAll('6775a1e4-6a67-4851-a2f6-fd56ca876cd1')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
-            <button onclick="expandAll('6775a1e4-6a67-4851-a2f6-fd56ca876cd1')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
+            <button onclick="collapseAll('5e513731-f7c5-477e-9b8e-e1680f39a860')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
+            <button onclick="expandAll('5e513731-f7c5-477e-9b8e-e1680f39a860')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
         </div>
     </div>
-    <div class="nhsd-o-schema" data-schema-uuid="6775a1e4-6a67-4851-a2f6-fd56ca876cd1">
+    <div class="nhsd-o-schema" data-schema-uuid="5e513731-f7c5-477e-9b8e-e1680f39a860">
         <div class="nhsd-m-table nhsd-t-body">
             <table data-no-sort="true">
                 <thead class="nhsd-o-schema__header">
@@ -1434,7 +1435,7 @@
                 </thead>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="73da8bf5-bbab-4280-aff2-2d9ee52df789" data-indentation="0" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="334f3e5d-9f3c-4139-a187-d5e35eb5ead1" data-indentation="0" colspan="2">
 
                     <td style="padding-left: 0.0em;" class="nhsd-o-schema__name-column">
 
@@ -1628,11 +1629,11 @@
             <h4 class="nhsd-t-heading-m nhsd-!t-margin-bottom-0">Schema</h4>
         </div>
         <div class="nhsd-t-col-xs-12 nhsd-t-col-s-8 nhsd-!t-padding-0 nhsd-t-text-align-l-right">
-            <button onclick="collapseAll('ab9d40b4-a005-4a6f-9dcf-a95d74ef0dcc')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
-            <button onclick="expandAll('ab9d40b4-a005-4a6f-9dcf-a95d74ef0dcc')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
+            <button onclick="collapseAll('651223f9-89c8-44ea-adbe-32b2b0bdf959')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
+            <button onclick="expandAll('651223f9-89c8-44ea-adbe-32b2b0bdf959')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
         </div>
     </div>
-    <div class="nhsd-o-schema" data-schema-uuid="ab9d40b4-a005-4a6f-9dcf-a95d74ef0dcc">
+    <div class="nhsd-o-schema" data-schema-uuid="651223f9-89c8-44ea-adbe-32b2b0bdf959">
         <div class="nhsd-m-table nhsd-t-body">
             <table data-no-sort="true">
                 <thead class="nhsd-o-schema__header">
@@ -1641,10 +1642,10 @@
                 </thead>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="cf3b2821-4fda-4c06-94d2-b88982ef4225" data-indentation="0" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="5940bf19-4007-4b31-90db-716e246cb0f7" data-indentation="0" colspan="2">
 
                     <td style="padding-left: 0.0em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="cf3b2821-4fda-4c06-94d2-b88982ef4225" onclick="collapseChildren('cf3b2821-4fda-4c06-94d2-b88982ef4225')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="5940bf19-4007-4b31-90db-716e246cb0f7" onclick="collapseChildren('5940bf19-4007-4b31-90db-716e246cb0f7')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
 
                         <div>
@@ -1709,7 +1710,7 @@
                 </tr>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="ad19ce7b-5dfc-42f3-8f26-bd6ce98711db" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="7badfada-093f-413f-8cc0-bf78cbb8aea0" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
@@ -1759,10 +1760,10 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="db4689a9-e69f-4072-b18b-d21a576abf33" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="f77eaf6b-4aa7-4175-b2a2-184f9ae5810c" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="db4689a9-e69f-4072-b18b-d21a576abf33" onclick="collapseChildren('db4689a9-e69f-4072-b18b-d21a576abf33')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="f77eaf6b-4aa7-4175-b2a2-184f9ae5810c" onclick="collapseChildren('f77eaf6b-4aa7-4175-b2a2-184f9ae5810c')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="nhsd-o-schema__border-short-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
                         <div><strong>issue</strong></div>
 
@@ -1807,10 +1808,10 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="4063a697-98ba-4bd9-91a7-583148f50965" data-indentation="2" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="6897f3c6-0960-4f99-a619-33f3ab9360c0" data-indentation="2" colspan="2">
 
                     <td style="padding-left: 3.0em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="4063a697-98ba-4bd9-91a7-583148f50965" onclick="collapseChildren('4063a697-98ba-4bd9-91a7-583148f50965')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="6897f3c6-0960-4f99-a619-33f3ab9360c0" onclick="collapseChildren('6897f3c6-0960-4f99-a619-33f3ab9360c0')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 35.4%"></span><span class="nhsd-o-schema__border-short-horizontal" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span>
 
                         <div>
@@ -1853,7 +1854,7 @@
                 </tr>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="e45d6946-590b-4402-87f3-fc22deae35b0" data-indentation="3" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="f7ebbe79-d4d3-4174-a32f-b7721bee9299" data-indentation="3" colspan="2">
 
                     <td style="padding-left: 4.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="nhsd-o-schema__border-vertical" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
@@ -1902,7 +1903,7 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="8bf10f26-9d58-4ed6-9600-5e441884aa84" data-indentation="3" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="0371580f-63e7-49c5-85ec-b1f33cb53548" data-indentation="3" colspan="2">
 
                     <td style="padding-left: 4.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
@@ -2130,11 +2131,11 @@
             <h4 class="nhsd-t-heading-m nhsd-!t-margin-bottom-0">Schema</h4>
         </div>
         <div class="nhsd-t-col-xs-12 nhsd-t-col-s-8 nhsd-!t-padding-0 nhsd-t-text-align-l-right">
-            <button onclick="collapseAll('0e921303-a9a5-4f97-8c43-aede46019427')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
-            <button onclick="expandAll('0e921303-a9a5-4f97-8c43-aede46019427')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
+            <button onclick="collapseAll('8873add1-772b-477d-8f76-df1b5480e67d')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
+            <button onclick="expandAll('8873add1-772b-477d-8f76-df1b5480e67d')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
         </div>
     </div>
-    <div class="nhsd-o-schema" data-schema-uuid="0e921303-a9a5-4f97-8c43-aede46019427">
+    <div class="nhsd-o-schema" data-schema-uuid="8873add1-772b-477d-8f76-df1b5480e67d">
         <div class="nhsd-m-table nhsd-t-body">
             <table data-no-sort="true">
                 <thead class="nhsd-o-schema__header">
@@ -2143,10 +2144,10 @@
                 </thead>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="629a65c4-94ef-4b80-9013-023dc795d678" data-indentation="0" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="e04fd22e-278d-4119-9280-eebeadc86b7e" data-indentation="0" colspan="2">
 
                     <td style="padding-left: 0.0em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="629a65c4-94ef-4b80-9013-023dc795d678" onclick="collapseChildren('629a65c4-94ef-4b80-9013-023dc795d678')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="e04fd22e-278d-4119-9280-eebeadc86b7e" onclick="collapseChildren('e04fd22e-278d-4119-9280-eebeadc86b7e')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
 
                         <div>
@@ -2189,7 +2190,7 @@
                 </tr>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="2cfe3fa5-be46-4801-a1ad-566abb8996b8" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="2577b64c-4ba3-4979-a420-c41133896d61" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
@@ -2239,7 +2240,7 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="ee00564b-8671-49a0-b096-df668104ba96" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="55a49a3b-f775-4dc5-9e9a-41512f5287e3" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
@@ -2342,11 +2343,11 @@
             <h4 class="nhsd-t-heading-m nhsd-!t-margin-bottom-0">Schema</h4>
         </div>
         <div class="nhsd-t-col-xs-12 nhsd-t-col-s-8 nhsd-!t-padding-0 nhsd-t-text-align-l-right">
-            <button onclick="collapseAll('5d463b0c-5fd9-41ae-8673-62d5a2ea00d5')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
-            <button onclick="expandAll('5d463b0c-5fd9-41ae-8673-62d5a2ea00d5')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
+            <button onclick="collapseAll('3ac0d605-220c-416c-8248-99488dc3315f')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
+            <button onclick="expandAll('3ac0d605-220c-416c-8248-99488dc3315f')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
         </div>
     </div>
-    <div class="nhsd-o-schema" data-schema-uuid="5d463b0c-5fd9-41ae-8673-62d5a2ea00d5">
+    <div class="nhsd-o-schema" data-schema-uuid="3ac0d605-220c-416c-8248-99488dc3315f">
         <div class="nhsd-m-table nhsd-t-body">
             <table data-no-sort="true">
                 <thead class="nhsd-o-schema__header">
@@ -2355,10 +2356,10 @@
                 </thead>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="02db0190-a061-4ddf-9bb4-d2e66b63deb5" data-indentation="0" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="c84a6545-a740-4027-a69c-a04be55393ba" data-indentation="0" colspan="2">
 
                     <td style="padding-left: 0.0em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="02db0190-a061-4ddf-9bb4-d2e66b63deb5" onclick="collapseChildren('02db0190-a061-4ddf-9bb4-d2e66b63deb5')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="c84a6545-a740-4027-a69c-a04be55393ba" onclick="collapseChildren('c84a6545-a740-4027-a69c-a04be55393ba')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
 
                         <div>
@@ -2423,7 +2424,7 @@
                 </tr>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="0f7e2316-8ca2-465a-b644-c2fecb9a3954" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="3ec4c080-ebb1-469f-9d8f-08ea22ef8d4f" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
@@ -2473,10 +2474,10 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="2ec04e5a-c5e6-449c-ae2c-e110cf0c71aa" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="899f2d4c-d21e-4698-9c83-e7158fb85071" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="2ec04e5a-c5e6-449c-ae2c-e110cf0c71aa" onclick="collapseChildren('2ec04e5a-c5e6-449c-ae2c-e110cf0c71aa')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="899f2d4c-d21e-4698-9c83-e7158fb85071" onclick="collapseChildren('899f2d4c-d21e-4698-9c83-e7158fb85071')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="nhsd-o-schema__border-short-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
                         <div><strong>issue</strong></div>
 
@@ -2521,10 +2522,10 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="67ce5326-1092-4571-ba20-bd5e5c171a12" data-indentation="2" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="e714a5b7-6fc7-4e57-832f-83633e835d0c" data-indentation="2" colspan="2">
 
                     <td style="padding-left: 3.0em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="67ce5326-1092-4571-ba20-bd5e5c171a12" onclick="collapseChildren('67ce5326-1092-4571-ba20-bd5e5c171a12')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="e714a5b7-6fc7-4e57-832f-83633e835d0c" onclick="collapseChildren('e714a5b7-6fc7-4e57-832f-83633e835d0c')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 35.4%"></span><span class="nhsd-o-schema__border-short-horizontal" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span>
 
                         <div>
@@ -2567,7 +2568,7 @@
                 </tr>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="88439ff1-76e3-48dc-b165-e2be36d03df8" data-indentation="3" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="6dd5c6b6-31ca-418c-bc26-bba03fe17e61" data-indentation="3" colspan="2">
 
                     <td style="padding-left: 4.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="nhsd-o-schema__border-vertical" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
@@ -2616,7 +2617,7 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="be22a32d-cf30-4c77-8621-b4b6560494df" data-indentation="3" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="31bcdaec-b9e0-483d-9406-4b4d5ba11002" data-indentation="3" colspan="2">
 
                     <td style="padding-left: 4.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>

--- a/cms/src/test/resources/test-data/api-specifications/CommonmarkMarkdownConverterTest/headings-with-duplicate-values.html
+++ b/cms/src/test/resources/test-data/api-specifications/CommonmarkMarkdownConverterTest/headings-with-duplicate-values.html
@@ -2,9 +2,13 @@
 <h2 class="nhsd-t-heading-xl" id="customPrefix__heading-aa">Heading AA</h2>
 <h3 class="nhsd-t-heading-l" id="customPrefix__heading-a-1">Heading A</h3>
 <h1 class="nhsd-t-heading-xxl" id="customPrefix__heading-b">Heading B</h1>
+<hr class="nhsd-a-horizontal-rule" />
 <h2 class="nhsd-t-heading-xl" id="customPrefix__heading-bb">Heading BB</h2>
+<hr class="nhsd-a-horizontal-rule" />
 <h2 class="nhsd-t-heading-xl" id="customPrefix__heading-a-2">Heading A</h2>
 <h1 class="nhsd-t-heading-xxl" id="customPrefix__heading-c">Heading C</h1>
+<hr class="nhsd-a-horizontal-rule" />
 <h2 class="nhsd-t-heading-xl" id="customPrefix__heading-a-3">Heading A</h2>
+<hr class="nhsd-a-horizontal-rule" />
 <h2 class="nhsd-t-heading-xl" id="customPrefix__heading-bb-1">Heading BB</h2>
 <h3 class="nhsd-t-heading-l" id="customPrefix__heading-bb-2">Heading BB</h3>

--- a/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/oasV3_complete.html
+++ b/cms/src/test/resources/test-data/api-specifications/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest/oasV3_complete.html
@@ -63,6 +63,7 @@
     <div id="api-description">
         <h2 class="nhsd-t-heading-xl" id="api-description__overview">Overview</h2>
         <p class="nhsd-t-body">Use this API to access the <a href="https://digital.nhs.uk/services/demographics" class="nhsd-a-link">Personal Demographics Service (PDS)</a></p>
+        <hr class="nhsd-a-horizontal-rule" />
         <h2 class="nhsd-t-heading-xl" id="api-description__legal-use">Legal use</h2>
         <p class="nhsd-t-body">This API can only be used where there is a legal basis.</p>
     </div>
@@ -249,11 +250,11 @@
             <h4 class="nhsd-t-heading-m nhsd-!t-margin-bottom-0">Schema</h4>
         </div>
         <div class="nhsd-t-col-xs-12 nhsd-t-col-s-8 nhsd-!t-padding-0 nhsd-t-text-align-l-right">
-            <button onclick="collapseAll('ec99e87a-5632-4419-a6c2-7cfb97f54645')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
-            <button onclick="expandAll('ec99e87a-5632-4419-a6c2-7cfb97f54645')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
+            <button onclick="collapseAll('366b2514-ae84-49c7-8b22-e5bf4191f1ba')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
+            <button onclick="expandAll('366b2514-ae84-49c7-8b22-e5bf4191f1ba')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
         </div>
     </div>
-    <div class="nhsd-o-schema" data-schema-uuid="ec99e87a-5632-4419-a6c2-7cfb97f54645">
+    <div class="nhsd-o-schema" data-schema-uuid="366b2514-ae84-49c7-8b22-e5bf4191f1ba">
         <div class="nhsd-m-table nhsd-t-body">
             <table data-no-sort="true">
                 <thead class="nhsd-o-schema__header">
@@ -262,10 +263,10 @@
                 </thead>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="f5a1c1c0-9eaa-4f97-a276-9a5513a496d1" data-indentation="0" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="24cbb256-74f9-472b-9d30-e6404f3aea78" data-indentation="0" colspan="2">
 
                     <td style="padding-left: 0.0em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="f5a1c1c0-9eaa-4f97-a276-9a5513a496d1" onclick="collapseChildren('f5a1c1c0-9eaa-4f97-a276-9a5513a496d1')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="24cbb256-74f9-472b-9d30-e6404f3aea78" onclick="collapseChildren('24cbb256-74f9-472b-9d30-e6404f3aea78')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
 
                         <div>
@@ -308,7 +309,7 @@
                 </tr>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="8b54ca35-9a72-47d6-96f1-95fb62e06441" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="4733f7df-a07a-4608-b844-cb3072f55970" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
@@ -358,7 +359,7 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="fc5b9b18-b6cb-4d00-b934-369b2482fff5" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="f9a4b0e2-a05e-4b5a-bdb3-c919061f074b" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
@@ -457,11 +458,11 @@
             <h4 class="nhsd-t-heading-m nhsd-!t-margin-bottom-0">Schema</h4>
         </div>
         <div class="nhsd-t-col-xs-12 nhsd-t-col-s-8 nhsd-!t-padding-0 nhsd-t-text-align-l-right">
-            <button onclick="collapseAll('fbe8357a-3140-4685-bd01-9ce8a4e10cf8')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
-            <button onclick="expandAll('fbe8357a-3140-4685-bd01-9ce8a4e10cf8')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
+            <button onclick="collapseAll('97404ee7-fc7d-499d-8472-cba4d7befd2e')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
+            <button onclick="expandAll('97404ee7-fc7d-499d-8472-cba4d7befd2e')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
         </div>
     </div>
-    <div class="nhsd-o-schema" data-schema-uuid="fbe8357a-3140-4685-bd01-9ce8a4e10cf8">
+    <div class="nhsd-o-schema" data-schema-uuid="97404ee7-fc7d-499d-8472-cba4d7befd2e">
         <div class="nhsd-m-table nhsd-t-body">
             <table data-no-sort="true">
                 <thead class="nhsd-o-schema__header">
@@ -470,10 +471,10 @@
                 </thead>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="0e8d0af0-abf1-4f60-a1e0-6f3ec9d425e4" data-indentation="0" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="fb6f2038-3a4f-490c-b3c3-272236fe3dd5" data-indentation="0" colspan="2">
 
                     <td style="padding-left: 0.0em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="0e8d0af0-abf1-4f60-a1e0-6f3ec9d425e4" onclick="collapseChildren('0e8d0af0-abf1-4f60-a1e0-6f3ec9d425e4')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="fb6f2038-3a4f-490c-b3c3-272236fe3dd5" onclick="collapseChildren('fb6f2038-3a4f-490c-b3c3-272236fe3dd5')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
 
                         <div>
@@ -538,7 +539,7 @@
                 </tr>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="bd55da0e-804a-484a-9872-17daf9cf6977" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="c6410946-7406-4943-a49f-fffc607e4c15" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
@@ -588,10 +589,10 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="3d4e1c15-f5c7-4157-bc86-c2a7eb2fd469" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="538740e4-7367-4ad3-bd42-a16604562059" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="3d4e1c15-f5c7-4157-bc86-c2a7eb2fd469" onclick="collapseChildren('3d4e1c15-f5c7-4157-bc86-c2a7eb2fd469')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="538740e4-7367-4ad3-bd42-a16604562059" onclick="collapseChildren('538740e4-7367-4ad3-bd42-a16604562059')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="nhsd-o-schema__border-short-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
                         <div><strong>issue</strong></div>
 
@@ -636,7 +637,7 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="c3cfddbe-71dc-4f47-a193-575b9e68b6b0" data-indentation="2" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="eb10b459-e01e-4fff-8ff5-7cc6599c0302" data-indentation="2" colspan="2">
 
                     <td style="padding-left: 3.0em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span>
@@ -893,11 +894,11 @@
             <h4 class="nhsd-t-heading-m nhsd-!t-margin-bottom-0">Schema</h4>
         </div>
         <div class="nhsd-t-col-xs-12 nhsd-t-col-s-8 nhsd-!t-padding-0 nhsd-t-text-align-l-right">
-            <button onclick="collapseAll('38c84ccb-b9e5-462e-8827-dcfc39c2c0c2')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
-            <button onclick="expandAll('38c84ccb-b9e5-462e-8827-dcfc39c2c0c2')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
+            <button onclick="collapseAll('7ab7494d-5030-4f4b-9037-f99b7d45ff27')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
+            <button onclick="expandAll('7ab7494d-5030-4f4b-9037-f99b7d45ff27')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
         </div>
     </div>
-    <div class="nhsd-o-schema" data-schema-uuid="38c84ccb-b9e5-462e-8827-dcfc39c2c0c2">
+    <div class="nhsd-o-schema" data-schema-uuid="7ab7494d-5030-4f4b-9037-f99b7d45ff27">
         <div class="nhsd-m-table nhsd-t-body">
             <table data-no-sort="true">
                 <thead class="nhsd-o-schema__header">
@@ -906,10 +907,10 @@
                 </thead>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="bb710af0-ac4e-4dcd-a2fd-a9a9e97e3c00" data-indentation="0" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="dd6f629a-b462-4c7e-9bd6-33face0856c8" data-indentation="0" colspan="2">
 
                     <td style="padding-left: 0.0em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="bb710af0-ac4e-4dcd-a2fd-a9a9e97e3c00" onclick="collapseChildren('bb710af0-ac4e-4dcd-a2fd-a9a9e97e3c00')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="dd6f629a-b462-4c7e-9bd6-33face0856c8" onclick="collapseChildren('dd6f629a-b462-4c7e-9bd6-33face0856c8')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
 
                         <div>
@@ -952,7 +953,7 @@
                 </tr>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="264aec99-7503-4793-8ef5-e8923cc8ab83" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="d7e260ac-3166-434c-b0c6-1e836d7394b1" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
@@ -1002,7 +1003,7 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="204474dd-484c-46d1-ac6f-3349b7a30f57" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="86b00e8c-08fb-4283-8b94-e4037e12a059" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
@@ -1052,7 +1053,7 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="675886e6-3b21-4590-837d-a4fb81938a96" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="65bc0673-f72b-4d95-8186-1c2138771713" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
@@ -1165,11 +1166,11 @@
             <h4 class="nhsd-t-heading-m nhsd-!t-margin-bottom-0">Schema</h4>
         </div>
         <div class="nhsd-t-col-xs-12 nhsd-t-col-s-8 nhsd-!t-padding-0 nhsd-t-text-align-l-right">
-            <button onclick="collapseAll('ff020950-5faf-46e7-a2bb-509d0ad0c444')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
-            <button onclick="expandAll('ff020950-5faf-46e7-a2bb-509d0ad0c444')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
+            <button onclick="collapseAll('29a65a07-dfd5-4d59-93bd-436f3cfade87')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
+            <button onclick="expandAll('29a65a07-dfd5-4d59-93bd-436f3cfade87')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
         </div>
     </div>
-    <div class="nhsd-o-schema" data-schema-uuid="ff020950-5faf-46e7-a2bb-509d0ad0c444">
+    <div class="nhsd-o-schema" data-schema-uuid="29a65a07-dfd5-4d59-93bd-436f3cfade87">
         <div class="nhsd-m-table nhsd-t-body">
             <table data-no-sort="true">
                 <thead class="nhsd-o-schema__header">
@@ -1178,7 +1179,7 @@
                 </thead>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="593358c5-b207-4373-9fc0-5616a97be8f9" data-indentation="0" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="2ea725e0-b14b-47fe-8528-bb3f8fc93322" data-indentation="0" colspan="2">
 
                     <td style="padding-left: 0.0em;" class="nhsd-o-schema__name-column">
 
@@ -1421,11 +1422,11 @@
             <h4 class="nhsd-t-heading-m nhsd-!t-margin-bottom-0">Schema</h4>
         </div>
         <div class="nhsd-t-col-xs-12 nhsd-t-col-s-8 nhsd-!t-padding-0 nhsd-t-text-align-l-right">
-            <button onclick="collapseAll('6775a1e4-6a67-4851-a2f6-fd56ca876cd1')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
-            <button onclick="expandAll('6775a1e4-6a67-4851-a2f6-fd56ca876cd1')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
+            <button onclick="collapseAll('5e513731-f7c5-477e-9b8e-e1680f39a860')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
+            <button onclick="expandAll('5e513731-f7c5-477e-9b8e-e1680f39a860')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
         </div>
     </div>
-    <div class="nhsd-o-schema" data-schema-uuid="6775a1e4-6a67-4851-a2f6-fd56ca876cd1">
+    <div class="nhsd-o-schema" data-schema-uuid="5e513731-f7c5-477e-9b8e-e1680f39a860">
         <div class="nhsd-m-table nhsd-t-body">
             <table data-no-sort="true">
                 <thead class="nhsd-o-schema__header">
@@ -1434,7 +1435,7 @@
                 </thead>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="73da8bf5-bbab-4280-aff2-2d9ee52df789" data-indentation="0" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="334f3e5d-9f3c-4139-a187-d5e35eb5ead1" data-indentation="0" colspan="2">
 
                     <td style="padding-left: 0.0em;" class="nhsd-o-schema__name-column">
 
@@ -1628,11 +1629,11 @@
             <h4 class="nhsd-t-heading-m nhsd-!t-margin-bottom-0">Schema</h4>
         </div>
         <div class="nhsd-t-col-xs-12 nhsd-t-col-s-8 nhsd-!t-padding-0 nhsd-t-text-align-l-right">
-            <button onclick="collapseAll('ab9d40b4-a005-4a6f-9dcf-a95d74ef0dcc')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
-            <button onclick="expandAll('ab9d40b4-a005-4a6f-9dcf-a95d74ef0dcc')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
+            <button onclick="collapseAll('651223f9-89c8-44ea-adbe-32b2b0bdf959')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
+            <button onclick="expandAll('651223f9-89c8-44ea-adbe-32b2b0bdf959')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
         </div>
     </div>
-    <div class="nhsd-o-schema" data-schema-uuid="ab9d40b4-a005-4a6f-9dcf-a95d74ef0dcc">
+    <div class="nhsd-o-schema" data-schema-uuid="651223f9-89c8-44ea-adbe-32b2b0bdf959">
         <div class="nhsd-m-table nhsd-t-body">
             <table data-no-sort="true">
                 <thead class="nhsd-o-schema__header">
@@ -1641,10 +1642,10 @@
                 </thead>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="cf3b2821-4fda-4c06-94d2-b88982ef4225" data-indentation="0" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="5940bf19-4007-4b31-90db-716e246cb0f7" data-indentation="0" colspan="2">
 
                     <td style="padding-left: 0.0em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="cf3b2821-4fda-4c06-94d2-b88982ef4225" onclick="collapseChildren('cf3b2821-4fda-4c06-94d2-b88982ef4225')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="5940bf19-4007-4b31-90db-716e246cb0f7" onclick="collapseChildren('5940bf19-4007-4b31-90db-716e246cb0f7')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
 
                         <div>
@@ -1709,7 +1710,7 @@
                 </tr>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="ad19ce7b-5dfc-42f3-8f26-bd6ce98711db" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="7badfada-093f-413f-8cc0-bf78cbb8aea0" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
@@ -1759,10 +1760,10 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="db4689a9-e69f-4072-b18b-d21a576abf33" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="f77eaf6b-4aa7-4175-b2a2-184f9ae5810c" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="db4689a9-e69f-4072-b18b-d21a576abf33" onclick="collapseChildren('db4689a9-e69f-4072-b18b-d21a576abf33')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="f77eaf6b-4aa7-4175-b2a2-184f9ae5810c" onclick="collapseChildren('f77eaf6b-4aa7-4175-b2a2-184f9ae5810c')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="nhsd-o-schema__border-short-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
                         <div><strong>issue</strong></div>
 
@@ -1807,10 +1808,10 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="4063a697-98ba-4bd9-91a7-583148f50965" data-indentation="2" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="6897f3c6-0960-4f99-a619-33f3ab9360c0" data-indentation="2" colspan="2">
 
                     <td style="padding-left: 3.0em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="4063a697-98ba-4bd9-91a7-583148f50965" onclick="collapseChildren('4063a697-98ba-4bd9-91a7-583148f50965')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="6897f3c6-0960-4f99-a619-33f3ab9360c0" onclick="collapseChildren('6897f3c6-0960-4f99-a619-33f3ab9360c0')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 35.4%"></span><span class="nhsd-o-schema__border-short-horizontal" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span>
 
                         <div>
@@ -1853,7 +1854,7 @@
                 </tr>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="e45d6946-590b-4402-87f3-fc22deae35b0" data-indentation="3" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="f7ebbe79-d4d3-4174-a32f-b7721bee9299" data-indentation="3" colspan="2">
 
                     <td style="padding-left: 4.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="nhsd-o-schema__border-vertical" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
@@ -1902,7 +1903,7 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="8bf10f26-9d58-4ed6-9600-5e441884aa84" data-indentation="3" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="0371580f-63e7-49c5-85ec-b1f33cb53548" data-indentation="3" colspan="2">
 
                     <td style="padding-left: 4.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
@@ -2130,11 +2131,11 @@
             <h4 class="nhsd-t-heading-m nhsd-!t-margin-bottom-0">Schema</h4>
         </div>
         <div class="nhsd-t-col-xs-12 nhsd-t-col-s-8 nhsd-!t-padding-0 nhsd-t-text-align-l-right">
-            <button onclick="collapseAll('0e921303-a9a5-4f97-8c43-aede46019427')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
-            <button onclick="expandAll('0e921303-a9a5-4f97-8c43-aede46019427')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
+            <button onclick="collapseAll('8873add1-772b-477d-8f76-df1b5480e67d')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
+            <button onclick="expandAll('8873add1-772b-477d-8f76-df1b5480e67d')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
         </div>
     </div>
-    <div class="nhsd-o-schema" data-schema-uuid="0e921303-a9a5-4f97-8c43-aede46019427">
+    <div class="nhsd-o-schema" data-schema-uuid="8873add1-772b-477d-8f76-df1b5480e67d">
         <div class="nhsd-m-table nhsd-t-body">
             <table data-no-sort="true">
                 <thead class="nhsd-o-schema__header">
@@ -2143,10 +2144,10 @@
                 </thead>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="629a65c4-94ef-4b80-9013-023dc795d678" data-indentation="0" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="e04fd22e-278d-4119-9280-eebeadc86b7e" data-indentation="0" colspan="2">
 
                     <td style="padding-left: 0.0em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="629a65c4-94ef-4b80-9013-023dc795d678" onclick="collapseChildren('629a65c4-94ef-4b80-9013-023dc795d678')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="e04fd22e-278d-4119-9280-eebeadc86b7e" onclick="collapseChildren('e04fd22e-278d-4119-9280-eebeadc86b7e')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
 
                         <div>
@@ -2189,7 +2190,7 @@
                 </tr>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="2cfe3fa5-be46-4801-a1ad-566abb8996b8" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="2577b64c-4ba3-4979-a420-c41133896d61" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
@@ -2239,7 +2240,7 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="ee00564b-8671-49a0-b096-df668104ba96" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="55a49a3b-f775-4dc5-9e9a-41512f5287e3" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
@@ -2342,11 +2343,11 @@
             <h4 class="nhsd-t-heading-m nhsd-!t-margin-bottom-0">Schema</h4>
         </div>
         <div class="nhsd-t-col-xs-12 nhsd-t-col-s-8 nhsd-!t-padding-0 nhsd-t-text-align-l-right">
-            <button onclick="collapseAll('5d463b0c-5fd9-41ae-8673-62d5a2ea00d5')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
-            <button onclick="expandAll('5d463b0c-5fd9-41ae-8673-62d5a2ea00d5')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
+            <button onclick="collapseAll('3ac0d605-220c-416c-8248-99488dc3315f')" class="nhsd-a-button nhsd-a-button--outline nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Collapse all</button>
+            <button onclick="expandAll('3ac0d605-220c-416c-8248-99488dc3315f')" class="nhsd-a-button nhsd-o-schema__header-button nhsd-!t-margin-bottom-0 nhsd-!t-display-hide">Expand all</button>
         </div>
     </div>
-    <div class="nhsd-o-schema" data-schema-uuid="5d463b0c-5fd9-41ae-8673-62d5a2ea00d5">
+    <div class="nhsd-o-schema" data-schema-uuid="3ac0d605-220c-416c-8248-99488dc3315f">
         <div class="nhsd-m-table nhsd-t-body">
             <table data-no-sort="true">
                 <thead class="nhsd-o-schema__header">
@@ -2355,10 +2356,10 @@
                 </thead>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="02db0190-a061-4ddf-9bb4-d2e66b63deb5" data-indentation="0" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="c84a6545-a740-4027-a69c-a04be55393ba" data-indentation="0" colspan="2">
 
                     <td style="padding-left: 0.0em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="02db0190-a061-4ddf-9bb4-d2e66b63deb5" onclick="collapseChildren('02db0190-a061-4ddf-9bb4-d2e66b63deb5')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="c84a6545-a740-4027-a69c-a04be55393ba" onclick="collapseChildren('c84a6545-a740-4027-a69c-a04be55393ba')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 31.4%"></span>
 
                         <div>
@@ -2423,7 +2424,7 @@
                 </tr>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="0f7e2316-8ca2-465a-b644-c2fecb9a3954" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="3ec4c080-ebb1-469f-9d8f-08ea22ef8d4f" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
@@ -2473,10 +2474,10 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="2ec04e5a-c5e6-449c-ae2c-e110cf0c71aa" data-indentation="1" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="899f2d4c-d21e-4698-9c83-e7158fb85071" data-indentation="1" colspan="2">
 
                     <td style="padding-left: 1.5em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="2ec04e5a-c5e6-449c-ae2c-e110cf0c71aa" onclick="collapseChildren('2ec04e5a-c5e6-449c-ae2c-e110cf0c71aa')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="899f2d4c-d21e-4698-9c83-e7158fb85071" onclick="collapseChildren('899f2d4c-d21e-4698-9c83-e7158fb85071')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 34.0%"></span><span class="nhsd-o-schema__border-short-horizontal" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 31.4%"></span>
                         <div><strong>issue</strong></div>
 
@@ -2521,10 +2522,10 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="67ce5326-1092-4571-ba20-bd5e5c171a12" data-indentation="2" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="e714a5b7-6fc7-4e57-832f-83633e835d0c" data-indentation="2" colspan="2">
 
                     <td style="padding-left: 3.0em;" class="nhsd-o-schema__name-column">
-                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="67ce5326-1092-4571-ba20-bd5e5c171a12" onclick="collapseChildren('67ce5326-1092-4571-ba20-bd5e5c171a12')"></a>
+                        <a class="nhsd-o-schema__button nhsd-o-schema__collapser nhsd-!t-display-hide" data-schema-uuid="e714a5b7-6fc7-4e57-832f-83633e835d0c" onclick="collapseChildren('e714a5b7-6fc7-4e57-832f-83633e835d0c')"></a>
                         <span class="nhsd-o-schema__border-child" style="--border-padding: 1.25em; --border-lightness: 35.4%"></span><span class="nhsd-o-schema__border-short-horizontal" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 34.0%"></span>
 
                         <div>
@@ -2567,7 +2568,7 @@
                 </tr>
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="88439ff1-76e3-48dc-b165-e2be36d03df8" data-indentation="3" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="6dd5c6b6-31ca-418c-bc26-bba03fe17e61" data-indentation="3" colspan="2">
 
                     <td style="padding-left: 4.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="nhsd-o-schema__border-vertical" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>
@@ -2616,7 +2617,7 @@
 
 
 
-                <tr class="nhsd-o-schema__expanded" data-schema-uuid="be22a32d-cf30-4c77-8621-b4b6560494df" data-indentation="3" colspan="2">
+                <tr class="nhsd-o-schema__expanded" data-schema-uuid="31bcdaec-b9e0-483d-9406-4b4d5ba11002" data-indentation="3" colspan="2">
 
                     <td style="padding-left: 4.5em;" class="nhsd-o-schema__name-column">
                         <span class="nhsd-o-schema__border-horizontal" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span><span class="nhsd-o-schema__border-short-vertical" style="--border-padding: -0.25em; --border-lightness: 35.4%"></span>


### PR DESCRIPTION
This user story has changed the way we parse the description text of specifications. 

Until now we just manage headers size from markdown. Based on the number of hashes(#) we set a number of attributes implementing `AttributeProvider` interface. However, it has some limitations that don't allow us to have proper control to add new HTML elements like `<hr>`

In order to have full control, I have implemented `NodeRenderer` interface, another interface that allows full control of nodes.

Within these changes I have deleted `HeadingAttributeProvider` class that was an `AttributeProvider` implementation and use the same logic in a new class `HeadingsRenderer` that implements a `NodeRenderer`. Now we have the same logic as before plus the possibility to add new HTML elements. 

