### PR TITLE
[AMP-1816] Revert changes to content paths

### DIFF
--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
@@ -554,10 +554,10 @@ definitions:
             jcr:primaryType: hst:sitemapitem
           /_index_:
             hst:componentconfigurationid: hst:pages/service-catalogue
-            hst:relativecontentpath: ${parent}/service-catalogue
+            hst:relativecontentpath: ${parent}/content
             jcr:primaryType: hst:sitemapitem
           hst:cacheable: false
-          hst:relativecontentpath: services
+          hst:relativecontentpath: services-catalogue
           jcr:primaryType: hst:sitemapitem
         hst:componentconfigurationid: hst:pages/nhsd-services-hub
         hst:relativecontentpath: nhsd-services-hub


### PR DESCRIPTION
Follow up to https://github.com/NHS-digital-website/hippo/pull/2534 since it did not sort the problem. Have just totally reverted the content path changes I made for now.