### PR TITLE
[ADZ-1411] Added support for highlighting filters 

### DIFF
--- a/repository-data/development/src/main/resources/hcm-content/content/documents/administration/developer-hub.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/administration/developer-hub.yaml
@@ -8,7 +8,7 @@
       hippostd:state: draft
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-04-07T06:26:52.343Z
-      hippostdpubwf:lastModificationDate: 2021-10-25T07:39:57.096Z
+      hippostdpubwf:lastModificationDate: 2021-11-05T11:53:13.710Z
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: 4e04e90e-c2f3-4cca-84a5-817e6a9c8995
       hippotranslation:locale: document-type-locale
@@ -72,10 +72,10 @@
         \  displayName: Central\r\n      - taxonomyKey: intermediary\r\n        displayName:\
         \ Intermediary\r\n    - taxonomyKey: api-standard\r\n      displayName: API\
         \ Standard\r\n\r\n  - displayName: API Status\r\n    entries:\r\n    - taxonomyKey:\
-        \ deprecated-api\r\n      displayName: Deprecated\r\n    - taxonomyKey: retired-api\r\
-        \n      displayName: Retired\r\n    - taxonomyKey: category,with,commas\r\n\
-        \      displayName: category,with,commas\r\n    - taxonomyKey: category_x007c_with_x007c_pipes\r\
-        \n      displayName: category|with|pipes"
+        \ deprecated-api\r\n      displayName: Deprecated\r\n      highlight: light-red\r\
+        \n    - taxonomyKey: retired-api\r\n      displayName: Retired\r\n    - taxonomyKey:\
+        \ category,with,commas\r\n      displayName: category,with,commas\r\n    -\
+        \ taxonomyKey: category_x007c_with_x007c_pipes\r\n      displayName: category|with|pipes"
     /taxonomy-filters-mapping[2]:
       common:searchable: true
       hippo:availability:
@@ -84,7 +84,7 @@
       hippostd:state: unpublished
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-04-07T06:26:52.343Z
-      hippostdpubwf:lastModificationDate: 2021-10-25T07:40:07.711Z
+      hippostdpubwf:lastModificationDate: 2021-11-05T11:53:13.657Z
       hippostdpubwf:lastModifiedBy: admin
       hippotranslation:id: 4e04e90e-c2f3-4cca-84a5-817e6a9c8995
       hippotranslation:locale: document-type-locale
@@ -149,10 +149,10 @@
         \  displayName: Central\r\n      - taxonomyKey: intermediary\r\n        displayName:\
         \ Intermediary\r\n    - taxonomyKey: api-standard\r\n      displayName: API\
         \ Standard\r\n\r\n  - displayName: API Status\r\n    entries:\r\n    - taxonomyKey:\
-        \ deprecated-api\r\n      displayName: Deprecated\r\n    - taxonomyKey: retired-api\r\
-        \n      displayName: Retired\r\n    - taxonomyKey: category,with,commas\r\n\
-        \      displayName: category,with,commas\r\n    - taxonomyKey: category_x007c_with_x007c_pipes\r\
-        \n      displayName: category|with|pipes"
+        \ deprecated-api\r\n      displayName: Deprecated\r\n      highlight: light-red\r\
+        \n    - taxonomyKey: retired-api\r\n      displayName: Retired\r\n    - taxonomyKey:\
+        \ category,with,commas\r\n      displayName: category,with,commas\r\n    -\
+        \ taxonomyKey: category_x007c_with_x007c_pipes\r\n      displayName: category|with|pipes"
     /taxonomy-filters-mapping[3]:
       common:searchable: true
       hippo:availability:
@@ -161,9 +161,9 @@
       hippostd:state: published
       hippostdpubwf:createdBy: admin
       hippostdpubwf:creationDate: 2021-04-07T06:26:52.343Z
