### PR TITLE
[AMP-2109] Check if published

### DIFF
--- a/site/components/src/main/java/uk/nhs/digital/common/components/catalogue/CatalogueComponent.java
+++ b/site/components/src/main/java/uk/nhs/digital/common/components/catalogue/CatalogueComponent.java
@@ -26,7 +26,8 @@ public class CatalogueComponent extends ContentRewriterComponent {
     }
 
     protected List<CatalogueLink> catalogueLinksFrom(final HstRequest request) {
-        return CatalogueLink.linksFrom(((ComponentList) request.getRequestContext().getContentBean()).getBlocks());
+        return CatalogueLink.linksFrom(((ComponentList) request.getRequestContext().getContentBean()).getBlocks())
+                .stream().filter(CatalogueLink::contentIsPublished).collect(toList());
     }
 
     protected static List<String> userSelectedFilterKeysFrom(final HstRequest request) {

--- a/site/components/src/main/java/uk/nhs/digital/common/components/catalogue/CatalogueLink.java
+++ b/site/components/src/main/java/uk/nhs/digital/common/components/catalogue/CatalogueLink.java
@@ -74,4 +74,11 @@ public class CatalogueLink {
     private boolean isFilterable() {
         return rawLink instanceof Internallink;
     }
+
+    boolean contentIsPublished() {
+        if (isFilterable()) {
+            return ((Internallink) raw()).getIsPublished();
+        }
+        return false;
+    }
 }

--- a/site/components/src/main/java/uk/nhs/digital/common/components/catalogue/CatalogueLink.java
+++ b/site/components/src/main/java/uk/nhs/digital/common/components/catalogue/CatalogueLink.java
@@ -79,6 +79,6 @@ public class CatalogueLink {
         if (isFilterable()) {
             return ((Internallink) raw()).getIsPublished();
         }
-        return false;
+        return true;
     }
 }

--- a/site/components/src/main/java/uk/nhs/digital/website/beans/Internallink.java
+++ b/site/components/src/main/java/uk/nhs/digital/website/beans/Internallink.java
@@ -5,6 +5,8 @@ import org.hippoecm.hst.content.beans.standard.HippoBean;
 import org.hippoecm.hst.content.beans.standard.HippoCompound;
 import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
 
