### PR TITLE
Amp 1816 change location of services list for catalogue

### DIFF
--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
@@ -542,7 +542,7 @@ definitions:
               - website:service
               hst:componentconfigurationmappingvalues:
               - hst:pages/service
-              hst:relativecontentpath: ${parent}/content
+              hst:relativecontentpath: ${parent}/service-catalogue
               jcr:primaryType: hst:sitemapitem
             hst:cacheable: true
             hst:componentconfigurationid: hst:pages/404
@@ -554,10 +554,10 @@ definitions:
             jcr:primaryType: hst:sitemapitem
           /_index_:
             hst:componentconfigurationid: hst:pages/service-catalogue
-            hst:relativecontentpath: ${parent}/content
+            hst:relativecontentpath: ${parent}/service-catalogue
             jcr:primaryType: hst:sitemapitem
           hst:cacheable: false
-          hst:relativecontentpath: service-catalogue
+          hst:relativecontentpath: services
           jcr:primaryType: hst:sitemapitem
         hst:componentconfigurationid: hst:pages/nhsd-services-hub
         hst:relativecontentpath: nhsd-services-hub

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/catalogue/catalogue.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/catalogue/catalogue.ftl
@@ -117,6 +117,8 @@
                             </label>
                         </div>
                     </div>
+                <#else>
+                    <div class="nhsd-!t-padding-top-4"/>
                 </#if>
 
                 <@apiCatalogueEntries alphabetical_hash filtersModel></@apiCatalogueEntries>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/catalogue/scrollable-filter-nav.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/catalogue/scrollable-filter-nav.ftl
@@ -9,11 +9,11 @@
         <div class="nhsd-!t-display-sticky nhsd-!t-display-sticky--offset-2">
         <div class="nhsd-a-box nhsd-a-box--border-grey nhsd-!t-margin-right-3 nhsd-!t-margin-bottom-5 nhsd-api-catalogue__scrollable-component">
         <div style="padding-bottom: 2.5rem">
-                <div class="nhsd-t-row">
+                <div style="justify-content: space-between" class="nhsd-t-row">
                     <h2 class="nhsd-t-heading-xs">
                         <span class="filter-head__title">Filters</span>
                     </h2>
-                    <span class="nhsd-t-body nhsd-!t-padding-left-6 nhsd-!t-margin-right-0">
+                    <span class="nhsd-t-body">
                         <a class="nhsd-a-link nhsd-!t-padding-0" href="<@hst.link/>" title="Reset filters">
                             Reset filters
                         </a>


### PR DESCRIPTION
Change the relative content path for the Service Catalogue links list so that it can be placed in the correct location within the CMS. Currently it resides in 'Service catalogue->content' but should be 'Services->service-catalogue'.

[Ticket](https://nhsd-jira.digital.nhs.uk/browse/AMP-1816)

Also included in this PR are small styling changes for [AMP-1815](https://nhsd-jira.digital.nhs.uk/browse/AMP-1815) to adjust the position of the 'Reset Filters' anchor on the Catalogue template and also add some vertical padding for when the 'include retired APIs' switch is not present.