-      hippostdpubwf:lastModificationDate: 2021-10-25T07:40:07.711Z
+      hippostdpubwf:lastModificationDate: 2021-11-05T11:53:13.657Z
       hippostdpubwf:lastModifiedBy: admin
-      hippostdpubwf:publicationDate: 2021-10-25T07:40:10.239Z
+      hippostdpubwf:publicationDate: 2021-11-05T11:53:16.202Z
       hippotranslation:id: 4e04e90e-c2f3-4cca-84a5-817e6a9c8995
       hippotranslation:locale: document-type-locale
       jcr:mixinTypes:
@@ -226,12 +226,12 @@
         \  displayName: Central\r\n      - taxonomyKey: intermediary\r\n        displayName:\
         \ Intermediary\r\n    - taxonomyKey: api-standard\r\n      displayName: API\
         \ Standard\r\n\r\n  - displayName: API Status\r\n    entries:\r\n    - taxonomyKey:\
-        \ deprecated-api\r\n      displayName: Deprecated\r\n    - taxonomyKey: retired-api\r\
-        \n      displayName: Retired\r\n    - taxonomyKey: category,with,commas\r\n\
-        \      displayName: category,with,commas\r\n    - taxonomyKey: category_x007c_with_x007c_pipes\r\
-        \n      displayName: category|with|pipes"
+        \ deprecated-api\r\n      displayName: Deprecated\r\n      highlight: light-red\r\
+        \n    - taxonomyKey: retired-api\r\n      displayName: Retired\r\n    - taxonomyKey:\
+        \ category,with,commas\r\n      displayName: category,with,commas\r\n    -\
+        \ taxonomyKey: category_x007c_with_x007c_pipes\r\n      displayName: category|with|pipes"
     hippo:name: Taxonomy filters mapping
-    hippo:versionHistory: 283ec566-7903-4bda-9f13-2a9dcd310bc9
+    hippo:versionHistory: db76f34b-d54f-4b60-b664-2e5220b2830b
     jcr:mixinTypes:
     - hippo:named
     - hippo:versionInfo

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/apicatalogue/api-catalogue-entries.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/apicatalogue/api-catalogue-entries.ftl
@@ -52,8 +52,12 @@
                                             </#if>
                                         </#if>
                                     </#if>
-
-                                    <h2 class="nhsd-t-heading-xs nhsd-!t-margin-bottom-1" id="${block.title?lower_case?replace(" ", "-")}">
+                                        <#list get_unique_sorted_tags(block filtersModel) as taxonomyTag>
+                                            <#if filtersModel.isHighlighted(taxonomyTag)>
+                                                <span class="nhsd-a-tag nhsd-a-tag--bg-${filtersModel.getHighlight(taxonomyTag)} nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-1">${taxonomyTag}</span>
+                                            </#if>
+                                        </#list>
+                                    <h2 class="nhsd-t-heading-xs nhsd-!t-margin-top-1 nhsd-!t-margin-bottom-1" id="${block.title?lower_case?replace(" ", "-")}">
                                         <#if link?has_content>
                                             <a href="${link}" class="nhsd-a-link" data-filterable>${block.title}</a>
                                         <#else>
@@ -68,10 +72,11 @@
                                             <@hst.html hippohtml=block.definition contentRewriter=brContentRewriter/>
                                         </div>
                                     </#if>
-                                    <#list get_sorted_tags(block filtersModel) as taxonomyTag>
-                                        <span class="nhsd-a-tag nhsd-a-tag--bg-light-grey nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-1">${taxonomyTag}</span>
+                                        <#list get_unique_sorted_tags(block filtersModel) as taxonomyTag>
+                                            <#if !filtersModel.isHighlighted(taxonomyTag)>
+                                                <span style="line-height:1" class="nhsd-a-tag nhsd-a-tag--bg-light-grey nhsd-!t-margin-top-3 nhsd-!t-margin-bottom-1">${taxonomyTag}</span>
+                                        </#if>
                                     </#list>
