### PR TITLE
Adz 2397 splunk logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,11 +313,6 @@
             <artifactId>okhttp</artifactId>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>com.squareup.okio</groupId>
-            <artifactId>okio</artifactId>
-            <scope>provided</scope>
-        </dependency>
 
     </dependencies>
 
@@ -460,14 +455,14 @@
                 <version>${gson.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp</artifactId>
-                <version>${okhttp.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>com.squareup.okio</groupId>
                 <artifactId>okio</artifactId>
                 <version>${okio.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>okhttp</artifactId>
+                <version>${okhttp.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.awaitility</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -211,8 +211,8 @@
         <maven-surefire.version>3.0.0-M6</maven-surefire.version>
         <mokito.version>3.12.4</mokito.version>
         <objenesis.version>3.2</objenesis.version>
-        <okhttp.version>4.9.3</okhttp.version>
         <okio.version>2.7.0</okio.version>
+        <okhttp.version>4.9.3</okhttp.version>
         <plexus-component.version>2.1.0</plexus-component.version>
         <plexus-utils.version>3.4.1</plexus-utils.version>
         <powermock.version>2.0.9</powermock.version>
@@ -232,7 +232,7 @@
         <xalan.version>2.7.2</xalan.version>
         <xml-apis.version>2.0.2</xml-apis.version>
 
-        <kotlin.version>1.4.10</kotlin.version>
+        <kotlin.version>1.6.20</kotlin.version>
     </properties>
 
     <repositories>
@@ -301,6 +301,11 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okio</groupId>
+            <artifactId>okio</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -1222,13 +1227,13 @@
                                         <classpath>shared</classpath>
                                     </dependency>
                                     <dependency>
-                                        <groupId>com.squareup.okhttp3</groupId>
-                                        <artifactId>okhttp</artifactId>
+                                        <groupId>com.squareup.okio</groupId>
+                                        <artifactId>okio</artifactId>
                                         <classpath>shared</classpath>
                                     </dependency>
                                     <dependency>
-                                        <groupId>com.squareup.okio</groupId>
-                                        <artifactId>okio</artifactId>
+                                        <groupId>com.squareup.okhttp3</groupId>
+                                        <artifactId>okhttp</artifactId>
                                         <classpath>shared</classpath>
                                     </dependency>
                                 </dependencies>
@@ -1332,13 +1337,13 @@
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
+                    <groupId>com.squareup.okio</groupId>
+                    <artifactId>okio</artifactId>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
-                    <groupId>com.squareup.okio</groupId>
-                    <artifactId>okio</artifactId>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
                     <scope>provided</scope>
                 </dependency>
             </dependencies>
@@ -1400,13 +1405,13 @@
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
+                    <groupId>com.squareup.okio</groupId>
+                    <artifactId>okio</artifactId>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
-                    <groupId>com.squareup.okio</groupId>
-                    <artifactId>okio</artifactId>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
@@ -1485,13 +1490,13 @@
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
-                    <groupId>com.squareup.okhttp3</groupId>
-                    <artifactId>okhttp</artifactId>
+                    <groupId>com.squareup.okio</groupId>
+                    <artifactId>okio</artifactId>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
-                    <groupId>com.squareup.okio</groupId>
-                    <artifactId>okio</artifactId>
+                    <groupId>com.squareup.okhttp3</groupId>
+                    <artifactId>okhttp</artifactId>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
         <mokito.version>3.12.4</mokito.version>
         <objenesis.version>3.2</objenesis.version>
         <okhttp.version>4.9.3</okhttp.version>
-        <okio.version>3.1.0</okio.version>
+        <okio.version>2.7.0</okio.version>
         <plexus-component.version>2.1.0</plexus-component.version>
         <plexus-utils.version>3.4.1</plexus-utils.version>
         <powermock.version>2.0.9</powermock.version>
@@ -231,6 +231,8 @@
         <woodstox.version>4.2.1</woodstox.version>
         <xalan.version>2.7.2</xalan.version>
         <xml-apis.version>2.0.2</xml-apis.version>
+
+        <kotlin.version>1.4.10</kotlin.version>
     </properties>
 
     <repositories>
@@ -273,6 +275,12 @@
     </repositories>
 
     <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>com.onehippo.cms7</groupId>
             <artifactId>hippo-addon-targeting-shared-api</artifactId>
@@ -1035,6 +1043,13 @@
             </properties>
             <dependencies>
                 <dependency>
+                    <groupId>org.jetbrains.kotlin</groupId>
+                    <artifactId>kotlin-stdlib</artifactId>
+                    <scope>provided</scope>
+                    <version>${kotlin.version}</version>
+                </dependency>
+
+                <dependency>
                     <groupId>org.onehippo.cms7</groupId>
                     <artifactId>hippo-addon-crisp-api</artifactId>
                     <scope>provided</scope>
@@ -1176,6 +1191,11 @@
 
                                 </systemProperties>
                                 <dependencies>
+                                    <dependency>
+                                        <groupId>org.jetbrains.kotlin</groupId>
+                                        <artifactId>kotlin-stdlib</artifactId>
+                                        <classpath>shared</classpath>
+                                    </dependency>
                                     <dependency>
                                         <groupId>org.onehippo.cms7</groupId>
                                         <artifactId>hippo-addon-crisp-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,7 @@
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
             <version>${kotlin.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
         <xalan.version>2.7.2</xalan.version>
         <xml-apis.version>2.0.2</xml-apis.version>
 
-        <kotlin.version>1.6.20</kotlin.version>
+        <kotlin.version>1.4.10</kotlin.version>
     </properties>
 
     <repositories>

--- a/src/main/assembly/shared-lib-component.xml
+++ b/src/main/assembly/shared-lib-component.xml
@@ -23,6 +23,7 @@
                 <include>com.onehippo.cms7:hippo-addon-targeting-shared-api</include>
                 <include>com.onehippo.cms7:hippo-addon-content-feed-search-api</include>
 
+                <include>org.jetbrains.kotlin:kotlin-stdlib</include>
                 <include>com.splunk.logging:splunk-library-javalogging</include>
                 <include>com.google.code.gson:gson</include>
                 <include>com.squareup.okhttp3:okhttp</include>

--- a/src/main/assembly/shared-lib-component.xml
+++ b/src/main/assembly/shared-lib-component.xml
@@ -26,8 +26,8 @@
                 <include>org.jetbrains.kotlin:kotlin-stdlib</include>
                 <include>com.splunk.logging:splunk-library-javalogging</include>
                 <include>com.google.code.gson:gson</include>
-                <include>com.squareup.okhttp3:okhttp</include>
                 <include>com.squareup.okio:okio</include>
+                <include>com.squareup.okhttp3:okhttp</include>
             </includes>
         </dependencySet>
     </dependencySets>


### PR DESCRIPTION
https://nhsd-jira.digital.nhs.uk/browse/ADZ-2397

https://github.com/NHS-digital-website/hippo/pull/2179/files#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8
seems to have upgraded the versions of okhttp and okio to the latest, but they are incompatible with each other. okio doesn't have any security advisories so the current version should be fine for dependabot.

The Kotlin standard library is required for the new version of okhttp.

I'm not really sure why we have to handle transitive dependencies manually as I'm not too familiar with Maven and Tomcat. We don't seem to use okhttp or okio directly but we have direct dependencies on them. If I remove them to let Maven handle it they just don't get pulled in.