### PR TITLE
[AMP-1816] Correct content path for services

### DIFF
--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
@@ -542,7 +542,7 @@ definitions:
               - website:service
               hst:componentconfigurationmappingvalues:
               - hst:pages/service
-              hst:relativecontentpath: ${parent}/service-catalogue
+              hst:relativecontentpath: ${parent}/content
               jcr:primaryType: hst:sitemapitem
             hst:cacheable: true
             hst:componentconfigurationid: hst:pages/404


### PR DESCRIPTION
I had set the relative content path for services as well as just Service catalogue in my previous PR AMP-1816.