### PR TITLE
[ADZ-2475] API catalogue A-Z nav is always responsive

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/apicatalogue/api-catalogue.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/apicatalogue/api-catalogue.ftl
@@ -7,6 +7,7 @@
 <#include "../macro/svgIcons.ftl">
 <#include "../../nhsd-common/macro/heroes/hero-options.ftl">
 <#include "../../nhsd-common/macro/heroes/hero.ftl">
+<#include "../../nhsd-common/macros/az-nav.ftl">
 
 <#-- @ftlvariable name="document" type="uk.nhs.digital.website.beans.ComponentList" -->
 <#-- @ftlvariable name="filtersModel" type="uk.nhs.digital.common.components.apicatalogue.filters.Filters" -->
@@ -33,13 +34,18 @@
 
     <#if alphabetical_hash??>
         <div class="nhsd-t-row">
+            <div class="nhsd-t-col-12 nhsd-!t-margin-bottom-5">
+                <h2 id="side-az-nav-heading" class="nhsd-t-heading-xs">Search A-Z</h2>
+                <@azList alphabetical_hash "side-az-nav-heading"/>
+            </div>
+
             <div class="nhsd-t-col-3 nhsd-!t-display-hide nhsd-!t-display-l-show">
-                <@scrollableFilterNav alphabetical_hash filtersModel false></@scrollableFilterNav>
+                <@scrollableFilterNav filtersModel false></@scrollableFilterNav>
             </div>
 
             <div class="nhsd-t-col-l-9 nhsd-t-col-m-12">
                 <div class="nhsd-!t-display-l-hide">
-                    <@scrollableFilterNav alphabetical_hash filtersModel true></@scrollableFilterNav>
+                    <@scrollableFilterNav filtersModel true></@scrollableFilterNav>
                 </div>
                 <div class="nhsd-t-row">
                     <div class="nhsd-t-col-3">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/apicatalogue/scrollable-filter-nav.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/apicatalogue/scrollable-filter-nav.ftl
@@ -1,21 +1,10 @@
 <#ftl output_format="HTML">
 <#include "../../include/imports.ftl">
-<#include "../../nhsd-common/macros/az-nav.ftl">
 
-<#assign lettersOfTheAlphabet = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]/>
 <#assign markdownDescription = "uk.nhs.digital.common.components.apicatalogue.FilterDescriptionDirective"?new() />
 
-<#macro scrollableFilterNav blockGroups filtersModel responsive>
+<#macro scrollableFilterNav filtersModel responsive>
     <#-- @ftlvariable name="filtersModel" type="uk.nhs.digital.common.components.apicatalogue.filters.Filters" -->
-    <div class="nhsd-a-box nhsd-a-box--border-grey nhsd-!t-margin-right-3 nhsd-!t-margin-bottom-5">
-    <#if responsive>
-        <h2 id="side-az-nav-heading-responsive" class="nhsd-t-heading-xs">Search A-Z</h2>
-        <@azList blockGroups "side-az-nav-heading-responsive"/>
-    <#else>
-        <h2 id="side-az-nav-heading" class="nhsd-t-heading-xs">Search A-Z</h2>
-        <@azList blockGroups "side-az-nav-heading"/>
-    </#if>
-    </div>
     <#if filtersModel?? && !filtersModel.isEmpty()>
         <div class="nhsd-!t-display-sticky nhsd-!t-display-sticky--offset-2">
         <div class="nhsd-a-box nhsd-a-box--border-grey nhsd-!t-margin-right-3 nhsd-!t-margin-bottom-5 nhsd-api-catalogue__scrollable-component">


### PR DESCRIPTION
[ADZ-2475](https://nhsd-jira.digital.nhs.uk/browse/ADZ-2475) | API Catalogue - Move to A-Z index box making it responsive

Updated the API catalogue A-Z nav so that is behaves like the service spec page [Services (digital.nhs.uk)](https://digital.nhs.uk/services)

<img width="1269" alt="image" src="https://user-images.githubusercontent.com/91538797/196721531-e4e77d0b-23f0-4600-89ed-748a5e9d0f7c.png">

<img width="330" alt="image" src="https://user-images.githubusercontent.com/91538797/196721660-27eb27b7-1efb-43e0-88ad-e74eb6eea77c.png">
