### PR TITLE
AMP-1861-proxygen-auth-issue

### DIFF
--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -356,7 +356,7 @@
                                     <platform>linux</platform>
                                     <bit>64</bit>
                                     <version>${chromedriver.version}</version>
-                                    <url>https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${chromedriver.version}/linux64/chromedriver_linux64.zip</url>
+                                    <url>https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${chromedriver.version}/linux64/chromedriver-linux64.zip</url>
                                 </driver>
                                 <driver>
                                     <name>chromedriver</name>

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -356,14 +356,14 @@
                                     <platform>linux</platform>
                                     <bit>64</bit>
                                     <version>${chromedriver.version}</version>
-                                    <url>https://chromedriver.storage.googleapis.com/${chromedriver.version}/chromedriver_linux64.zip</url>
+                                    <url>https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${chromedriver.version}/linux64/chromedriver_linux64.zip</url>
                                 </driver>
                                 <driver>
                                     <name>chromedriver</name>
                                     <platform>mac</platform>
                                     <bit>64</bit>
                                     <version>${chromedriver.version}</version>
-                                    <url>https://chromedriver.storage.googleapis.com/${chromedriver.version}/chromedriver_mac64.zip</url>
+                                    <url>https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${chromedriver.version}/mac-x64/chromedriver-mac-x64.zip</url>
                                 </driver>
                             </drivers>
                         </configuration>

--- a/cms/src/main/java/uk/nhs/digital/apispecs/services/auth/ProxygenJwtClientAuthenticationHandler.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/services/auth/ProxygenJwtClientAuthenticationHandler.java
@@ -29,7 +29,7 @@ public class ProxygenJwtClientAuthenticationHandler implements ClientAuthenticat
     private final String privateKey;
     private final String clientId;
     private final String audUrl;