-
                                     <#if block?index lt blockGroups[letter]?size - 1>
                                         <hr class="nhsd-a-horizontal-rule"/>
                                     </#if>
@@ -85,13 +90,13 @@
     </#if>
 </#macro>
 
-<#function get_sorted_tags block filtersModel>
+<#function get_unique_sorted_tags block filtersModel>
     <#local documentTags = block.getMultipleProperty("hippotaxonomy:keys")![] />
-    <#local sortedTagDisplayNames = [] />
+    <#local uniqueSortedTagDisplayNames = [] />
     <#list filtersModel.sectionsInOrderOfDeclaration() as filterSection>
-        <#if documentTags?? && documentTags?seq_contains(filterSection.getKey())>
-            <#local sortedTagDisplayNames = sortedTagDisplayNames + [ filterSection.displayName ] />
+        <#if documentTags?? && documentTags?seq_contains(filterSection.getKey()) && !uniqueSortedTagDisplayNames?seq_contains(filterSection.getDisplayName())>
+            <#local uniqueSortedTagDisplayNames = uniqueSortedTagDisplayNames + [ filterSection.displayName ] />
         </#if>
     </#list>
-    <#return sortedTagDisplayNames>
+    <#return uniqueSortedTagDisplayNames>
 </#function>

--- a/site/components/src/main/java/uk/nhs/digital/common/components/apicatalogue/filters/Filters.java
+++ b/site/components/src/main/java/uk/nhs/digital/common/components/apicatalogue/filters/Filters.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 public class Filters implements Walkable {
 
@@ -84,15 +85,35 @@ public class Filters implements Walkable {
 
         if (selectedFiltersKeys == null) {
 
-            selectedFiltersKeys = sectionsInOrderOfDeclaration().stream()
-                .filter(Subsection.class::isInstance)
-                .map(Subsection.class::cast)
+            selectedFiltersKeys = getSubsectionsStream()
                 .filter(Subsection::isSelected)
                 .map(Subsection::getKey)
                 .collect(toSet());
         }
 
         return selectedFiltersKeys;
+    }
+
+    public boolean isHighlighted(final String displayName) {
+        return getSubsectionsStream()
+            .filter(section -> section.getDisplayName().equals(displayName))
+            .findAny()      //If filters are duplicated this method will pick up the highlight status of the instance the highest up the tree.
+            .map(section -> section.isHighlighted())
+            .orElse(false);
+    }
+
+    public String getHighlight(final String displayName) {
+        return getSubsectionsStream()
+            .filter(section -> section.getDisplayName().equals(displayName))
+            .findAny()      //If filters are duplicated this method will pick up the highlight colour of the instance the highest up the tree.
+            .map(section -> section.getHighlight())
+            .orElse("light-grey");      //light-grey is returned if the highlight field is not populated as this is the default.
+    }
+
+    private Stream<Subsection> getSubsectionsStream() {
+        return sectionsInOrderOfDeclaration().stream()
+            .filter(Subsection.class::isInstance)
+            .map(Subsection.class::cast);
     }
 
     public static Filters emptyInstance() {

--- a/site/components/src/main/java/uk/nhs/digital/common/components/apicatalogue/filters/Subsection.java
+++ b/site/components/src/main/java/uk/nhs/digital/common/components/apicatalogue/filters/Subsection.java
@@ -2,11 +2,13 @@ package uk.nhs.digital.common.components.apicatalogue.filters;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.*;
 
 public class Subsection extends Section {
 
     private final String taxonomyKey;
+    private final String highlight;
 
     private boolean selected;
     private boolean selectable;
@@ -16,15 +18,25 @@ public class Subsection extends Section {
         @JsonProperty("displayName") final String displayName,
         @JsonProperty("taxonomyKey") final String taxonomyKey,
         @JsonProperty("description") final String description,
+        @JsonProperty("highlight") final String highlight,
         @JsonProperty("entries") final Subsection... subsections
     ) {
         super(displayName, description, subsections);
         this.taxonomyKey = taxonomyKey;
+        this.highlight = highlight;
     }
 
     @Override
     public String getKey() {
         return taxonomyKey;
+    }
+
+    public String getHighlight() {
+        return highlight;
+    }
+
+    public boolean isHighlighted() {
+        return !StringUtils.isBlank(highlight);
     }
 
     public boolean isSelected() {
@@ -67,17 +79,22 @@ public class Subsection extends Section {
 
         final Subsection that = (Subsection) o;
 
-        return new EqualsBuilder().appendSuper(super.equals(o))
+        return new EqualsBuilder()
+            .appendSuper(super.equals(o))
             .append(selected, that.selected)
             .append(selectable, that.selectable)
             .append(taxonomyKey, that.taxonomyKey)
+            .append(highlight, that.highlight)
             .isEquals();
     }
 
     @Override public int hashCode() {
         return new HashCodeBuilder(17, 37)
             .appendSuper(super.hashCode())
-            .append(taxonomyKey).append(selected).append(selectable)
+            .append(selected)
+            .append(selectable)
+            .append(taxonomyKey)
+            .append(highlight)
             .toHashCode();
     }
 }

--- a/site/components/src/test/java/uk/nhs/digital/common/components/apicatalogue/filters/FiltersTest.java
+++ b/site/components/src/test/java/uk/nhs/digital/common/components/apicatalogue/filters/FiltersTest.java
@@ -76,19 +76,77 @@ public class FiltersTest {
         );
     }
 
+    @Test
+    public void isHighlighted_returnsHighlightStatus_GivenDisplayName() {
+
+        // given
+        final Filters filters = baseFilters();
+
+        final List<Boolean> expectedHighlightStatusResults = asList(
+            false,
+            true,
+            true,
+            false,
+            true,
+            false
+        );
+
+        // when
+        final List<Boolean> actualHighlightStatusResults = asList(
+            filters.isHighlighted("Subsection Z"),
+            filters.isHighlighted("Subsection D"),
+            filters.isHighlighted("Subsection S"),
+            filters.isHighlighted("Subsection U"),
+            filters.isHighlighted("Subsection T"),
+            filters.isHighlighted("Subsection E")
+        );
+
+        // then
+        assertThat("Filters returned correct highlight status.",actualHighlightStatusResults ,is(expectedHighlightStatusResults));
+    }
+
+    @Test
+    public void getHighlight_returnsHighlightColour_GivenDisplayName() {
+
+        // given
+        final Filters filters = baseFilters();
+
+        final List<String> expectedHighlightResults = asList(
+            "light-grey",
+            "colour-a",
+            "colour-b",
+            "light-grey",
+            "colour-c",
+            "light-grey"
+        );
+
+        // when
+        final List<String> actualHighlightResults = asList(
+            filters.getHighlight("Subsection Z"),
+            filters.getHighlight("Subsection D"),
+            filters.getHighlight("Subsection S"),
+            filters.getHighlight("Subsection U"),
+            filters.getHighlight("Subsection T"),
+            filters.getHighlight("Subsection E")
+        );
+
+        // then
+        assertThat("Filters returned correct highlight status.",actualHighlightResults ,is(expectedHighlightResults));
+    }
+
     private Filters baseFilters() {
         return FiltersTestUtils.filters(
             section("Section 5",
                 subsection("Subsection Z", "key-z"),
-                subsection("Subsection D", "key-d",
-                    subsection("Subsection S", "key-s"),
+                subsection("Subsection D", "key-d", "colour-a",
+                    subsection("Subsection S", "key-s", null, "colour-b"),
                     subsection("Subsection U", "key-u")
                 )
             ),
             section("Section 2",
                 subsection("Subsection 3", "key-3"),
                 subsection("Subsection I", "key-i",
-                    subsection("Subsection T", "key-t"),
+                    subsection("Subsection T", "key-t", null, "colour-c"),
                     subsection("Subsection E", "key-e")
                 )
             )

--- a/site/components/src/test/java/uk/nhs/digital/common/components/apicatalogue/filters/FiltersTestUtils.java
+++ b/site/components/src/test/java/uk/nhs/digital/common/components/apicatalogue/filters/FiltersTestUtils.java
@@ -1,7 +1,6 @@
 package uk.nhs.digital.common.components.apicatalogue.filters;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
 
 import com.google.common.collect.ImmutableSet;
 import uk.nhs.digital.test.util.ReflectionTestUtils;
@@ -31,19 +30,27 @@ public class FiltersTestUtils {
     }
 
     public static Subsection subsection(final String displayName, final Subsection... subsections) {
-        return new Subsection(displayName, null, null, subsections);
+        return new Subsection(displayName, null, null, null, subsections);
     }
 
     public static Subsection subsection(final String displayName, final String taxonomyKey) {
-        return new Subsection(displayName, taxonomyKey, null);
+        return new Subsection(displayName, taxonomyKey, null, null);
     }
 
     public static Subsection subsection(final String displayName, final String taxonomyKey, final Subsection... subsections) {
-        return new Subsection(displayName, taxonomyKey, null, subsections);
+        return new Subsection(displayName, taxonomyKey, null, null, subsections);
     }
 
     public static Subsection subsection(final String displayName, final String taxonomyKey, final String description) {
-        return new Subsection(displayName, taxonomyKey, description);
+        return new Subsection(displayName, taxonomyKey, description, null);
+    }
+
+    public static Subsection subsection(final String displayName, final String taxonomyKey, final String highlight, final Subsection... subsections) {
+        return new Subsection(displayName, taxonomyKey, null, highlight, subsections);
+    }
+
+    public static Subsection subsection(final String displayName, final String taxonomyKey, final String description, final String highlight, final Subsection... subsections) {
+        return new Subsection(displayName, taxonomyKey, description, highlight, subsections);
     }
 
     public static void updateFilters(

--- a/site/components/src/test/java/uk/nhs/digital/common/components/apicatalogue/filters/JacksonFiltersFactoryTest.java
+++ b/site/components/src/test/java/uk/nhs/digital/common/components/apicatalogue/filters/JacksonFiltersFactoryTest.java
@@ -49,6 +49,7 @@ public class JacksonFiltersFactoryTest {
             "            description: subsection multiline description",
             "              with <a href=\"https://digital.nhs.uk/developer\" class=\"nhsd-a-link\" target=\"_blank\">hyperlink</a>",
             "              more text",
+            "            highlight: light-red",
             "          - displayName: Subsection E",
             "            taxonomyKey: key-e"
         );
@@ -69,8 +70,10 @@ public class JacksonFiltersFactoryTest {
                 subsection("Subsection I", "key-i",
                     subsection("Subsection T", "key-t",
                         "subsection multiline description"
-                            + " with <a href=\"https://digital.nhs.uk/developer\" class=\"nhsd-a-link\" target=\"_blank\">hyperlink</a>"
-                            + " more text"),
+                        + " with <a href=\"https://digital.nhs.uk/developer\" class=\"nhsd-a-link\" target=\"_blank\">hyperlink</a>"
+                        + " more text",
+                        "light-red"
+                    ),
                     subsection("Subsection E", "key-e")
                 )
             )


### PR DESCRIPTION
Adds functionality to mark filters with a highlight colour which changes the filter background and makes them show above the API Name.
Screenshot showing Inpatient filter highlighted in light-red and Outpatient filter highlighted in light-blue:
![implemented ](https://user-images.githubusercontent.com/72503593/140393386-c780fbc6-3e9a-470c-a286-7b29bb41c97c.png)