+import javax.jcr.RepositoryException;
+
 @HippoEssentialsGenerated(internalName = "website:internallink")
 @Node(jcrType = "website:internallink")
 public class Internallink extends HippoCompound {
@@ -21,5 +23,18 @@ public class Internallink extends HippoCompound {
 
     public String getTitle() {
         return getLink().getDisplayName();
+    }
+
+    public boolean getIsPublished() {
+        HippoBean link = getLink();
+        javax.jcr.Node linkNode = link.getNode();
+        try {
+            if (linkNode.hasProperty("hippostd:state") && "published".equals(linkNode.getProperty("hippostd:state").getString())) {
+                return true;
+            }
+        } catch (RepositoryException e) {
+            return false;
+        }
+        return false;
     }
 }

--- a/site/components/src/main/java/uk/nhs/digital/website/beans/Internallink.java
+++ b/site/components/src/main/java/uk/nhs/digital/website/beans/Internallink.java
@@ -5,8 +5,6 @@ import org.hippoecm.hst.content.beans.standard.HippoBean;
 import org.hippoecm.hst.content.beans.standard.HippoCompound;
 import org.onehippo.cms7.essentials.dashboard.annotations.HippoEssentialsGenerated;
 
-import javax.jcr.RepositoryException;
-
 @HippoEssentialsGenerated(internalName = "website:internallink")
 @Node(jcrType = "website:internallink")
 public class Internallink extends HippoCompound {
@@ -27,12 +25,12 @@ public class Internallink extends HippoCompound {
 
     public boolean getIsPublished() {
         HippoBean link = getLink();
-        javax.jcr.Node linkNode = link.getNode();
         try {
+            javax.jcr.Node linkNode = link.getNode();
             if (linkNode.hasProperty("hippostd:state") && "published".equals(linkNode.getProperty("hippostd:state").getString())) {
                 return true;
             }
-        } catch (RepositoryException e) {
+        } catch (Exception e) {
             return false;
         }
         return false;

--- a/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/ApiCatalogueComponentTest.java
+++ b/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/ApiCatalogueComponentTest.java
@@ -300,6 +300,7 @@ public class ApiCatalogueComponentTest extends MockitoSessionTestBase {
         given(link.getLinkType()).willReturn("internal");
         given(link.getLink()).willReturn(bean);
         given(link.toString()).willReturn("Internallink of a doc tagged with: " + String.join(", ", taxonomyKeys));
+        given(link.getIsPublished()).willReturn(true);
 
         return link;
     }

--- a/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/ApiCatalogueComponentTest.java
+++ b/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/ApiCatalogueComponentTest.java
@@ -269,7 +269,7 @@ public class ApiCatalogueComponentTest extends MockitoSessionTestBase {
         final List<String> noUserSelectedFilterKeys = emptyList();
 
         given(expectedFiltersFromFactory.initialisedWith(
-                allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys,
+                allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys.stream().map(key -> new NavFilter(key, 0)).collect(Collectors.toSet()),
                 noUserSelectedFilterKeys
         )).willReturn(expectedFiltersFromFactory);
 

--- a/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/ApiCatalogueComponentTest.java
+++ b/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/ApiCatalogueComponentTest.java
@@ -126,7 +126,7 @@ public class ApiCatalogueComponentTest extends MockitoSessionTestBase {
                 allCatalogueLinksToTaggedDocuments.get(3),
                 allCatalogueLinksToTaggedDocuments.get(4),
                 allCatalogueLinksToTaggedDocuments.get(6),
-                allCatalogueLinksToTaggedDocuments.get(7)
+                allCatalogueLinksToTaggedDocuments.get(8)
             ))
         );
 
@@ -160,9 +160,18 @@ public class ApiCatalogueComponentTest extends MockitoSessionTestBase {
         // then
         final List<?> actualResults = (List<?>) request.getAttribute(REQUEST_ATTR_RESULTS);
         assertThat(
-            "Results comprise links of all docs referenced from API catalogue, including of docs tagged as Retired.",
-            actualResults,
-            is(allCatalogueLinksToTaggedDocuments)
+                "Results comprise links of all docs referenced from API catalogue, except of docs tagged as Retired.",
+                actualResults,
+                is(asList(
+                        allCatalogueLinksToTaggedDocuments.get(0),
+                        allCatalogueLinksToTaggedDocuments.get(1),
+                        allCatalogueLinksToTaggedDocuments.get(2),
+                        allCatalogueLinksToTaggedDocuments.get(3),
+                        allCatalogueLinksToTaggedDocuments.get(4),
+                        allCatalogueLinksToTaggedDocuments.get(5),
+                        allCatalogueLinksToTaggedDocuments.get(6),
+                        allCatalogueLinksToTaggedDocuments.get(8)
+                ))
         );
 
         final Filters actualFilters = (Filters) request.getAttribute(REQUEST_ATTR_FILTERS);
@@ -254,7 +263,7 @@ public class ApiCatalogueComponentTest extends MockitoSessionTestBase {
                         allCatalogueLinksToTaggedDocuments.get(3),
                         allCatalogueLinksToTaggedDocuments.get(4),
                         allCatalogueLinksToTaggedDocuments.get(6),
-                        allCatalogueLinksToTaggedDocuments.get(7)
+                        allCatalogueLinksToTaggedDocuments.get(8)
                 ))
         );
 
@@ -271,6 +280,32 @@ public class ApiCatalogueComponentTest extends MockitoSessionTestBase {
         );
     }
 
+    @Test
+    public void unpublishedInternalLinkIsNotIncludedInRendering() {
+
+        // given
+        final Set<String> allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys
+                = ImmutableSet.of("fhir", "hl7-v3", "inpatient", "hospital", "mental-health", "dental-health", "deprecated-api");
+
+        final List<String> noUserSelectedFilterKeys = emptyList();
+
+        given(expectedFiltersFromFactory.initialisedWith(
+                allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys,
+                noUserSelectedFilterKeys
+        )).willReturn(expectedFiltersFromFactory);
+
+        // when
+        apiCatalogueComponent.doBeforeRender(request, irrelevantResponse);
+
+        // then
+        final List<?> actualResults = (List<?>) request.getAttribute(REQUEST_ATTR_RESULTS);
+        assertThat(
+                "Results do not include unpublished internal link",
+                actualResults.size(),
+                is(7)
+        );
+    }
+
     @SuppressWarnings({"unchecked", "rawtypes"})
     private void givenApiCatalogueDocumentWithInternalLinksToCatalogueDocuments() {
 
@@ -283,6 +318,7 @@ public class ApiCatalogueComponentTest extends MockitoSessionTestBase {
             internalLinkToDocTaggedWith("fhir",   "deprecated-api"),                // [4]
             internalLinkToDocTaggedWith("fhir",   "retired-api"),                   // [5]
             internalLinkToDocTaggedWith("hl7-v3", "deprecated-api"),                // [6]
+            internalLinkThatIsUnpublished("fhir", "inpatient"),                     // [6.5] (Unpublished)
             externalLink("https://www.google.com")                                  // [7]
         );
         // @formatter:on
@@ -312,6 +348,12 @@ public class ApiCatalogueComponentTest extends MockitoSessionTestBase {
         given(link.getLink()).willReturn(url);
         given(link.toString()).willReturn("Externallink: " + url);
 
+        return link;
+    }
+
+    private Internallink internalLinkThatIsUnpublished(final String... taxonomyKeys) {
+        Internallink link = internalLinkToDocTaggedWith(taxonomyKeys);
+        given(link.getIsPublished()).willReturn(false);
         return link;
     }
 

--- a/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/ServiceCatalogueComponentTest.java
+++ b/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/ServiceCatalogueComponentTest.java
@@ -238,6 +238,7 @@ public class ServiceCatalogueComponentTest extends MockitoSessionTestBase {
         given(link.getLinkType()).willReturn("internal");
         given(link.getLink()).willReturn(bean);
         given(link.toString()).willReturn("Internallink of a doc tagged with: " + String.join(", ", taxonomyKeys));
+        given(link.getIsPublished()).willReturn(true);
 
         return link;
     }


### PR DESCRIPTION
[Ticket](https://nhsd-jira.digital.nhs.uk/browse/AMP-2109)

Documents that are part of the catalogue link lists when unpublished would cause the catalogue to break. This change will check to see if a document has a visible node and is published before including it in the catalogue.