### PR TITLE
Dw 2887 refactor svg magic

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/base-footer-menu.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/base-footer-menu.ftl
@@ -8,6 +8,8 @@
 <#assign getRemoteSvg="uk.nhs.digital.freemarker.svg.SvgFromUrl"?new() />
 
 <#include "../include/imports.ftl">
+<#include "macro/svgMacro.ftl">
+
 
 <#if menu??>
     <footer class="nhsd-o-global-footer" id="footer">
@@ -31,7 +33,11 @@
                                             <span class="nhsd-a-icon nhsd-a-icon--size-l nhsd-a-icon--col-dark-grey">
                                                 <#if socialMediaLink.icon == "other" >
                                                     <@hst.link hippobean=socialMediaLink.linkIcon var="iconLink" />
-                                                    <img src="${iconLink}">
+                                                    <#if iconLink?contains(".svg")>
+                                                        <@svgWithoutAltText svgString=socialMediaLink.svgXmlFromRepository/>
+                                                    <#else>
+                                                        <img src="${iconLink}">
+                                                    </#if>
                                                 <#else>
                                                     <#assign svg = getRemoteSvg(socialMediaLink.icon) />
                                                     ${svg.data?no_esc}

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/navigationBlockLarge.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/navigationBlockLarge.ftl
@@ -31,8 +31,11 @@
                             <figure class="nhsd-a-image nhsd-a-image--square" aria-hidden="true">
                                 <picture class="nhsd-a-image__picture">
                                     <@hst.link hippobean=item.icon var="image"/>
-                                    <#assign imgDescription = item.icon.description />
-                                    <#assign altText = imgDescription?has_content?then(imgDescription, "image of ${id}") />
+
+                                    <#if item.icon.description?? && item.icon.description?has_content>
+                                        <#assign imgDescription = item.icon.description />
+                                        <#assign altText = imgDescription?has_content?then(imgDescription, "image of ${id}") />
+                                    </#if>
 
                                     <#if image?ends_with("svg")>
                                         <#if altText?? && altText?has_content>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/navigationBlockLarge.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/navigationBlockLarge.ftl
@@ -1,6 +1,7 @@
 <#ftl output_format="HTML">
 <#include "../../include/imports.ftl">
 <#include "./digiBlock.ftl">
+<#include "svgMacro.ftl">
 
 <@hst.setBundle basename="rb.generic.texts"/>
 <@fmt.message key="text.sr-only-link" var="srOnlyLinkText" />
@@ -26,7 +27,7 @@
                 <div class="nhsd-a-icon nhsd-a-icon--size-xxl">
                     <#if hasImage>
                         <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false" viewBox="0 0 16 16">
-                        <path d="M8,16l-6.9-4V4L8,0l6.9,4v8L8,16z M2,11.5L8,15l6-3.5v-7L8,1L2,4.5V11.5z"/>  
+                        <path d="M8,16l-6.9-4V4L8,0l6.9,4v8L8,16z M2,11.5L8,15l6-3.5v-7L8,1L2,4.5V11.5z"/>
                             <figure class="nhsd-a-image nhsd-a-image--square" aria-hidden="true">
                                 <picture class="nhsd-a-image__picture">
                                     <@hst.link hippobean=item.icon var="image"/>
@@ -34,13 +35,11 @@
                                     <#assign altText = imgDescription?has_content?then(imgDescription, "image of ${id}") />
 
                                     <#if image?ends_with("svg")>
-                                        <#assign lightTxt = "FFFFFF" />
-                                        <#assign darkTxt = "231F20" />
-                                        <#assign colour = isDarkMolecule?has_content?then(lightTxt, darkTxt)/>
-
-                                        <#assign imageUrl = '${image?replace("/binaries", "/svg-magic/binaries")}' />
-                                        <#assign imageUrl += "?colour=${colour}" />
-                                        <img src="${imageUrl}" alt="${altText}">
+                                        <#if altText?? && altText?has_content>
+                                            <@svgWithAltText svgString=item.svgXmlFromRepository altText=altText/>
+                                        <#else>
+                                            <@svgWithoutAltText svgString=item.svgXmlFromRepository/>
+                                        </#if>
                                     <#else>
                                         <img src="${image}" alt="${altText}">
                                     </#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/navigationBlockSmall.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/navigationBlockSmall.ftl