-    private final String kid;
+    private final String kid; //KID
 
     public ProxygenJwtClientAuthenticationHandler(final String privateKey, String clientId, String audUrl, String kid) {
         this.privateKey = privateKey;

--- a/cms/src/main/java/uk/nhs/digital/apispecs/services/auth/ProxygenJwtClientAuthenticationHandler.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/services/auth/ProxygenJwtClientAuthenticationHandler.java
@@ -29,15 +29,18 @@ public class ProxygenJwtClientAuthenticationHandler implements ClientAuthenticat
     private final String privateKey;
     private final String clientId;
     private final String audUrl;
+    private final String kid;
 
-    public ProxygenJwtClientAuthenticationHandler(final String privateKey, String clientId, String audUrl) {
+    public ProxygenJwtClientAuthenticationHandler(final String privateKey, String clientId, String audUrl, String kid) {
         this.privateKey = privateKey;
         this.clientId = clientId;
         this.audUrl = audUrl;
+        this.kid = kid;
 
         ensureRequiredArgProvided("Proxygen Private Key", privateKey);
         ensureRequiredArgProvided("Proxygen Client ID", clientId);
         ensureRequiredArgProvided("Proxygen Audience URL", audUrl);
+        ensureRequiredArgProvided("Proxygen Auth KID", kid);
     }
 
     @Override
@@ -59,6 +62,7 @@ public class ProxygenJwtClientAuthenticationHandler implements ClientAuthenticat
         return Jwts.builder()
             .setSubject(clientId)
             .setIssuer(clientId)
+            .setHeaderParam("kid", kid)
             .setId(String.valueOf(UUID.randomUUID()))
             .setAudience(audUrl)
             .setExpiration(new Date(System.currentTimeMillis() + 300 * 1000))

--- a/cms/src/main/java/uk/nhs/digital/apispecs/services/auth/ProxygenJwtClientAuthenticationHandler.java
+++ b/cms/src/main/java/uk/nhs/digital/apispecs/services/auth/ProxygenJwtClientAuthenticationHandler.java
@@ -29,7 +29,7 @@ public class ProxygenJwtClientAuthenticationHandler implements ClientAuthenticat
     private final String privateKey;
     private final String clientId;
     private final String audUrl;
-    private final String kid; //KID
+    private final String kid;
 
     public ProxygenJwtClientAuthenticationHandler(final String privateKey, String clientId, String audUrl, String kid) {
         this.privateKey = privateKey;

--- a/cms/src/main/resources/META-INF/hst-assembly/addon/crisp/overrides/custom-resource-resolvers.xml
+++ b/cms/src/main/resources/META-INF/hst-assembly/addon/crisp/overrides/custom-resource-resolvers.xml
@@ -71,6 +71,7 @@
                                 <constructor-arg value="#{applicationSecrets.getValueChained('devzone.proxygen.oauth.privateKey')}"/>
                                 <constructor-arg value="#{applicationSecrets.getValue('DEVZONE_PROXYGEN_OAUTH_CLIENT_ID')}"/>
                                 <constructor-arg value="#{applicationSecrets.getValue('devzone.proxygen.oauth.aud.url')}"/>
+                                <constructor-arg value="#{applicationSecrets.getValue('devzone.proxygen.oauth.kid')}"/>
                             </bean>
                         </property>
                     </bean>

--- a/cms/src/test/java/uk/nhs/digital/apispecs/jobs/ApiSpecSyncFromApigeeJobIntegrationTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/jobs/ApiSpecSyncFromApigeeJobIntegrationTest.java
@@ -170,6 +170,7 @@ public class ApiSpecSyncFromApigeeJobIntegrationTest {
         given(System.getenv("proxygenMachineUser.key")).willReturn("privateKey");
         given(System.getenv("DEVZONE_PROXYGEN_OAUTH_CLIENT_ID")).willReturn("clientId");
         given(System.getenv("devzone.proxygen.oauth.aud.url")).willReturn("audUrl");
+        given(System.getenv("devzone.proxygen.oauth.kid")).willReturn("test-1");
     }
 
     private void crispApiConfiguredForOAuth2() {

--- a/cms/src/test/java/uk/nhs/digital/apispecs/jobs/ApiSpecSyncFromProxygenJobIntegrationTest.java
+++ b/cms/src/test/java/uk/nhs/digital/apispecs/jobs/ApiSpecSyncFromProxygenJobIntegrationTest.java
@@ -74,6 +74,7 @@ public class ApiSpecSyncFromProxygenJobIntegrationTest {
     private static final String PARAM_PROXYGEN_OAUTH_AUD_URL = "devzone.proxygen.oauth.aud.url";
     private static final String PARAM_PROXYGEN_OAUTH_CLIENT_ID = "DEVZONE_PROXYGEN_OAUTH_CLIENT_ID";
     private static final String PARAM_PROXYGEN_OAUTH_PRIVATE_KEY = "devzone.proxygen.oauth.privateKey";
+    private static final String PARAM_PROXYGEN_OAUTH_KID = "devzone.proxygen.oauth.kid";
 
     private static final String PROXYGEN_CLIENT_ID = "clientId";
     private static final String PROXYGEN_TEST_PRIVATE_KEY = "-----BEGIN RSA PRIVATE KEY-----\n"
@@ -103,6 +104,8 @@ public class ApiSpecSyncFromProxygenJobIntegrationTest {
         + "e3hJttb3KgXD4Rx/LLvBto6hhBVo+qLdbALZMBPQNKiCgY0hL1+lhKeUyYiZbx76\n"
         + "puFQeyOxa0XT7lrib0qGGS1nHzt62YxTBzHziNwNo6YexTp7ouE0578=\n"
         + "-----END RSA PRIVATE KEY-----\n";
+
+    private static final String PROXYGEN_OAUTH_KID = "test-1";
 
     private static final String PROXYGEN_OAUTH_ACCESS_TOKEN = "accessToken";
     private static final String PROXYGEN_CLIENT_ASSERTION_TYPE = "urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer";
@@ -184,6 +187,7 @@ public class ApiSpecSyncFromProxygenJobIntegrationTest {
         given(System.getProperty(PARAM_PROXYGEN_OAUTH_AUD_URL)).willReturn(oauthAudUrl);
         given(System.getenv(PARAM_PROXYGEN_OAUTH_CLIENT_ID)).willReturn(PROXYGEN_CLIENT_ID);
         given(System.getenv(PARAM_PROXYGEN_OAUTH_PRIVATE_KEY)).willReturn(PROXYGEN_TEST_PRIVATE_KEY);
+        given(System.getenv(PARAM_PROXYGEN_OAUTH_KID)).willReturn(PROXYGEN_OAUTH_KID);
 
         // This config is required to create the apigeeManagementApi bean in custom-resource-resolvers
         given(System.getenv("DEVZONE_APIGEE_OAUTH_BASICAUTHTOKEN")).willReturn("authToken");
@@ -196,7 +200,8 @@ public class ApiSpecSyncFromProxygenJobIntegrationTest {
             .withProperty(PARAM_PROXYGEN_OAUTH_TOKEN_URL, oauthTokenUrl)
             .withProperty(PARAM_PROXYGEN_RESOURCES_SPECS_INDIVIDUAL_URL, proxygenSingleSpecUrlTemplate)
             .withProperty(PARAM_PROXYGEN_OAUTH_CLIENT_ID, PROXYGEN_CLIENT_ID)
-            .withProperty(PARAM_PROXYGEN_OAUTH_PRIVATE_KEY, PROXYGEN_TEST_PRIVATE_KEY);
+            .withProperty(PARAM_PROXYGEN_OAUTH_PRIVATE_KEY, PROXYGEN_TEST_PRIVATE_KEY)
+            .withProperty(PARAM_PROXYGEN_OAUTH_KID, PROXYGEN_OAUTH_KID);
 
         // See https://documentation.bloomreach.com/14/library/concepts/crisp-api/unit-testing.html
 

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
         Consult https://chromedriver.chromium.org/downloads
         to find the right ChromeDriver version to use with the current browser version,
         -->
-        <chromedriver.version>113.0.5672.63</chromedriver.version>
+        <chromedriver.version>115.0.5790.102</chromedriver.version>
 
         <annotation-api.version>1.3.2</annotation-api.version>
         <aspectweaver.version>1.9.9.1</aspectweaver.version>


### PR DESCRIPTION
Getting an access token for use in a call to get proxygen specs is failing. Seems like this is due to a missing KID header.

Have already updated the config properties for UAT and CS environments in testing. Need to update production config in order for this to work upon deployment.