### PR TITLE
[DW-000] Change freemarker servlet to error only

### DIFF
--- a/conf/log4j2-dist.xml
+++ b/conf/log4j2-dist.xml
@@ -77,6 +77,7 @@
                 level="info"/>
 
         <Logger name="freemarker" level="error"/>
+        <Logger name="org.hippoecm.hst.servlet.HstFreemarkerServlet" level="error"/>
         <Logger name="org.apache.cxf" level="error"/>
         <Logger name="javax.ws.rs.core" level="error"/>
         <Logger name="org.apache.commons.pool" level="error"/>


### PR DESCRIPTION
@GeoffreyHayward  it did not quite stop the org.hippoecm.hst.servlet.HstFreemarkerServlet warnings, I think this might be because it is a servlet rather than freemarker. I have added an extra error line for this.

If you could do the honors... and I will check again on UAT.

Thanks.