### PR TITLE
[AMP-1377]-safari-retired-filter-toggle-issue

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/catalogue/catalogue.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/catalogue/catalogue.ftl
@@ -98,6 +98,7 @@
                         <div class="nhsd-t-col-6 nhsd-!t-padding-left-0">
                             <label aria-label="Include retired APIs and API standards"
                                    class="nhsd-m-selector-toggle-card nhsd-!t-padding-left-0">
+                                <input onclick="window.location = '<@renderUrl baseUrl=baseUrl retiredFilterEnabled=retiredFilterEnabled showRetired=!showRetired filters=filtersModel.selectedFiltersKeysMinusCollection(["retired-api","retired","retired-standard"]) />'" type="checkbox" <#if showRetired>checked</#if>>
                                 <div class="nhsd-a-box nhsd-!t-padding-left-0">
                                     <span class="nhsd-m-selector-toggle-card__toggle">
                                         <div class="nhsd-a-selector-toggle">

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/catalogue/catalogue.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/catalogue/catalogue.ftl
@@ -98,12 +98,12 @@
                         <div class="nhsd-t-col-6 nhsd-!t-padding-left-0">
                             <label aria-label="Include retired APIs and API standards"
                                    class="nhsd-m-selector-toggle-card nhsd-!t-padding-left-0">
-                                <input onclick="window.location = '<@renderUrl baseUrl=baseUrl retiredFilterEnabled=retiredFilterEnabled showRetired=!showRetired filters=filtersModel.selectedFiltersKeysMinusCollection(["retired-api","retired","retired-standard"]) />'" type="checkbox" <#if showRetired>checked</#if>>
                                 <div class="nhsd-a-box nhsd-!t-padding-left-0">
                                     <span class="nhsd-m-selector-toggle-card__toggle">
                                         <div class="nhsd-a-selector-toggle">
                                         <@hst.link var="baseUrl"/>
-                                            <a href="<@renderUrl baseUrl=baseUrl retiredFilterEnabled=retiredFilterEnabled showRetired=!showRetired filters=filtersModel.selectedFiltersKeysMinusCollection(["retired-api","retired","retired-standard"]) />"
+                                            <a onclick="window.location = '<@renderUrl baseUrl=baseUrl retiredFilterEnabled=retiredFilterEnabled showRetired=!showRetired filters=filtersModel.selectedFiltersKeysMinusCollection(["retired-api","retired","retired-standard"]) />'"
+                                               href="<@renderUrl baseUrl=baseUrl retiredFilterEnabled=retiredFilterEnabled showRetired=!showRetired filters=filtersModel.selectedFiltersKeysMinusCollection(["retired-api","retired","retired-standard"]) />"
                                                class="nhsd-a-checkbox__label nhsd-t-body-s">
                                                 <input type="checkbox"
                                                        <#if showRetired>checked</#if> />


### PR DESCRIPTION
[Ticket](https://nhsd-jira.digital.nhs.uk/browse/AMP-1377)

Issue identified with Safari browser in which the 'Include retired APIs and API standards' toggle is not updating the page url and refreshing. This is not and issue for other browsers tested.