### PR TITLE
Amp 1880 counts on filters

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/catalogue/scrollable-filter-nav.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/catalogue/scrollable-filter-nav.ftl
@@ -69,33 +69,26 @@
             <#assign filtersParam = filtersModel.selectedFiltersKeysPlus(filter.key) />
         </#if>
         <div class="section-label-container"><#-- This div is needed to add vertical spacing between checkboxes -->
-            <div class="nhsd-t-row">
-                <div class="nhsd-t-col-10">
-                    <span class="nhsd-a-checkbox">
-                        <label class="filter-label <#if filter.description()??>filter-label__described</#if>">
-                            <input onclick="window.location = '<@renderUrl baseUrl=baseUrl retiredFilterEnabled=retiredFilterEnabled showRetired=showRetired filters=filtersParam />'" type="checkbox" <#if filter.selected>checked</#if> <#if !filter.selectable>disabled</#if>>
-                            <#if filter.selectable>
-                                <a aria-label="Filter by ${filter.displayName}"
-                                   href="<@renderUrl baseUrl=baseUrl retiredFilterEnabled=retiredFilterEnabled showRetired=showRetired filters=filtersParam />"
-                                   class="nhsd-a-checkbox__label nhsd-!t-margin-bottom-0 nhsd-t-body-s <#if filter.selected>selected</#if> <#if filter.entries?has_content>nhsd-!t-font-weight-bold</#if>">
-                                    <input type="checkbox">
-                                    <span class="<#if !responsive>filter-label__text</#if>">${filter.displayName}</span>
-                                </a>
-                            <#else>
-                                <a class="nhsd-a-checkbox__label nhsd-!t-margin-bottom-0 nhsd-t-body-s <#if filter.entries?has_content>nhsd-!t-font-weight-bold</#if>">
-                                    <input type="checkbox" disabled>
-                                    <span class="<#if !responsive>filter-label__text</#if>">${filter.displayName}</span>
-                                </a>
-                            </#if>
-                            <div class="checkmark"></div>
-                        </label>
-                        <@filterDescription filter.description() responsive/>
-                    </span>
-                </div>
-                <div class="nhsd-t-col-2">
-                    <span class="nhsd-a-tag nhsd-a-tag--bg-light-grey">${filter.count()}</span>
-                </div>
-            </div>
+            <span class="nhsd-a-checkbox">
+            <label class="filter-label <#if filter.description()??>filter-label__described</#if>">
+                <input onclick="window.location = '<@renderUrl baseUrl=baseUrl retiredFilterEnabled=retiredFilterEnabled showRetired=showRetired filters=filtersParam />'" type="checkbox" <#if filter.selected>checked</#if> <#if !filter.selectable>disabled</#if>>
+                <#if filter.selectable>
+                    <a aria-label="Filter by ${filter.displayName}"
+                       href="<@renderUrl baseUrl=baseUrl retiredFilterEnabled=retiredFilterEnabled showRetired=showRetired filters=filtersParam />"
+                       class="nhsd-a-checkbox__label nhsd-!t-margin-bottom-0 nhsd-t-body-s <#if filter.selected>selected</#if> <#if filter.entries?has_content>nhsd-!t-font-weight-bold</#if>">
+                        <input type="checkbox">
+                        <span class="<#if !responsive>filter-label__text</#if>">${filter.displayName} <#if filter.count() != "0">(${filter.count()})</#if></span>
+                    </a>
+                <#else>
+                    <a class="nhsd-a-checkbox__label nhsd-!t-margin-bottom-0 nhsd-t-body-s <#if filter.entries?has_content>nhsd-!t-font-weight-bold</#if>">
+                        <input type="checkbox" disabled>
+                        <span class="<#if !responsive>filter-label__text</#if>">${filter.displayName} <#if filter.count() != "0">(${filter.count()})</#if></span>
+                    </a>
+                </#if>
+                <div class="checkmark"></div>
+            </label>
+            <@filterDescription filter.description() responsive/>
+        </span>
         </div>
         <#local nextLevel = indentationLevel + 1>
         <#if filter.entries?has_content>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/catalogue/scrollable-filter-nav.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/catalogue/scrollable-filter-nav.ftl
@@ -69,26 +69,33 @@
             <#assign filtersParam = filtersModel.selectedFiltersKeysPlus(filter.key) />
         </#if>
         <div class="section-label-container"><#-- This div is needed to add vertical spacing between checkboxes -->
