### PR TITLE
[DW-2820] Remove Gov Delivery Bean from the Site context

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/configuration/modules/crispregistry.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/modules/crispregistry.yaml
@@ -19,7 +19,4 @@ definitions:
       crisp:propvalues:
       - 'true'
       - https://www.google.com
-      crisp:sitescopes:
-      - publicationsystem
-      - platform
       jcr:primaryType: crisp:resourceresolver

--- a/site/components/src/main/resources/META-INF/hst-assembly/addon/crisp/overrides/custom-resource-resolvers.xml
+++ b/site/components/src/main/resources/META-INF/hst-assembly/addon/crisp/overrides/custom-resource-resolvers.xml
@@ -4,7 +4,7 @@
        xmlns:cotext="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-4.1.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
-        <bean id="govDeliveryApi"
+    <bean id="govDeliveryApi"
           parent="abstractCrispSimpleRestTemplateResourceResolver"
           class="org.onehippo.cms7.crisp.core.resource.jdom.SimpleJdomRestTemplateResourceResolver">
         <property name="cacheEnabled" value="false"/>

--- a/site/components/src/main/resources/META-INF/hst-assembly/overrides/application-secrets.xml
+++ b/site/components/src/main/resources/META-INF/hst-assembly/overrides/application-secrets.xml
@@ -10,6 +10,7 @@
     <beans profile="cloud-config-odv1">
 
         <context:property-placeholder location="file:#{systemProperties['secure.properties.location']}/microsoft-graph.properties" />
+        <context:property-placeholder location="file:#{systemProperties['secure.properties.location']}/govdelivery.properties"   />
 
         <bean id="applicationSecrets" class="uk.nhs.digital.toolbox.secrets.ApplicationSecrets">
             <constructor-arg name="cache">
@@ -19,6 +20,8 @@
                     <entry key="graph.api.redirect.url" value="${graph.api.redirect.url}" />
                     <entry key="auth.resource.redirect.url" value="${auth.resource.redirect.url}" />
                     <entry key="graph.api.base.url" value="${graph.api.base.url}" />
+                    <entry key="govdelivery.api.username" value="${govdelivery.api.username}" />
+                    <entry key="govdelivery.api.password" value="${govdelivery.api.password}" />
                 </map>
             </constructor-arg>
         </bean>


### PR DESCRIPTION
I have also removed `crisp:sitescopes` as this is not needed in a single site project. 