### PR TITLE
[ADZ-1926] Disables First Level Page Cache

### DIFF
--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
@@ -346,7 +346,7 @@ definitions:
         /api-catalogue:
           /_any_:
             /_index_:
-              hst:cacheable: true
+              hst:cacheable: false
               hst:componentconfigurationmappingnames:
               - website:service
               - website:general
@@ -359,7 +359,7 @@ definitions:
               - hst:pages/apispecification
               hst:relativecontentpath: ${parent}/content
               jcr:primaryType: hst:sitemapitem
-            hst:cacheable: true
+            hst:cacheable: false
             hst:componentconfigurationid: hst:pages/404
             hst:componentconfigurationmappingnames:
             - website:service


### PR DESCRIPTION
Disables First Level Page Caching for the purpose of collecting garbage collection logs so that the impact of First Level Page Caching on garbage collection can be better assessed.