-        <span class="nhsd-a-checkbox">
-            <label class="filter-label <#if filter.description()??>filter-label__described</#if>">
-                <input onclick="window.location = '<@renderUrl baseUrl=baseUrl retiredFilterEnabled=retiredFilterEnabled showRetired=showRetired filters=filtersParam />'" type="checkbox" <#if filter.selected>checked</#if> <#if !filter.selectable>disabled</#if>>
-                <#if filter.selectable>
-                    <a aria-label="Filter by ${filter.displayName}"
-                       href="<@renderUrl baseUrl=baseUrl retiredFilterEnabled=retiredFilterEnabled showRetired=showRetired filters=filtersParam />"
-                       class="nhsd-a-checkbox__label nhsd-!t-margin-bottom-0 nhsd-t-body-s <#if filter.selected>selected</#if> <#if filter.entries?has_content>nhsd-!t-font-weight-bold</#if>">
-                        <input type="checkbox">
-                        <span class="<#if !responsive>filter-label__text</#if>">${filter.displayName}</span>
-                    </a>
-                <#else>
-                    <a class="nhsd-a-checkbox__label nhsd-!t-margin-bottom-0 nhsd-t-body-s <#if filter.entries?has_content>nhsd-!t-font-weight-bold</#if>">
-                        <input type="checkbox" disabled>
-                        <span class="<#if !responsive>filter-label__text</#if>">${filter.displayName}</span>
-                    </a>
-                </#if>
-                <div class="checkmark"></div>
-            </label>
-            <@filterDescription filter.description() responsive/>
-        </span>
+            <div class="nhsd-t-row">
+                <div class="nhsd-t-col-10">
+                    <span class="nhsd-a-checkbox">
+                        <label class="filter-label <#if filter.description()??>filter-label__described</#if>">
+                            <input onclick="window.location = '<@renderUrl baseUrl=baseUrl retiredFilterEnabled=retiredFilterEnabled showRetired=showRetired filters=filtersParam />'" type="checkbox" <#if filter.selected>checked</#if> <#if !filter.selectable>disabled</#if>>
+                            <#if filter.selectable>
+                                <a aria-label="Filter by ${filter.displayName}"
+                                   href="<@renderUrl baseUrl=baseUrl retiredFilterEnabled=retiredFilterEnabled showRetired=showRetired filters=filtersParam />"
+                                   class="nhsd-a-checkbox__label nhsd-!t-margin-bottom-0 nhsd-t-body-s <#if filter.selected>selected</#if> <#if filter.entries?has_content>nhsd-!t-font-weight-bold</#if>">
+                                    <input type="checkbox">
+                                    <span class="<#if !responsive>filter-label__text</#if>">${filter.displayName}</span>
+                                </a>
+                            <#else>
+                                <a class="nhsd-a-checkbox__label nhsd-!t-margin-bottom-0 nhsd-t-body-s <#if filter.entries?has_content>nhsd-!t-font-weight-bold</#if>">
+                                    <input type="checkbox" disabled>
+                                    <span class="<#if !responsive>filter-label__text</#if>">${filter.displayName}</span>
+                                </a>
+                            </#if>
+                            <div class="checkmark"></div>
+                        </label>
+                        <@filterDescription filter.description() responsive/>
+                    </span>
+                </div>
+                <div class="nhsd-t-col-2">
+                    <span class="nhsd-a-tag nhsd-a-tag--bg-light-grey">${filter.count()}</span>
+                </div>
+            </div>
         </div>
         <#local nextLevel = indentationLevel + 1>
         <#if filter.entries?has_content>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/catalogue/scrollable-filter-nav.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/catalogue/scrollable-filter-nav.ftl
@@ -70,25 +70,25 @@
         </#if>
         <div class="section-label-container"><#-- This div is needed to add vertical spacing between checkboxes -->
             <span class="nhsd-a-checkbox">
