### PR TITLE
[AMP-1878] Catalogue search will include tags

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/apicatalogue/apicatalogue.js
+++ b/repository-data/webfiles/src/main/resources/site/apicatalogue/apicatalogue.js
@@ -12,7 +12,10 @@ function containsMatchingText(result, searchTerm) {
     const regex = new RegExp(`\\b${searchTerm.trim()}`, 'gi');
     const headingContainsTerm = result.querySelector('h2').textContent.match(regex);
     const summaryContainsTerm = result.querySelector('p').textContent.match(regex);
-    return headingContainsTerm || summaryContainsTerm;
+    const tagsContainTerm = Array.from(result.querySelectorAll('.nhsd-a-tag'))
+        .map((item) => item.textContent.match(regex) != null)
+        .includes(true);
+    return headingContainsTerm || summaryContainsTerm || tagsContainTerm;
 }
 
 function isVisible(element) {


### PR DESCRIPTION
For the search in API and Service catalogues tags will now be included as part of the search parameter matching for items in the list.

There don't seem to be any tests around these functions so I can add them perhaps.