### PR TITLE
[DW-0000] Directory Maven plugin workaround

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -357,36 +357,36 @@
                             <configuration>
                                 <configfiles>
                                     <configfile>
-                                        <file>${website.basedir}/conf/context.xml</file>
+                                        <file>${maven.multiModuleProjectDirectory}/conf/context.xml</file>
                                         <todir>conf/</todir>
                                         <tofile>context.xml</tofile>
                                     </configfile>
                                     <configfile>
-                                        <file>${website.basedir}/conf/catalina-logging.properties</file>
+                                        <file>${maven.multiModuleProjectDirectory}/conf/catalina-logging.properties</file>
                                         <todir>conf/</todir>
                                         <tofile>logging.properties</tofile>
                                     </configfile>
                                     <configfile>
-                                        <file>${website.basedir}/conf/query/lucene/indexing_configuration.xml</file>
+                                        <file>${maven.multiModuleProjectDirectory}/conf/query/lucene/indexing_configuration.xml</file>
                                         <todir>conf/query/lucene</todir>
                                         <tofile>indexing_configuration.xml</tofile>
                                     </configfile>
                                 </configfiles>
                                 <files>
                                     <file>
-                                        <file>${website.basedir}/repository-data/development/target/website-repository-data-development-${project.version}.jar</file>
+                                        <file>${maven.multiModuleProjectDirectory}/repository-data/development/target/website-repository-data-development-${project.version}.jar</file>
                                         <todir>${development-module-deploy-dir}</todir>
                                     </file>
                                     <file>
-                                        <file>${website.basedir}/repository-data/local/target/website-repository-data-local-${project.version}.jar</file>
+                                        <file>${maven.multiModuleProjectDirectory}/repository-data/local/target/website-repository-data-local-${project.version}.jar</file>
                                         <todir>${local-module-deploy-dir}</todir>
                                     </file>
                                     <file>
-                                        <file>${website.basedir}/s3connector/target/s3-connector-${project.version}.jar</file>
+                                        <file>${maven.multiModuleProjectDirectory}/s3connector/target/s3-connector-${project.version}.jar</file>
                                         <todir>shared/lib</todir>
                                     </file>
                                     <file>
-                                        <file>${website.basedir}/repository-data/site-development/target/website-repository-data-site-development-${project.version}.jar</file>
+                                        <file>${maven.multiModuleProjectDirectory}/repository-data/site-development/target/website-repository-data-site-development-${project.version}.jar</file>
                                         <todir>${development-module-deploy-dir}</todir>
                                     </file>
                                 </files>
@@ -397,14 +397,14 @@
                                     <properties>
                                         <context>/cms</context>
                                     </properties>
-                                    <location>${website.basedir}/cms/target/cms.war</location>
+                                    <location>${maven.multiModuleProjectDirectory}/cms/target/cms.war</location>
                                 </deployable>
                                 <deployable>
                                     <type>war</type>
                                     <properties>
                                         <context>/site</context>
                                     </properties>
-                                    <location>${website.basedir}/site/webapp/target/site.war</location>
+                                    <location>${maven.multiModuleProjectDirectory}/site/webapp/target/site.war</location>
                                 </deployable>
                             </deployables>
                             <container>
@@ -413,12 +413,12 @@
                                     <url>${cargo.tomcat.distribution.url}</url>
                                 </zipUrlInstaller>
                                 <systemProperties>
-                                    <log4j.configurationFile>file://${website.basedir}/conf/log4j2-dev.xml</log4j.configurationFile>
+                                    <log4j.configurationFile>file://${maven.multiModuleProjectDirectory}/conf/log4j2-dev.xml</log4j.configurationFile>
                                     <!-- enables auto export and web files watch: -->
-                                    <project.basedir>${website.basedir}/</project.basedir>
+                                    <project.basedir>${maven.multiModuleProjectDirectory}/</project.basedir>
                                     <send.usage.statistics.to.hippo>false</send.usage.statistics.to.hippo>
                                     <repo.autoexport.allowed>false</repo.autoexport.allowed>
-                                    <repo.config>file://${website.basedir}/conf/repository.xml</repo.config>
+                                    <repo.config>file://${maven.multiModuleProjectDirectory}/conf/repository.xml</repo.config>
 
                                     <!-- Splunk forwarder config -->
                                     <splunk.hec.name>${splunk.hec.name}</splunk.hec.name>

--- a/pom.xml
+++ b/pom.xml
@@ -730,28 +730,11 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.commonjava.maven.plugins</groupId>
-                <artifactId>directory-maven-plugin</artifactId>
-                <version>0.3.1</version>
-                <executions>
-                    <execution>
-                        <id>directories</id>
-                        <goals>
-                            <goal>highest-basedir</goal>
-                        </goals>
-                        <phase>initialize</phase>
-                        <configuration>
-                            <property>website.basedir</property>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
                 <version>2.8.1</version>
                 <configuration>
-                    <rulesUri>file://${website.basedir}/conf/maven-version-rules.xml</rulesUri>
+                    <rulesUri>file://${project.basedir}/conf/maven-version-rules.xml</rulesUri>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Latest Maven version breaks directory-maven-plugin.

The plugin is used to identify filesystem path of the
root module of the Maven project, which is then exposed
to the other modules via `website.basedir` property
(note that `project.basedir` property changes between
modules and so is not suitable).

The workaround is to apply property
`maven.multiModuleProjectDirectory` instead of the
plugin and instead of `website.basedir`.

This is only a temporary workaround, because
`maven.multiModuleProjectDirectory` is Maven's internal,
undocumented property which may change without warning
in Maven's future versions and so its use is discouraged.

A proper fix to the issue is in progress of being developed,
and once
https://github.com/jdcasey/directory-maven-plugin/issues/16
issue is addressed, the plugin should be updated and the current
workaround reversed.