### PR TITLE
[AMP-1598] set enableRapiDoc flag to default to true

### DIFF
--- a/repository-data/application/src/main/resources/hcm-config/namespaces/website/apispecification.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/website/apispecification.yaml
@@ -200,7 +200,7 @@ definitions:
           - mix:referenceable
           - hippotaxonomy:classifiable
           jcr:primaryType: website:apispecification
-          website:enable_rapidoc: false
+          website:enable_rapidoc: true
           website:json: ''
           website:seosummary: ''
           website:shortsummary: ''

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/apispecification.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/apispecification.ftl
@@ -5,7 +5,7 @@
 <#include "../nhsd-common/macro/heroes/hero-options.ftl">
 <#include "../nhsd-common/macro/component/lastModified.ftl">
 
-<#if document?? && (document.enableRapiDoc!false || isDevEnv!false)>
+<#if document?? && (document.enableRapiDoc!isDevEnv!false)>
     <#include "../common/macro/metaTags.ftl">
     <@metaTags></@metaTags>
 


### PR DESCRIPTION
Done following the 19/05 RapiDoc migration deadline to try to prevent new specs from using the old renderer