### PR TITLE
[ADZ-1365] API catalogue categories restyle

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -20,7 +20,11 @@
         <cucumber.version>1.2.5</cucumber.version>
         <spring.version>5.1.15.RELEASE</spring.version>
         <selenium.version>3.141.59</selenium.version>
-        <chromedriver.version>92.0.4515.43</chromedriver.version>
+        <!--
+        Consult https://chromedriver.chromium.org/downloads
+        to find the right ChromeDriver version to use with the current browser version,
+        -->
+        <chromedriver.version>93.0.4577.63</chromedriver.version>
     </properties>
 
     <dependencies>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/apicatalogue/scrollable-filter-nav.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/apicatalogue/scrollable-filter-nav.ftl
@@ -32,20 +32,26 @@
             <nav>
                 <#list filtersModel.sections as section>
                     <#if section.displayed>
-                        <div>
-                            <input id="<#if responsive>responsive_</#if>toggler_${section.key}" class="section-folder" style="display:none;" type="checkbox" aria-hidden="true"/>
-                            <label for="<#if responsive>responsive_</#if>toggler_${section.key}">
-                        <span class="icon">
-                            <span class="nhsd-a-icon nhsd-a-icon--size-xxs">
-                                <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
-                                    <path d="M8,12L1,5.5L2.5,4L8,9.2L13.5,4L15,5.5L8,12z"></path>
-                                </svg>
-                            </span>
-                        </span>
-                                <span class="nhsd-m-filter-menu-section__heading-text nhsd-t-body-s nhsd-!t-margin-bottom-0 nhsd-!t-padding-0 <#if section.expanded>selected</#if>">
-                            ${section.displayName}
-                        </span>
-                            </label>
+                        <div> <#-- the div separates sections so that CSS sibling selectors '~' only target elements within one section. -->
+                            <input id="<#if responsive>responsive_</#if>toggler_${section.key}"
+                                   class="section-folder"
+                                   style="display:none;"
+                                   type="checkbox"
+                                   aria-hidden="true"
+                                   <#if section.expanded>checked</#if>/>
+                            <div class="nhsd-m-filter-menu-section__menu-button">
+                                <label for="<#if responsive>responsive_</#if>toggler_${section.key}"
+                                       class="nhsd-m-filter-menu-section__heading-text">
+                                        <span class="nhsd-a-icon nhsd-a-icon--size-xxs">
+                                            <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16" width="100%" height="100%">
+                                                <path d="M8,12L1,5.5L2.5,4L8,9.2L13.5,4L15,5.5L8,12z"></path>
+                                            </svg>
+                                        </span>
+                                        <span class="nhsd-t-body-s nhsd-!t-margin-bottom-0 nhsd-!t-padding-0 <#if section.expanded>selected</#if>">
+                                            ${section.displayName}
+                                        </span>
+                                </label>
+                            </div>
                             <hr class="nhsd-a-horizontal-rule nhsd-a-horizontal-rule--size-s">
                             <div class="section-entries">
                                 <#list section.entries as filter>

--- a/repository-data/webfiles/src/main/resources/site/src/scss/rebrand/components/_api-catalogue.scss
+++ b/repository-data/webfiles/src/main/resources/site/src/scss/rebrand/components/_api-catalogue.scss
@@ -50,18 +50,20 @@
     }
   }
 
-  input.section-folder:not(:checked) {
+  input.section-folder {
 
-    ~ label .icon svg {
-      rotate: -90deg;
+    &:checked {
+      ~ .nhsd-m-filter-menu-section__menu-button svg {
+        rotate: 180deg;
+      }
     }
 
-    ~ .section-entries {
-      display: none;
-    }
+    &:not(:checked) {
 
-    ~ hr:first-of-type {
-      display: none;
+      ~ .section-entries,
+      ~ hr:first-of-type {
+        display: none;
+      }
     }
   }
 
@@ -70,10 +72,8 @@
     color: #231f20;
   }
 
-  & .nhsd-a-button {
-    margin-bottom: -.3rem;
-    padding: .2555555556rem 1.1111111111rem;
-    float: right;
+  & .nhsd-m-filter-menu-section__menu-button {
+    padding: 0;
   }
 }
 


### PR DESCRIPTION
Category headings in API catalogue's _Filters_
section are now styled in line with the Design
System > Filter Menu Section.

Also, implements [ADZ-1376] '_API Catalogue -
Side Nav Refinement (Filters to remain
expanded when selected)_'.