@@ -1,6 +1,7 @@
 <#ftl output_format="HTML">
 <#include "../../include/imports.ftl">
 <#include "./iconGenerator.ftl">
+<#include "svgMacro.ftl">
 
 <#macro navigationBlockSmall item id colourVariant isDarkMolecule isYellowLink hasHeading>
     <#assign hasTitle = item.title?has_content />
@@ -37,13 +38,11 @@
                                 <#assign altText = imgDescription?has_content?then(imgDescription, "image of ${id}") />
 
                                 <#if image?ends_with("svg")>
-                                    <#assign lightTxt = "FFFFFF" />
-                                    <#assign darkTxt = "231F20" />
-                                    <#assign colour = isDarkMolecule?has_content?then(lightTxt, darkTxt)/>
-
-                                    <#assign imageUrl = '${image?replace("/binaries", "/svg-magic/binaries")}' />
-                                    <#assign imageUrl += "?colour=${colour}" />
-                                    <img src="${imageUrl}" alt="${altText}">
+                                    <#if altText?? && altText?has_content>
+                                        <@svgWithAltText svgString=item.svgXmlFromRepository altText=altText/>
+                                    <#else>
+                                        <@svgWithoutAltText svgString=item.svgXmlFromRepository/>
+                                    </#if>
                                 <#else>
                                     <img src="${image}" alt="${altText}">
                                 </#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/navigationBlockSmall.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/navigationBlockSmall.ftl
@@ -34,8 +34,10 @@
                         <figure class="nhsd-a-image nhsd-a-image--square" aria-hidden="true">
                             <picture class="nhsd-a-image__picture">
                                 <@hst.link hippobean=item.icon var="image"/>
-                                <#assign imgDescription = item.icon.description />
-                                <#assign altText = imgDescription?has_content?then(imgDescription, "image of ${id}") />
+                                <#if item.icon.description?? && item.icon.description?has_content>
+                                    <#assign imgDescription = item.icon.description />
+                                    <#assign altText = imgDescription?has_content?then(imgDescription, "image of ${id}") />
+                                </#if>
 
                                 <#if image?ends_with("svg")>
                                     <#if altText?? && altText?has_content>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/svgMacro.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/svgMacro.ftl
@@ -1,0 +1,11 @@
+<#ftl output_format="HTML">
+
+<#include "../../include/imports.ftl">
+
+<#macro svgWithoutAltText svgString>
+    <#if svgString?? && svgString?has_content && svgString?contains("svg")>
+        ${svgString?no_esc}
+    <#else>
+        Unsupported image
+    </#if>
+</#macro>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/svgMacro.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/macro/svgMacro.ftl
@@ -2,6 +2,14 @@
 
 <#include "../../include/imports.ftl">
 
+<#macro svgWithAltText svgString altText>
+    <#if svgString?? && svgString?has_content && svgString?contains("svg")>
+        ${svgString?replace("</svg>", "<title>${altText}</title></svg>")?no_esc}
+    <#else>
+        Unsupported image
+    </#if>
+</#macro>
+
 <#macro svgWithoutAltText svgString>
     <#if svgString?? && svgString?has_content && svgString?contains("svg")>
         ${svgString?no_esc}

--- a/repository-data/webfiles/src/main/resources/site/freemarker/intranet/document-list/task-list.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/intranet/document-list/task-list.ftl
@@ -1,6 +1,8 @@
 <#ftl output_format="HTML">
 
 <#include "../../include/imports.ftl">
+<#include "../../common/macro/svgMacro.ftl">
+
 
 <#assign getRemoteSvg="uk.nhs.digital.freemarker.svg.SvgFromUrl"?new() />
 
@@ -33,7 +35,11 @@
                                         <span class="nhsd-a-icon nhsd-a-icon--size-m nhsd-a-icon--col-white">
                                             <#if task.icon == "other" >
                                                 <@hst.link hippobean=task.linkIcon var="iconLink" />
-                                                <img style="width: auto" src="${iconLink}">
+                                                <#if iconLink?contains(".svg")>
+                                                    <@svgWithoutAltText svgString=task.svgXmlFromRepository/>
+                                                <#else>
+                                                    <img style="width: auto" src="${iconLink}">
+                                                </#if>
                                             <#else>
                                                 <#assign svg = getRemoteSvg(task.icon) />
                                                 ${svg.data?replace('<svg ', '<svg style="width: auto" ')?no_esc}

