### PR TITLE
[AMP-1816] reimplement move service catalogue

### DIFF
--- a/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
+++ b/repository-data/site/src/main/resources/hcm-config/hst/configurations/common/sitemap.yaml
@@ -557,7 +557,7 @@ definitions:
             hst:relativecontentpath: ${parent}/content
             jcr:primaryType: hst:sitemapitem
           hst:cacheable: false
-          hst:relativecontentpath: services-catalogue
+          hst:relativecontentpath: services/service-catalogue
           jcr:primaryType: hst:sitemapitem
         hst:componentconfigurationid: hst:pages/nhsd-services-hub
         hst:relativecontentpath: nhsd-services-hub


### PR DESCRIPTION
I had already done this with [AMP-1816](https://github.com/NHS-digital-website/hippo/pull/2532) however this cause live issues with links to services becoming broken. Those changes had since been undone.
The reason for this is because my changes to sitemap had caused services content links to be 'services/service-catalogue/content' which is not correct.
This PR simply changes the source of the content for service catalogue to be in its own directory within services.