### PR TITLE
[AMP-1708] Stop tooltip from blocking filter description

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/SitePage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/SitePage.java
@@ -68,6 +68,10 @@ public class SitePage extends AbstractSitePage {
         return helper.findElement(By.xpath("//*[@title='" + title + "']"));
     }
 
+    public WebElement findElementWithLabel(String label) {
+        return helper.findElement(By.xpath("//*[@aria-label='" + label + "']"));
+    }
+
     public WebElement findOptionalElementWithTitle(String title) {
         return helper.findOptionalElement(By.xpath("//*[@title='" + title + "']"));
     }

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/SiteSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/SiteSteps.java
@@ -17,8 +17,6 @@ import static org.slf4j.LoggerFactory.getLogger;
 import static uk.nhs.digital.ps.test.acceptance.util.FileHelper.waitUntilFileAppears;
 
 import cucumber.api.DataTable;
-import cucumber.api.PendingException;
-import cucumber.api.java.en.And;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;

--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/SiteSteps.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/steps/site/SiteSteps.java
@@ -17,6 +17,8 @@ import static org.slf4j.LoggerFactory.getLogger;
 import static uk.nhs.digital.ps.test.acceptance.util.FileHelper.waitUntilFileAppears;
 
 import cucumber.api.DataTable;
+import cucumber.api.PendingException;
+import cucumber.api.java.en.And;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
@@ -75,6 +77,19 @@ public class SiteSteps extends AbstractSpringSteps {
         WebElement element = sitePage.findElementWithTitle(linkTitle);
 
         assertThat("I can find element with title: " + linkTitle,
+            element, is(notNullValue()));
+
+        sitePage.clickOnElement(element);
+
+        // Note: this is temporary while we have some pages that don't have the new cookie banner (old RPS style)
+        sitePage.clickCookieAcceptButton();
+    }
+
+    @When("^I click on the \"([^\"]*)\" labelled button$")
+    public void whenIClickOnLinkLabelled(String linkLabel) throws Throwable {
+        WebElement element = sitePage.findElementWithLabel(linkLabel);
+
+        assertThat("I can find element with label: " + linkLabel,
             element, is(notNullValue()));
 
         sitePage.clickOnElement(element);

--- a/acceptance-tests/src/test/resources/features/site/apiCatalogue.feature
+++ b/acceptance-tests/src/test/resources/features/site/apiCatalogue.feature
@@ -28,7 +28,7 @@ Feature: API Catalogue in Developer hub
     Scenario: API Catalogue renders filtered results when filters applied
         Given I navigate to "Static API Catalogue" page
         When I click on the label for "toggler_care-setting"
-        And I click on the "Filter by Inpatient" button
+        And I click on the "Filter by Inpatient" labelled button
         Then the index is rendered with entries:
             | text | href  | aria-label                                    |
             | H    | #h    | Jump to articles starting with the letter 'H' |

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/catalogue/scrollable-filter-nav.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/catalogue/scrollable-filter-nav.ftl
@@ -73,7 +73,7 @@
             <label class="filter-label <#if filter.description()??>filter-label__described</#if>">
                 <input onclick="window.location = '<@renderUrl baseUrl=baseUrl retiredFilterEnabled=retiredFilterEnabled showRetired=showRetired filters=filtersParam />'" type="checkbox" <#if filter.selected>checked</#if> <#if !filter.selectable>disabled</#if>>
                 <#if filter.selectable>
-                    <a title="Filter by ${filter.displayName}"
+                    <a aria-label="Filter by ${filter.displayName}"
                        href="<@renderUrl baseUrl=baseUrl retiredFilterEnabled=retiredFilterEnabled showRetired=showRetired filters=filtersParam />"
                        class="nhsd-a-checkbox__label nhsd-!t-margin-bottom-0 nhsd-t-body-s <#if filter.selected>selected</#if> <#if filter.entries?has_content>nhsd-!t-font-weight-bold</#if>">
                         <input type="checkbox">


### PR DESCRIPTION
In the API and Service catalogues there exists and issue in which the auto tooltip to display title text for the anchor elements of the filters is covering the pop-up description text.
Have set aria-label instead of title to preserve accessibility for screen readers.