--- a/repository-data/webfiles/src/main/resources/site/freemarker/nhsd-common/macro/navigationBlockLarge.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/nhsd-common/macro/navigationBlockLarge.ftl
@@ -1,6 +1,8 @@
 <#ftl output_format="HTML">
 <#include "../../include/imports.ftl">
 <#include "./digiBlock.ftl">
+<#include "../../common/macro/svgMacro.ftl">
+
 
 <@hst.setBundle basename="rb.generic.texts"/>
 <@fmt.message key="text.sr-only-link" var="srOnlyLinkText" />
@@ -25,23 +27,22 @@
             <div class="nhsd-m-nav-block__content-box">
                 <div class="nhsd-a-icon nhsd-a-icon--size-xxl" aria-hidden="true">
                     <@hst.link hippobean=item.icon var="image"/>
-                    <#assign imgDescription = item.icon.description />
 
                     <#if hasIcon>
-                        <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" focusable="false" viewBox="0 0 16 16">
-                            <path d="M8,16l-6.9-4V4L8,0l6.9,4v8L8,16z M2,11.5L8,15l6-3.5v-7L8,1L2,4.5V11.5z"/>
-                            <#if image?ends_with("svg")>
-                                <#assign lightTxt = "FFFFFF" />
-                                <#assign darkTxt = "231F20" />
-                                <#assign colour = isDarkMolecule?has_content?then(lightTxt, darkTxt)/>
+                        <#if item.icon.description?? && item.icon.description?has_content>
+                            <#assign imgDescription = item.icon.description />
+                            <#assign altText = imgDescription?has_content?then(imgDescription, "image of ${id}") />
+                        </#if>
 
-                                <#assign imageUrl = '${image?replace("/binaries", "/svg-magic/binaries")}' />
-                                <#assign imageUrl += "?colour=${colour}" />
-                                <image x="4" y="4" width="8" height="8" href="${imageUrl}"/>
+                        <#if image?ends_with("svg")>
+                            <#if altText?? && altText?has_content>
+                                <@svgWithAltText svgString=item.svgXmlFromRepository altText=altText/>
                             <#else>
-                                <image x="4" y="4" width="8" height="8" href="${image}"/>
+                                <@svgWithoutAltText svgString=item.svgXmlFromRepository/>
                             </#if>
-                        </svg>
+                        <#else>
+                            <img src="${image}" alt="${altText}">
+                        </#if>
                     <#else>
                         <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" focusable="false" viewBox="0 0 16 16">
                             <path d="M8,16l-6.9-4V4L8,0l6.9,4v8L8,16z M2,11.5L8,15l6-3.5v-7L8,1L2,4.5V11.5z"/>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/nhsd-common/macro/navigationBlockSmall.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/nhsd-common/macro/navigationBlockSmall.ftl
@@ -1,6 +1,7 @@
 <#ftl output_format="HTML">
 <#include "../../include/imports.ftl">
 <#include "./iconGenerator.ftl">
+<#include "../../common/macro/svgMacro.ftl">
 
 <#macro navigationBlockSmall item id colourVariant isDarkMolecule isYellowLink hasHeading>
     <#assign hasTitle = item.title?has_content />
@@ -30,23 +31,22 @@
                 </#if>
                 <div class="nhsd-a-icon nhsd-a-icon--size-xxl nhsd-m-card__icon" aria-hidden="true">
                     <@hst.link hippobean=item.icon var="image"/>
-                    <#assign imgDescription = item.icon.description />
 
                     <#if hasImage>
-                        <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" focusable="false" viewBox="0 0 16 16">
-                            <path d="M8,16l-6.9-4V4L8,0l6.9,4v8L8,16z M2,11.5L8,15l6-3.5v-7L8,1L2,4.5V11.5z"/>
-                            <#if image?ends_with("svg")>
-                                <#assign lightTxt = "FFFFFF" />
-                                <#assign darkTxt = "231F20" />
-                                <#assign colour = isDarkMolecule?has_content?then(lightTxt, darkTxt)/>
+                        <#if item.icon.description?? && item.icon.description?has_content>
+                            <#assign imgDescription = item.icon.description />
+                            <#assign altText = imgDescription?has_content?then(imgDescription, "image of ${id}") />
+                        </#if>
 
