### PR TITLE
[ADZ-2685] Revert rendering config

### DIFF
--- a/site/components/src/main/java/uk/nhs/digital/common/components/apispecification/swagger/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverter.java
+++ b/site/components/src/main/java/uk/nhs/digital/common/components/apispecification/swagger/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverter.java
@@ -56,7 +56,9 @@ public class SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverter implements Op
 
         final ParseOptions parseOptions = new ParseOptions();
         parseOptions.setResolve(true);
-        parseOptions.setResolveFully(true);
+
+        // Do not enable this until circular refs no longer cause infinite recursion.
+        //parseOptions.setResolveFully(true);
 
         final SwaggerParseResult swaggerParseResult = new OpenAPIV3Parser()
             .readContents(openApiSpecificationJson, null, parseOptions);

--- a/site/components/src/test/java/uk/nhs/digital/common/components/apispecification/swagger/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest.java
+++ b/site/components/src/test/java/uk/nhs/digital/common/components/apispecification/swagger/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest.java
@@ -624,7 +624,7 @@ public class SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest {
     }
 
     @Test
-    @Ignore("Crashes on circular references")
+    @Ignore("Tests for setResolveFully which is currently disabled as it causes crashes on circular schema references")
     public void rendersUnresolvedRefElements() {
         // given
         final String specificationJson = from("oasV3_withRefElements.json");

--- a/site/components/src/test/java/uk/nhs/digital/common/components/apispecification/swagger/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest.java
+++ b/site/components/src/test/java/uk/nhs/digital/common/components/apispecification/swagger/SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest.java
@@ -13,6 +13,7 @@ import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import org.hamcrest.Matcher;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.nhs.digital.test.util.TestDataCache;
@@ -623,6 +624,7 @@ public class SwaggerCodeGenOpenApiSpecificationJsonToHtmlConverterTest {
     }
 
     @Test
+    @Ignore("Crashes on circular references")
     public void rendersUnresolvedRefElements() {
         // given
         final String specificationJson = from("oasV3_withRefElements.json");


### PR DESCRIPTION
Config can cause circular schema refs to infinitely recurse.