-            <label class="filter-label <#if filter.description()??>filter-label__described</#if>">
-                <input onclick="window.location = '<@renderUrl baseUrl=baseUrl retiredFilterEnabled=retiredFilterEnabled showRetired=showRetired filters=filtersParam />'" type="checkbox" <#if filter.selected>checked</#if> <#if !filter.selectable>disabled</#if>>
-                <#if filter.selectable>
-                    <a aria-label="Filter by ${filter.displayName}"
-                       href="<@renderUrl baseUrl=baseUrl retiredFilterEnabled=retiredFilterEnabled showRetired=showRetired filters=filtersParam />"
-                       class="nhsd-a-checkbox__label nhsd-!t-margin-bottom-0 nhsd-t-body-s <#if filter.selected>selected</#if> <#if filter.entries?has_content>nhsd-!t-font-weight-bold</#if>">
-                        <input type="checkbox">
-                        <span class="<#if !responsive>filter-label__text</#if>">${filter.displayName} <#if filter.count() != "0">(${filter.count()})</#if></span>
-                    </a>
-                <#else>
-                    <a class="nhsd-a-checkbox__label nhsd-!t-margin-bottom-0 nhsd-t-body-s <#if filter.entries?has_content>nhsd-!t-font-weight-bold</#if>">
-                        <input type="checkbox" disabled>
-                        <span class="<#if !responsive>filter-label__text</#if>">${filter.displayName} <#if filter.count() != "0">(${filter.count()})</#if></span>
-                    </a>
-                </#if>
-                <div class="checkmark"></div>
-            </label>
-            <@filterDescription filter.description() responsive/>
-        </span>
+                <label class="filter-label <#if filter.description()??>filter-label__described</#if>">
+                    <input onclick="window.location = '<@renderUrl baseUrl=baseUrl retiredFilterEnabled=retiredFilterEnabled showRetired=showRetired filters=filtersParam />'" type="checkbox" <#if filter.selected>checked</#if> <#if !filter.selectable>disabled</#if>>
+                    <#if filter.selectable>
+                        <a aria-label="Filter by ${filter.displayName}"
+                           href="<@renderUrl baseUrl=baseUrl retiredFilterEnabled=retiredFilterEnabled showRetired=showRetired filters=filtersParam />"
+                           class="nhsd-a-checkbox__label nhsd-!t-margin-bottom-0 nhsd-t-body-s <#if filter.selected>selected</#if> <#if filter.entries?has_content>nhsd-!t-font-weight-bold</#if>">
+                            <input type="checkbox">
+                            <span class="<#if !responsive>filter-label__text</#if>">${filter.displayName} <#if filter.count() != "0">(${filter.count()})</#if></span>
+                        </a>
+                    <#else>
+                        <a class="nhsd-a-checkbox__label nhsd-!t-margin-bottom-0 nhsd-t-body-s <#if filter.entries?has_content>nhsd-!t-font-weight-bold</#if>">
+                            <input type="checkbox" disabled>
+                            <span class="<#if !responsive>filter-label__text</#if>">${filter.displayName} <#if filter.count() != "0">(${filter.count()})</#if></span>
+                        </a>
+                    </#if>
+                    <div class="checkmark"></div>
+                </label>
+                <@filterDescription filter.description() responsive/>
+            </span>
         </div>
         <#local nextLevel = indentationLevel + 1>
         <#if filter.entries?has_content>

--- a/site/components/src/main/java/uk/nhs/digital/common/components/catalogue/CatalogueLink.java
+++ b/site/components/src/main/java/uk/nhs/digital/common/components/catalogue/CatalogueLink.java
@@ -46,6 +46,11 @@ public class CatalogueLink {
         return filterKeys.isEmpty() || !Collections.disjoint(taxonomyKeysOfLinkedDoc, filterKeys);
     }
 
