### PR TITLE
[AMP-2732] Fix for handling broken special character '&' in catalogue…

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/apicatalogue/apicatalogue.js
+++ b/repository-data/webfiles/src/main/resources/site/apicatalogue/apicatalogue.js
@@ -67,9 +67,10 @@ function findHTMLElementData(result, element, htmlElement) {
 function replaceHTMLContent(result, element, text, searchTerm, htmlElement) {
     const highlightContent1 = text.replaceAll('<span class="filter-tag-yellow-highlight">', '');
     const highlightContent2 = highlightContent1.replaceAll('</span>', '');
+    const highlightContent3 = highlightContent2.replaceAll('&amp;', '&');
     let highlightContentFinal = '';
     if (searchTerm.length !== 0) {
-        highlightContentFinal = highlightContent2.replaceAll(new RegExp(searchTerm, 'gi'), (match) => {
+        highlightContentFinal = highlightContent3.replaceAll(new RegExp(searchTerm, 'gi'), (match) => {
             const returnString = `<span class="filter-tag-yellow-highlight">${match}</span>`;
             return returnString;
         });
@@ -79,7 +80,7 @@ function replaceHTMLContent(result, element, text, searchTerm, htmlElement) {
         if (searchTerm.length !== 0) {
             resultNew.querySelector(element).innerHTML = highlightContentFinal;
         } else {
-            resultNew.querySelector(element).innerHTML = highlightContent2;
+            resultNew.querySelector(element).innerHTML = highlightContent3;
         }
     } else {
         const htmlElementNew = htmlElement;


### PR DESCRIPTION
This fix for handling the broken special character - '&' after implementing yellow highlight match string in search pages in both Service and API catalogues.

Before Fix:
![Screenshot from 2024-04-29 16-14-30](https://github.com/NHS-digital-website/hippo/assets/164230338/982b585d-80df-4e93-a7b2-fc6045dde929)

After Fix:
![image](https://github.com/NHS-digital-website/hippo/assets/164230338/ae7b3756-dc5b-4a42-813d-69ffffa12d12)