-                                <#assign imageUrl = '${image?replace("/binaries", "/svg-magic/binaries")}' />
-                                <#assign imageUrl += "?colour=${colour}" />
-                                <image x="4" y="4" width="8" height="8" href="${imageUrl}"/>
+                        <#if image?ends_with("svg")>
+                            <#if altText?? && altText?has_content>
+                                <@svgWithAltText svgString=item.svgXmlFromRepository altText=altText/>
                             <#else>
-                                <image x="4" y="4" width="8" height="8" href="${image}"/>
+                                <@svgWithoutAltText svgString=item.svgXmlFromRepository/>
                             </#if>
-                        </svg>
+                        <#else>
+                            <img src="${image}" alt="${altText}">
+                        </#if>
                     <#else>
                         <svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" focusable="false" viewBox="0 0 16 16">
                             <path d="M8,16l-6.9-4V4L8,0l6.9,4v8L8,16z M2,11.5L8,15l6-3.5v-7L8,1L2,4.5V11.5z"/>

--- a/site/components/src/main/java/uk/nhs/digital/freemarker/svg/SvgContent.java
+++ b/site/components/src/main/java/uk/nhs/digital/freemarker/svg/SvgContent.java
@@ -1,11 +1,19 @@
 package uk.nhs.digital.freemarker.svg;
 
+import uk.nhs.digital.svg.SvgProvider;
+
 import java.util.Base64;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 
+/**
+ * @deprecated
+ * For future SVG usage, this class should not be used. Please upload svg images on the repository.
+ * <p> Use {@link SvgProvider#getSvgXmlFromBean(org.hippoecm.hst.content.beans.standard.HippoBean)} instead.
+ */
 @XmlAccessorType(XmlAccessType.FIELD)