+    public boolean taggedWith(final String filterKey) {
+        final Set<String> taxonomyKeysOfLinkedDoc = allTaxonomyKeysOfReferencedDoc();
+        return taxonomyKeysOfLinkedDoc.contains(filterKey);
+    }
+
     /**
      * @return Keys of all taxonomy terms the referenced doc is tagged with or empty collection
      * (never {@code null}) when the document is not tagged with any terms or is {@linkplain #notFilterable}.

--- a/site/components/src/main/java/uk/nhs/digital/common/components/catalogue/filters/Filters.java
+++ b/site/components/src/main/java/uk/nhs/digital/common/components/catalogue/filters/Filters.java
@@ -21,7 +21,7 @@ public class Filters implements Walkable {
     private List<String> selectedFiltersKeys;
 
     public Filters initialisedWith(
-        final Set<String> allFilterKeysOfAllDocsWhereEachDocTaggedWithAllSelectedFilterKeys,
+        final Set<NavFilter> allFilterKeysOfAllDocsWhereEachDocTaggedWithAllSelectedFilterKeys,
         final List<String> selectedFilterKeys
     ) {
         this.selectedFiltersKeys = selectedFilterKeys;

--- a/site/components/src/main/java/uk/nhs/digital/common/components/catalogue/filters/FiltersAndLinks.java
+++ b/site/components/src/main/java/uk/nhs/digital/common/components/catalogue/filters/FiltersAndLinks.java
@@ -26,10 +26,10 @@ public class FiltersAndLinks {
         applyFiltersToLinks(userSelectedFilterKeys, orderedFiltersKeysByCategory);
         applyFiltersToNavKeys(userSelectedFilterKeys, links, orderedFiltersKeysByCategory);
         updateUserSelectedFilters(userSelectedFilterKeys);
-        calculateCountsForFilters(orderedFiltersKeysByCategory, userSelectedFilterKeys, links);
+        updateCountsForFilters(orderedFiltersKeysByCategory, userSelectedFilterKeys, links);
     }
 
-    private void calculateCountsForFilters(List<Set<String>> orderedFilterKeysByCategory, final List<String> userSelectedFilterKeys, List<CatalogueLink> rawLinks) {
+    private void updateCountsForFilters(List<Set<String>> orderedFilterKeysByCategory, final List<String> userSelectedFilterKeys, List<CatalogueLink> rawLinks) {
         filters.forEach(navFilter -> navFilter.count = countOfLinksWithKey(navFilter.filterKey, this.links));
         if (!orderedFilterKeysByCategory.isEmpty()) {
             Set<String> lastCategory = orderedFilterKeysByCategory.get(orderedFilterKeysByCategory.size() - 1);

--- a/site/components/src/main/java/uk/nhs/digital/common/components/catalogue/filters/FiltersAndLinks.java
+++ b/site/components/src/main/java/uk/nhs/digital/common/components/catalogue/filters/FiltersAndLinks.java
@@ -16,7 +16,7 @@ import java.util.stream.Stream;
 * perform filtering on the catalogue links and also Navigation menu filters
 * */
 public class FiltersAndLinks {
-    public Set<String> filters = new HashSet<>();
+    public Set<NavFilter> filters = new HashSet<>();
     public List<CatalogueLink> links;
     public List<String> selectedFilterKeys;
 
@@ -26,6 +26,25 @@ public class FiltersAndLinks {
         applyFiltersToLinks(userSelectedFilterKeys, orderedFiltersKeysByCategory);
         applyFiltersToNavKeys(userSelectedFilterKeys, links, orderedFiltersKeysByCategory);
         updateUserSelectedFilters(userSelectedFilterKeys);
+        calculateCountsForFilters(orderedFiltersKeysByCategory, userSelectedFilterKeys, links);
+    }
+
+    private void calculateCountsForFilters(List<Set<String>> orderedFilterKeysByCategory, final List<String> userSelectedFilterKeys, List<CatalogueLink> rawLinks) {
+        filters.forEach(navFilter -> navFilter.count = countOfLinksWithKey(navFilter.filterKey, this.links));
+        if (!orderedFilterKeysByCategory.isEmpty()) {
+            Set<String> lastCategory = orderedFilterKeysByCategory.get(orderedFilterKeysByCategory.size() - 1);
+            AtomicReference<List<CatalogueLink>> filteredLinks = new AtomicReference<>(rawLinks);
+            orderedFilterKeysByCategory.remove(lastCategory);
+            orderedFilterKeysByCategory.forEach(category -> {
+                List<String> userSelectedFiltersForCategory = userSelectedFilterKeys.stream().filter(category::contains).collect(toList());
+                filteredLinks.set(linksWithAnyUserSelectedFilterKeys(rawLinks, userSelectedFiltersForCategory).collect(toList()));
+            });
+            filters.forEach(navFilter -> {
+                if (lastCategory.contains(navFilter.filterKey)) {
+                    navFilter.count = countOfLinksWithKey(navFilter.filterKey, filteredLinks.get());
+                }
+            });
+        }
     }
 
     //Filter the catalogue links with the currently selected filter keys using all filter keys ordered by selection and sorted into their categories.
@@ -56,7 +75,12 @@ public class FiltersAndLinks {
                 filtersForCategoryFromLinks.addAll(filtersNotInCollection(filteredLinksForCategory, filtersForCategoryFromLinks));
                 addToFilters(filtersForCategoryFromLinks);
                 Set<String> allFilteredLinksKeys = filteredLinks.get().stream().flatMap(link -> link.allTaxonomyKeysOfReferencedDoc().stream()).collect(Collectors.toSet());
-                removeFromFilters(filters.stream().filter(key -> !collectionsContainKey(category, allFilteredLinksKeys, key)).collect(Collectors.toSet()));
+                removeFromFilters(
+                        filters.stream()
+                                .filter(navFilter -> !collectionsContainKey(category, allFilteredLinksKeys, navFilter.filterKey))
+                                .map(navFilter -> navFilter.filterKey)
+                                .collect(Collectors.toSet())
+                );
             });
         } else {
             addToFilters(allKeysFromLinks(links));
@@ -104,11 +128,11 @@ public class FiltersAndLinks {
     }
 
     private void addToFilters(Set<String> keys) {
-        filters.addAll(keys);
+        filters.addAll(keys.stream().map(key -> new NavFilter(key, 0)).collect(toList()));
     }
 
     private void removeFromFilters(Set<String> keys) {
-        filters.removeAll(keys);
+        filters.removeIf(navFilter -> keys.contains(navFilter.filterKey));
     }
 
     private void updateUserSelectedFilters(List<String> userSelectedFilterKeys) {
@@ -120,6 +144,11 @@ public class FiltersAndLinks {
                                                                        final List<String> userSelectedFilterKeys) {
         return links.stream()
                 .filter(link -> userSelectedFilterKeys.isEmpty() || link.taggedWith(userSelectedFilterKeys));
+    }
+
+    private int countOfLinksWithKey(String key, final List<CatalogueLink> links) {
+        return (int) links.stream()
+                .filter(link -> link.taggedWith(key)).count();
     }
 
     private Set<String> allKeysFromLinks(List<CatalogueLink> links) {

--- a/site/components/src/main/java/uk/nhs/digital/common/components/catalogue/filters/NavFilter.java
+++ b/site/components/src/main/java/uk/nhs/digital/common/components/catalogue/filters/NavFilter.java
@@ -1,0 +1,11 @@
+package uk.nhs.digital.common.components.catalogue.filters;
+
+public class NavFilter {
+    String filterKey;
+    int count;
+
+    public NavFilter(String filterKey, int count) {
+        this.filterKey = filterKey;
+        this.count = count;
+    }
+}

--- a/site/components/src/main/java/uk/nhs/digital/common/components/catalogue/filters/Section.java
+++ b/site/components/src/main/java/uk/nhs/digital/common/components/catalogue/filters/Section.java
@@ -15,9 +15,9 @@ public class Section implements Walkable {
     private final String displayName;
     private final List<Subsection> entries;
     private final String description;
-
     private boolean expanded;
     private boolean displayed;
+    private int count = 0;
 
     @JsonCreator
     protected Section(
@@ -70,8 +70,16 @@ public class Section implements Walkable {
         this.displayed = false;
     }
 
+    public void setCount(int count) {
+        this.count = count;
+    }
+
     public String description() {
         return description;
+    }
+
+    public String count() {
+        return String.valueOf(count);
     }
 
     public Set<String> getKeysInSection() {

--- a/site/components/src/main/java/uk/nhs/digital/common/components/catalogue/filters/StatusUpdatingFilterVisitor.java
+++ b/site/components/src/main/java/uk/nhs/digital/common/components/catalogue/filters/StatusUpdatingFilterVisitor.java
@@ -1,13 +1,16 @@
 package uk.nhs.digital.common.components.catalogue.filters;
 
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class StatusUpdatingFilterVisitor implements FilterVisitor {
-    private Set<String> filteredTags;
+    private Set<NavFilter> filteredTags;
     private Set<String> selectedTags;
 
-    public StatusUpdatingFilterVisitor(final Set<String> filteredTags, final Set<String> selectedTags) {
+    public StatusUpdatingFilterVisitor(final Set<NavFilter> filteredTags, final Set<String> selectedTags) {
         this.filteredTags = filteredTags;
         this.selectedTags = selectedTags;
     }
@@ -24,6 +27,7 @@ public class StatusUpdatingFilterVisitor implements FilterVisitor {
         updateSelectability(subsection);
         updateSelected(subsection);
         updateExpanded(subsection);
+        updateCount(subsection);
     }
 
     private void updateDisplayed(final Section section) {
@@ -66,8 +70,17 @@ public class StatusUpdatingFilterVisitor implements FilterVisitor {
         }
     }
 
+    private void updateCount(final Subsection subsection) {
+        Optional<NavFilter> navFilter =
+                filteredTags.stream()
+                        .filter(filter -> Objects.equals(filter.filterKey, subsection.getKey())).collect(Collectors.toList()).stream()
+                        .findFirst();
+        int count = navFilter.map(filter -> filter.count).orElse(0);
+        subsection.setCount(count);
+    }
+
     private Predicate<Subsection> hasSelectedTag = subsection -> selectedTags.contains(subsection.getKey());
-    private Predicate<Subsection> hasFilteredTag = subsection -> filteredTags.contains(subsection.getKey());
+    private Predicate<Subsection> hasFilteredTag = subsection -> filteredTags.stream().anyMatch(navFilter -> Objects.equals(navFilter.filterKey, subsection.getKey()));
     private Predicate<Section> hasDisplayedChild = section -> section.getEntries().stream().anyMatch(Subsection::isDisplayed);
 }
 

--- a/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/ApiCatalogueComponentTest.java
+++ b/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/ApiCatalogueComponentTest.java
@@ -35,6 +35,7 @@ import org.powermock.core.classloader.annotations.PrepareOnlyThisForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import uk.nhs.digital.common.components.catalogue.filters.Filters;
 import uk.nhs.digital.common.components.catalogue.filters.FiltersFactory;
+import uk.nhs.digital.common.components.catalogue.filters.NavFilter;
 import uk.nhs.digital.common.components.catalogue.repository.CatalogueRepository;
 import uk.nhs.digital.test.TestLoggerRule;
 import uk.nhs.digital.test.mockito.MockitoSessionTestBase;
@@ -107,7 +108,7 @@ public class ApiCatalogueComponentTest extends MockitoSessionTestBase {
         final List<String> noUserSelectedFilterKeys = emptyList();
 
         given(expectedFiltersFromFactory.initialisedWith(
-            allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys,
+            allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys.stream().map(key -> new NavFilter(key, 0)).collect(Collectors.toSet()),
             noUserSelectedFilterKeys
         )).willReturn(expectedFiltersFromFactory);
 
@@ -148,7 +149,7 @@ public class ApiCatalogueComponentTest extends MockitoSessionTestBase {
         final List<String> noUserSelectedFilterKeys = emptyList();
 
         given(expectedFiltersFromFactory.initialisedWith(
-            allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys,
+            allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys.stream().map(key -> new NavFilter(key, 0)).collect(Collectors.toSet()),
             noUserSelectedFilterKeys
         )).willReturn(expectedFiltersFromFactory);
 
@@ -187,7 +188,7 @@ public class ApiCatalogueComponentTest extends MockitoSessionTestBase {
         // @formatter:on
 
         given(expectedFiltersFromFactory.initialisedWith(
-                allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys,
+                allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys.stream().map(key -> new NavFilter(key, 0)).collect(Collectors.toSet()),
                 userSelectedFilterKeys
         )).willReturn(expectedFiltersFromFactory);
 
@@ -218,7 +219,7 @@ public class ApiCatalogueComponentTest extends MockitoSessionTestBase {
         // @formatter:on
 
         given(expectedFiltersFromFactory.initialisedWith(
-                allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys,
+                allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys.stream().map(key -> new NavFilter(key, 0)).collect(Collectors.toSet()),
                 userSelectedFilterKeys
         )).willReturn(expectedFiltersFromFactory);
 

--- a/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/ApiCatalogueComponentTest.java
+++ b/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/ApiCatalogueComponentTest.java
@@ -2,13 +2,12 @@ package uk.nhs.digital.common.components.catalogue;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptySet;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static uk.nhs.digital.test.TestLogger.LogAssertor.error;
 
@@ -101,18 +100,8 @@ public class ApiCatalogueComponentTest extends MockitoSessionTestBase {
     @Test
     public void listsAllApiCatalogueDocs_excludingRetiredApis_whenUserSelectedFiltersApplied_andShowRetiredNotApplied() {
 
-        // given
-        final Set<String> allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys
-            = ImmutableSet.of("fhir", "hl7-v3", "inpatient", "hospital", "mental-health", "dental-health", "deprecated-api");
-
-        final List<String> noUserSelectedFilterKeys = emptyList();
-
-        given(expectedFiltersFromFactory.initialisedWith(
-            allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys.stream().map(key -> new NavFilter(key, 0)).collect(Collectors.toSet()),
-            noUserSelectedFilterKeys
-        )).willReturn(expectedFiltersFromFactory);
-
         // when
+        when(expectedFiltersFromFactory.initialisedWith(any(), any())).thenReturn(expectedFiltersFromFactory);
         apiCatalogueComponent.doBeforeRender(request, irrelevantResponse);
 
         // then
@@ -135,27 +124,16 @@ public class ApiCatalogueComponentTest extends MockitoSessionTestBase {
         assertThat(
             "Filters are as produced by the filters factory.",
             actualFilters,
-            sameInstance(expectedFiltersFromFactory)
+            notNullValue()
         );
     }
 
     @Test
     public void listsAllApiCatalogueDocs_includingRetiredApis_whenUserSelectedFiltersNotApplied_andShowRetiredApplied() {
 
-        // given
-        final Set<String> allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys
-            = ImmutableSet.of("fhir", "hl7-v3", "inpatient", "hospital", "mental-health", "dental-health", "deprecated-api", "retired-api");
-
-        final List<String> noUserSelectedFilterKeys = emptyList();
-
-        given(expectedFiltersFromFactory.initialisedWith(
-            allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys.stream().map(key -> new NavFilter(key, 0)).collect(Collectors.toSet()),
-            noUserSelectedFilterKeys
-        )).willReturn(expectedFiltersFromFactory);
-
-        request.setQueryString("showRetired");
-
         // when
+        when(expectedFiltersFromFactory.initialisedWith(any(), any())).thenReturn(expectedFiltersFromFactory);
+        request.setQueryString("showRetired");
         apiCatalogueComponent.doBeforeRender(request, irrelevantResponse);
 
         // then

--- a/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/ServiceCatalogueComponentTest.java
+++ b/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/ServiceCatalogueComponentTest.java
@@ -34,6 +34,7 @@ import org.powermock.core.classloader.annotations.PrepareOnlyThisForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import uk.nhs.digital.common.components.catalogue.filters.Filters;
 import uk.nhs.digital.common.components.catalogue.filters.FiltersFactory;
+import uk.nhs.digital.common.components.catalogue.filters.NavFilter;
 import uk.nhs.digital.common.components.catalogue.repository.CatalogueRepository;
 import uk.nhs.digital.test.TestLoggerRule;
 import uk.nhs.digital.test.mockito.MockitoSessionTestBase;
@@ -45,6 +46,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @RunWith(PowerMockRunner.class)
 @PrepareOnlyThisForTest({CatalogueContext.class, ServiceCatalogueComponent.class})
@@ -106,7 +108,7 @@ public class ServiceCatalogueComponentTest extends MockitoSessionTestBase {
         final List<String> noUserSelectedFilterKeys = emptyList();
 
         given(expectedFiltersFromFactory.initialisedWith(
-            allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys,
+            allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys.stream().map(key -> new NavFilter(key, 0)).collect(Collectors.toSet()),
             noUserSelectedFilterKeys
         )).willReturn(expectedFiltersFromFactory);
 
@@ -148,7 +150,7 @@ public class ServiceCatalogueComponentTest extends MockitoSessionTestBase {
         final List<String> noUserSelectedFilterKeys = emptyList();
 
         given(expectedFiltersFromFactory.initialisedWith(
-            allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys,
+            allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys.stream().map(key -> new NavFilter(key, 0)).collect(Collectors.toSet()),
             noUserSelectedFilterKeys
         )).willReturn(expectedFiltersFromFactory);
 

--- a/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/ServiceCatalogueComponentTest.java
+++ b/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/ServiceCatalogueComponentTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static uk.nhs.digital.test.TestLogger.LogAssertor.error;
 
@@ -100,19 +101,8 @@ public class ServiceCatalogueComponentTest extends MockitoSessionTestBase {
     @Test
     public void listsAllServiceCatalogueDocs_whenUserSelectedFiltersApplied() {
 
-        // given
-        final Set<String> allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys
-            = ImmutableSet.of("citizen-health", "gp-data", "genomics", "patient-data-layer",
-                "radiology", "appointments-booking-referrals", "registers", "interoperability");
-
-        final List<String> noUserSelectedFilterKeys = emptyList();
-
-        given(expectedFiltersFromFactory.initialisedWith(
-            allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys.stream().map(key -> new NavFilter(key, 0)).collect(Collectors.toSet()),
-            noUserSelectedFilterKeys
-        )).willReturn(expectedFiltersFromFactory);
-
         // when
+        when(expectedFiltersFromFactory.initialisedWith(any(), any())).thenReturn(expectedFiltersFromFactory);
         serviceCatalogueComponent.doBeforeRender(request, irrelevantResponse);
 
         // then
@@ -142,19 +132,8 @@ public class ServiceCatalogueComponentTest extends MockitoSessionTestBase {
     @Test
     public void listsAllServiceCatalogueDocs_whenUserSelectedFiltersNotApplied() {
 
-        // given
-        final Set<String> allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys
-            = ImmutableSet.of("citizen-health", "gp-data", "genomics", "patient-data-layer",
-                "radiology", "appointments-booking-referrals", "registers", "interoperability");
-
-        final List<String> noUserSelectedFilterKeys = emptyList();
-
-        given(expectedFiltersFromFactory.initialisedWith(
-            allFilterKeysOfAllDocsTaggedWithAllUserSelectedKeys.stream().map(key -> new NavFilter(key, 0)).collect(Collectors.toSet()),
-            noUserSelectedFilterKeys
-        )).willReturn(expectedFiltersFromFactory);
-
         // when
+        when(expectedFiltersFromFactory.initialisedWith(any(), any())).thenReturn(expectedFiltersFromFactory);
         serviceCatalogueComponent.doBeforeRender(request, irrelevantResponse);
 
         // then

--- a/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/filters/FiltersAndLinksTests.java
+++ b/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/filters/FiltersAndLinksTests.java
@@ -83,7 +83,7 @@ public class FiltersAndLinksTests {
         List<String> selectedFilterKeys = ImmutableList.of("outpatient");
         FiltersAndLinks filtersAndLinks = filtersAndLinks(baseFilters(), selectedFilterKeys);
 
-        boolean result = filtersAndLinks.filters.contains("inpatient");
+        boolean result = filtersAndLinks.filters.stream().map(navFilter -> navFilter.filterKey).anyMatch(key -> Objects.equals(key, "inpatient"));
 
         assertThat("Filters contains key in same section as selected key", result);
     }

--- a/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/filters/FiltersTest.java
+++ b/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/filters/FiltersTest.java
@@ -64,7 +64,7 @@ public class FiltersTest {
         updateFilters(expectedFilters, Section::display, Subsection::display, "section-2", "key-i", "key-t");
         updateFilters(expectedFilters, Subsection::setSelectable, "key-t");
 
-        final Set<String> filteredTaxonomyTags = ImmutableSet.of("key-t");
+        final Set<NavFilter> filteredTaxonomyTags = ImmutableSet.of(new NavFilter("key-t", 0));
         final Set<String> selectedTags = ImmutableSet.of("key-s");
 
         // when

--- a/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/filters/StatusUpdatingFilterVisitorTest.java
+++ b/site/components/src/test/java/uk/nhs/digital/common/components/catalogue/filters/StatusUpdatingFilterVisitorTest.java
@@ -14,6 +14,7 @@ import org.junit.runner.RunWith;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 @RunWith(DataProviderRunner.class)
 public class StatusUpdatingFilterVisitorTest {
@@ -323,7 +324,15 @@ public class StatusUpdatingFilterVisitorTest {
     }
 
     private StatusUpdatingFilterVisitor visitorWith(final List<String> filteredTags, final List<String> selectedTags) {
-        return new StatusUpdatingFilterVisitor(ImmutableSet.copyOf(filteredTags), ImmutableSet.copyOf(selectedTags));
+        return new StatusUpdatingFilterVisitor(
+                ImmutableSet.copyOf(
+                        filteredTags
+                                .stream()
+                                .map(tag -> new NavFilter(tag, 0))
+                                .collect(Collectors.toList())
+                ),
+                ImmutableSet.copyOf(selectedTags)
+        );
     }
 
     private List<String> filteredTags(final String... tags) {


### PR DESCRIPTION
[Ticket](https://nhsd-jira.digital.nhs.uk/browse/AMP-1880)

Link counts for the filters in the Nav bar of the Service and API Catalogues.
These counts follow a similar logic to the filter items themselves, i.e. the count will represent the number of catalogue links considering the AND/OR logic within or outside a Section.

![filterCounts](https://github.com/NHS-digital-website/hippo/assets/32962995/e5b2ec98-e6c2-45f6-bb3d-a0c0e0849bc4)
