### PR TITLE
[ADZ-1926] Re-enables First Level Page Cache

### DIFF
--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
@@ -346,7 +346,7 @@ definitions:
         /api-catalogue:
           /_any_:
             /_index_:
-              hst:cacheable: false
+              hst:cacheable: true
               hst:componentconfigurationmappingnames:
               - website:service
               - website:general
@@ -359,7 +359,7 @@ definitions:
               - hst:pages/apispecification
               hst:relativecontentpath: ${parent}/content
               jcr:primaryType: hst:sitemapitem
-            hst:cacheable: false
+            hst:cacheable: true
             hst:componentconfigurationid: hst:pages/404
             hst:componentconfigurationmappingnames:
             - website:service


### PR DESCRIPTION
First Level Page Cache (FLPC) was temporarily disabled
for the content of `/developer/api-catalogue` in
commit `597485b0` for testing of impact of FLPC
on garbage collection performance.

This change reverts that commit, re-enabling
First Level Page Caching for content of
`/developer/api-catalogue` (with the exclusion
of API catalogue page itself - as it was
previously).