+@Deprecated
 public class SvgContent {
     private String data;
 

--- a/site/components/src/main/java/uk/nhs/digital/freemarker/svg/SvgFromUrl.java
+++ b/site/components/src/main/java/uk/nhs/digital/freemarker/svg/SvgFromUrl.java
@@ -3,7 +3,14 @@ package uk.nhs.digital.freemarker.svg;
 import static org.hippoecm.hst.site.HstServices.getComponentManager;
 
 import uk.nhs.digital.freemarker.AbstractRemoteContent;
+import uk.nhs.digital.svg.SvgProvider;
 
+/**
+ * @deprecated
+ * For future SVG usage, this class should not be used. Please upload svg images on the repository.
+ * <p> Use {@link SvgProvider#getSvgXmlFromBean(org.hippoecm.hst.content.beans.standard.HippoBean)} instead.
+ */
+@Deprecated
 public class SvgFromUrl extends AbstractRemoteContent {
 
     private static final String RESOURCE_RESOLVER = "svgResourceResolver";

--- a/site/components/src/main/java/uk/nhs/digital/intranet/beans/Task.java
+++ b/site/components/src/main/java/uk/nhs/digital/intranet/beans/Task.java
@@ -1,7 +1,5 @@
 package uk.nhs.digital.intranet.beans;
 
-import static org.apache.commons.collections.IteratorUtils.toList;
-
 import org.hippoecm.hst.container.RequestContextProvider;
 import org.hippoecm.hst.content.beans.Node;
 import org.hippoecm.hst.content.beans.query.HstQuery;
@@ -16,12 +14,15 @@ import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerat
 import uk.nhs.digital.intranet.enums.SearchResultType;
 import uk.nhs.digital.intranet.model.IntranetSearchResult;
 import uk.nhs.digital.ps.beans.HippoBeanHelper;
+import uk.nhs.digital.svg.SvgProvider;
 import uk.nhs.digital.website.beans.BannerControl;
 import uk.nhs.digital.website.beans.PriorityAction;
 import uk.nhs.digital.website.beans.Team;
 
 import java.util.Calendar;
 import java.util.List;
+
+import static org.apache.commons.collections.IteratorUtils.toList;
 
 @Node(jcrType = "intranet:task")
 public class Task extends BaseDocument implements IntranetSearchResult {
@@ -77,7 +78,7 @@ public class Task extends BaseDocument implements IntranetSearchResult {
     }
 
     private <T extends HippoBean> List<T> getRelatedDocuments(String property,
-        Class<T> beanClass) throws HstComponentException, QueryException {
+                                                              Class<T> beanClass) throws HstComponentException, QueryException {
 
         final HstRequestContext context = RequestContextProvider.get();
 
@@ -91,6 +92,11 @@ public class Task extends BaseDocument implements IntranetSearchResult {
     @HippoEssentialsGenerated(internalName = "intranet:linkicon")
     public HippoGalleryImageSet getLinkIcon() {
         return getLinkedBean("intranet:linkicon", HippoGalleryImageSet.class);
+    }
+
+    public String getSvgXmlFromRepository() {
+        HippoBean imageBean = getLinkIcon();
+        return SvgProvider.getSvgXmlFromBean(imageBean);
     }
 
     @HippoEssentialsGenerated(internalName = "intranet:icon")

--- a/site/components/src/main/java/uk/nhs/digital/intranet/beans/Task.java
+++ b/site/components/src/main/java/uk/nhs/digital/intranet/beans/Task.java
@@ -1,5 +1,8 @@
 package uk.nhs.digital.intranet.beans;
 
+import static org.apache.commons.collections.IteratorUtils.toList;
+
+
 import org.hippoecm.hst.container.RequestContextProvider;
 import org.hippoecm.hst.content.beans.Node;
 import org.hippoecm.hst.content.beans.query.HstQuery;
@@ -22,7 +25,6 @@ import uk.nhs.digital.website.beans.Team;
 import java.util.Calendar;
 import java.util.List;
 
-import static org.apache.commons.collections.IteratorUtils.toList;
 
 @Node(jcrType = "intranet:task")
 public class Task extends BaseDocument implements IntranetSearchResult {
@@ -78,7 +80,7 @@ public class Task extends BaseDocument implements IntranetSearchResult {
     }
 
     private <T extends HippoBean> List<T> getRelatedDocuments(String property,
-                                                              Class<T> beanClass) throws HstComponentException, QueryException {
+              Class<T> beanClass) throws HstComponentException, QueryException {
 
         final HstRequestContext context = RequestContextProvider.get();
 

--- a/site/components/src/main/java/uk/nhs/digital/svg/SvgProvider.java
+++ b/site/components/src/main/java/uk/nhs/digital/svg/SvgProvider.java
@@ -7,11 +7,11 @@ import org.onehippo.repository.util.JcrConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.jcr.Node;
-import javax.jcr.RepositoryException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
 
 public class SvgProvider {
 
@@ -31,7 +31,7 @@ public class SvgProvider {
                 LOG.warn("Could not find Binary data from the SVG section of the document.");
                 return null;
             }
-        } catch (RepositoryException | IOException exception){
+        } catch (RepositoryException | IOException exception) {
             LOG.error("Unknown exception occurred while trying to retrieve SVG from repository.", exception);
             return null;
         }

--- a/site/components/src/main/java/uk/nhs/digital/svg/SvgProvider.java
+++ b/site/components/src/main/java/uk/nhs/digital/svg/SvgProvider.java
@@ -1,0 +1,38 @@
+package uk.nhs.digital.svg;
+
+import org.apache.commons.io.IOUtils;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
+import org.hippoecm.hst.servlet.utils.ResourceUtils;
+import org.onehippo.repository.util.JcrConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
+
+public class SvgProvider {
+
+    private static final String IMAGE_TYPE_ORIGINAL = "hippogallery:original";
+    private static final Logger LOG = LoggerFactory.getLogger(SvgProvider.class);
+
+    public static String getSvgXmlFromBean(HippoBean svgBean) throws RepositoryException, IOException {
+
+        HippoBean imageTypeSvgBean = svgBean.getBean(IMAGE_TYPE_ORIGINAL);
+
+        if (hasBinaryData(imageTypeSvgBean.getNode())) {
+            LOG.debug("Fetching binary data from {}.", imageTypeSvgBean.getParentBean().getParentBean().getName());
+            InputStream svgBinaryStream = imageTypeSvgBean.getNode().getProperty(JcrConstants.JCR_DATA).getBinary().getStream();
+            return IOUtils.toString(svgBinaryStream, StandardCharsets.UTF_8.name());
+        } else {
+            LOG.warn("Could not find Binary data from the SVG section of the document.");
+            return null;
+        }
+    }
+
+    private static boolean hasBinaryData(Node svgNode) {
+        return ResourceUtils.hasBinaryProperty(svgNode, JcrConstants.JCR_DATA);
+    }
+}

--- a/site/components/src/main/java/uk/nhs/digital/svg/SvgProvider.java
+++ b/site/components/src/main/java/uk/nhs/digital/svg/SvgProvider.java
@@ -7,27 +7,32 @@ import org.onehippo.repository.util.JcrConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.jcr.Node;
+import javax.jcr.RepositoryException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import javax.jcr.Node;
-import javax.jcr.RepositoryException;
 
 public class SvgProvider {
 
     private static final String IMAGE_TYPE_ORIGINAL = "hippogallery:original";
     private static final Logger LOG = LoggerFactory.getLogger(SvgProvider.class);
 
-    public static String getSvgXmlFromBean(HippoBean svgBean) throws RepositoryException, IOException {
+    public static String getSvgXmlFromBean(HippoBean svgBean) {
 
         HippoBean imageTypeSvgBean = svgBean.getBean(IMAGE_TYPE_ORIGINAL);
-
-        if (hasBinaryData(imageTypeSvgBean.getNode())) {
-            LOG.debug("Fetching binary data from {}.", imageTypeSvgBean.getParentBean().getParentBean().getName());
-            InputStream svgBinaryStream = imageTypeSvgBean.getNode().getProperty(JcrConstants.JCR_DATA).getBinary().getStream();
-            return IOUtils.toString(svgBinaryStream, StandardCharsets.UTF_8.name());
-        } else {
-            LOG.warn("Could not find Binary data from the SVG section of the document.");
+        try {
+            if (hasBinaryData(imageTypeSvgBean.getNode())) {
+                LOG.debug("Fetching binary data from {}.", imageTypeSvgBean.getParentBean().getParentBean().getName());
+                InputStream svgBinaryStream = null;
+                svgBinaryStream = imageTypeSvgBean.getNode().getProperty(JcrConstants.JCR_DATA).getBinary().getStream();
+                return IOUtils.toString(svgBinaryStream, StandardCharsets.UTF_8.name());
+            } else {
+                LOG.warn("Could not find Binary data from the SVG section of the document.");
+                return null;
+            }
+        } catch (RepositoryException | IOException exception){
+            LOG.error("Unknown exception occurred while trying to retrieve SVG from repository.", exception);
             return null;
         }
     }

--- a/site/components/src/main/java/uk/nhs/digital/svg/colour/SvgColourMagic.java
+++ b/site/components/src/main/java/uk/nhs/digital/svg/colour/SvgColourMagic.java
@@ -1,10 +1,18 @@
 package uk.nhs.digital.svg.colour;
 
+import uk.nhs.digital.svg.SvgProvider;
+
 import static java.text.MessageFormat.format;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * @deprecated
+ * For future SVG usage, this class should not be used. Please upload svg images on the repository.
+ * <p> Use {@link SvgProvider#getSvgXmlFromBean(org.hippoecm.hst.content.beans.standard.HippoBean)} instead.
+ */
+@Deprecated
 public class SvgColourMagic {
 
     static final Pattern regex = Pattern.compile("#((?:[0-9a-fA-F]{3}){1,2})", Pattern.UNICODE_CASE);

--- a/site/components/src/main/java/uk/nhs/digital/svg/colour/SvgColourMagic.java
+++ b/site/components/src/main/java/uk/nhs/digital/svg/colour/SvgColourMagic.java
@@ -1,11 +1,13 @@
 package uk.nhs.digital.svg.colour;
 
-import uk.nhs.digital.svg.SvgProvider;
 
 import static java.text.MessageFormat.format;
 
+import uk.nhs.digital.svg.SvgProvider;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 
 /**
  * @deprecated

--- a/site/components/src/main/java/uk/nhs/digital/svg/colour/SvgColourMagicServlet.java
+++ b/site/components/src/main/java/uk/nhs/digital/svg/colour/SvgColourMagicServlet.java
@@ -5,6 +5,7 @@ import static java.text.MessageFormat.format;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.nhs.digital.svg.ProxyDispatcher;
+import uk.nhs.digital.svg.SvgProvider;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -15,6 +16,12 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+/**
+ * @deprecated
+ * For future SVG usage, this class should not be used. Please upload svg images on the repository.
+ * <p> Use {@link SvgProvider#getSvgXmlFromBean(org.hippoecm.hst.content.beans.standard.HippoBean)} instead.
+ */
+@Deprecated
 public class SvgColourMagicServlet extends ProxyDispatcher {
 
     private static final Logger log = LoggerFactory.getLogger(SvgColourMagicServlet.class);

--- a/site/components/src/main/java/uk/nhs/digital/website/beans/Calltoaction.java
+++ b/site/components/src/main/java/uk/nhs/digital/website/beans/Calltoaction.java
@@ -5,9 +5,6 @@ import org.hippoecm.hst.content.beans.standard.*;
 import org.onehippo.cms7.essentials.dashboard.annotations.*;
 import uk.nhs.digital.svg.SvgProvider;
 
-import javax.jcr.RepositoryException;
-import java.io.IOException;
-
 @HippoEssentialsGenerated(internalName = "website:calltoaction")
 @Node(jcrType = "website:calltoaction")
 public class Calltoaction extends BaseDocument {

--- a/site/components/src/main/java/uk/nhs/digital/website/beans/Calltoaction.java
+++ b/site/components/src/main/java/uk/nhs/digital/website/beans/Calltoaction.java
@@ -3,6 +3,10 @@ package uk.nhs.digital.website.beans;
 import org.hippoecm.hst.content.beans.*;
 import org.hippoecm.hst.content.beans.standard.*;
 import org.onehippo.cms7.essentials.dashboard.annotations.*;
+import uk.nhs.digital.svg.SvgProvider;
+
+import javax.jcr.RepositoryException;
+import java.io.IOException;
 
 @HippoEssentialsGenerated(internalName = "website:calltoaction")
 @Node(jcrType = "website:calltoaction")
@@ -55,5 +59,10 @@ public class Calltoaction extends BaseDocument {
     @HippoEssentialsGenerated(internalName = "website:icon")
     public CorporateWebsiteImageset getIcon() {
         return getLinkedBean("website:icon", CorporateWebsiteImageset.class);
+    }
+
+    public String getSvgXmlFromRepository() {
+        HippoBean imageBean = getIcon();
+        return SvgProvider.getSvgXmlFromBean(imageBean);
     }
 }

--- a/site/components/src/main/java/uk/nhs/digital/website/beans/SocialMediaLink.java
+++ b/site/components/src/main/java/uk/nhs/digital/website/beans/SocialMediaLink.java
@@ -1,8 +1,13 @@
 package uk.nhs.digital.website.beans;
 
 import org.hippoecm.hst.content.beans.Node;
+import org.hippoecm.hst.content.beans.standard.HippoBean;
 import org.hippoecm.hst.content.beans.standard.HippoGalleryImageSet;
 import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
+import uk.nhs.digital.svg.SvgProvider;
+
+import javax.jcr.RepositoryException;
+import java.io.IOException;
 
 @Node(jcrType = "website:socialmedialink")
 public class SocialMediaLink extends CommonFieldsBean {
@@ -24,6 +29,11 @@ public class SocialMediaLink extends CommonFieldsBean {
     @HippoEssentialsGenerated(internalName = "website:linkicon")
     public HippoGalleryImageSet getLinkIcon() {
         return getLinkedBean("website:linkicon", HippoGalleryImageSet.class);
+    }
+
+    public String getSvgXmlFromRepository() throws RepositoryException, IOException {
+        HippoBean imageBean = getLinkIcon();
+        return SvgProvider.getSvgXmlFromBean(imageBean);
     }
 
     @HippoEssentialsGenerated(internalName = "website:notes")

--- a/site/components/src/main/java/uk/nhs/digital/website/beans/SocialMediaLink.java
+++ b/site/components/src/main/java/uk/nhs/digital/website/beans/SocialMediaLink.java
@@ -6,9 +6,6 @@ import org.hippoecm.hst.content.beans.standard.HippoGalleryImageSet;
 import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
 import uk.nhs.digital.svg.SvgProvider;
 
-import javax.jcr.RepositoryException;
-import java.io.IOException;
-
 @Node(jcrType = "website:socialmedialink")
 public class SocialMediaLink extends CommonFieldsBean {
     @HippoEssentialsGenerated(internalName = "website:linkname")
@@ -31,7 +28,7 @@ public class SocialMediaLink extends CommonFieldsBean {
         return getLinkedBean("website:linkicon", HippoGalleryImageSet.class);
     }
 
-    public String getSvgXmlFromRepository() throws RepositoryException, IOException {
+    public String getSvgXmlFromRepository() {
         HippoBean imageBean = getLinkIcon();
         return SvgProvider.getSvgXmlFromBean(imageBean);
     }

--- a/site/components/src/main/java/uk/nhs/digital/website/beans/SvgSection.java
+++ b/site/components/src/main/java/uk/nhs/digital/website/beans/SvgSection.java
@@ -1,27 +1,18 @@
 package uk.nhs.digital.website.beans;
 
-import org.apache.commons.io.IOUtils;
 import org.hippoecm.hst.content.beans.Node;
 import org.hippoecm.hst.content.beans.standard.HippoBean;
 import org.hippoecm.hst.content.beans.standard.HippoCompound;
-import org.hippoecm.hst.servlet.utils.ResourceUtils;
 import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
-import org.onehippo.repository.util.JcrConstants;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import uk.nhs.digital.svg.SvgProvider;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import javax.jcr.RepositoryException;
 
 
 @HippoEssentialsGenerated(internalName = "website:svg")
 @Node(jcrType = "website:svg")
 public class SvgSection extends HippoCompound {
-
-    private static final String IMAGE_TYPE_ORIGINAL = "hippogallery:original";
-    private static final Logger LOG = LoggerFactory.getLogger(SvgSection.class);
 
     public String getSectionType() {
         return "svg";
@@ -38,18 +29,8 @@ public class SvgSection extends HippoCompound {
     }
 
     public String getSvgXmlFromRepository() throws RepositoryException, IOException {
-        HippoBean imageBean = getLinkedBean("website:link", CorporateWebsiteImageset.class);
-        HippoBean imageTypeBean = imageBean.getBean(IMAGE_TYPE_ORIGINAL);
-        boolean hasBinaryData = ResourceUtils.hasBinaryProperty(imageTypeBean.getNode(),JcrConstants.JCR_DATA);
-
-        if (hasBinaryData) {
-            LOG.debug("Fetching binary data from {}.", this.getParentBean().getParentBean().getName());
-            InputStream svgBinaryStream = imageTypeBean.getNode().getProperty(JcrConstants.JCR_DATA).getBinary().getStream();
-            return IOUtils.toString(svgBinaryStream, StandardCharsets.UTF_8.name());
-        } else {
-            LOG.warn("Could not find Binary data from the SVG section of the document.");
-            return null;
-        }
+        HippoBean imageBean = getLink();
+        return SvgProvider.getSvgXmlFromBean(imageBean);
     }
 
 }

--- a/site/components/src/main/java/uk/nhs/digital/website/beans/SvgSection.java
+++ b/site/components/src/main/java/uk/nhs/digital/website/beans/SvgSection.java
@@ -6,9 +6,6 @@ import org.hippoecm.hst.content.beans.standard.HippoCompound;
 import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
 import uk.nhs.digital.svg.SvgProvider;
 
-import java.io.IOException;
-import javax.jcr.RepositoryException;
-
 
 @HippoEssentialsGenerated(internalName = "website:svg")
 @Node(jcrType = "website:svg")
@@ -28,7 +25,7 @@ public class SvgSection extends HippoCompound {
         return getLinkedBean("website:link", CorporateWebsiteImageset.class);
     }
 
-    public String getSvgXmlFromRepository() throws RepositoryException, IOException {
+    public String getSvgXmlFromRepository() {
         HippoBean imageBean = getLink();
         return SvgProvider.getSvgXmlFromBean(imageBean);
     }


### PR DESCRIPTION
SVG:
    - Social Media & Task List
        - Use “other” and upload own svg to use method 3.
    - NavigationBlock
        - Colors were hardcoded with svg magic. Frontend must add css
        - There are duplicate ftls? In folders Common and Nhsd-common. Problem is fixed in both.
    - Check if all places have the new method in place
    - Slowly phase out the old method