### PR TITLE
[ADZ-2495] Update OAS CTA wording so no longer truncated

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/apispecification.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/apispecification.ftl
@@ -61,7 +61,7 @@
         "summary": (htmlSummary + oasHintText)?no_esc,
         "buttons": [{
             "src": oasLink,
-            "text": "Get this specification in OAS format",
+            "text": "Get OAS file",
             "target": "_blank"
         }]
     }/>


### PR DESCRIPTION
[ADZ-2495](https://nhsd-jira.digital.nhs.uk/browse/ADZ-2495)
<img width="684" alt="image" src="https://user-images.githubusercontent.com/91538797/194320154-31f0965b-aa5d-4d22-84d0-df1d1baef0db.png">
