### PR TITLE
[AMP-2509] Pushing Left nav link names to GA data layer

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/apispecification/rapidoc-customisation.js
+++ b/repository-data/webfiles/src/main/resources/site/apispecification/rapidoc-customisation.js
@@ -146,6 +146,14 @@
         const elements = rapiDocEl.querySelectorAll(('.').concat(className));
         elements.forEach((element) => {
             element.classList.add(additionalClassName);
+            const elementData = element.textContent
+                .replaceAll('\n', '')
+                .replaceAll('GET', '')
+                .replaceAll('PATCH', '')
+                .replaceAll('POST', '')
+                .replaceAll('DELETE', '')
+                .trim();
+            element.setAttribute('onclick', 'dataLayer.push({\'event\':\'left_nav\',\'leftNavLink\':\''.concat(elementData).concat('\'});'));
         });
     }
 
@@ -155,6 +163,7 @@
         addHorizontalRuleBetweenHeadings();
         highlightNavbarOnScroll();
         addSecNavEventInLeftNav('nav-bar-h2', 'section-nav-event');
+        addSecNavEventInLeftNav('nav-bar-path', 'section-nav-event');
     }
 
     document.addEventListener('DOMContentLoaded', () => {

--- a/repository-data/webfiles/src/main/resources/site/freemarker/nhsd-common/macro/stickyNavSections.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/nhsd-common/macro/stickyNavSections.ftl
@@ -20,11 +20,11 @@
                             <#assign numberedListCount++ />
                             <#assign numberedLinkTitle = numberedListCount + ". " + link.title>
                             <li class="nhsd-m-sticky-navigation__item nhsd-m-sticky-navigation__item--nested" data-nav-content="${slugify(link.title)}">
-                                <a href="${link.url}" aria-label="${label}" title="${label}" class="nhsd-a-link section-nav-event">${numberedLinkTitle}</a>
+                                <a href="${link.url}" aria-label="${label}" title="${label}" class="nhsd-a-link section-nav-event" onclick="dataLayer.push({'event':'left_nav','leftNavLink':'${numberedLinkTitle}'});">${numberedLinkTitle}</a>
                             </li>
                         <#else>
                             <li class="nhsd-m-sticky-navigation__item" data-nav-content="${slugify(link.title)}">
-                                <a href="${link.url}" aria-label="${label}" title="${label}" class="nhsd-a-link section-nav-event">${link.title}</a>
+                                <a href="${link.url}" aria-label="${label}" title="${label}" class="nhsd-a-link section-nav-event" onclick="dataLayer.push({'event':'left_nav','leftNavLink':'${link.title}'});">${link.title}</a>
                             </li>
                         </#if>
                     </#list>


### PR DESCRIPTION
For the Google analytics reporting, to capture all the links held in the left navigation in one event, changes has been done in C&C application FTL code and rapidoc customisation file.

This change is applicable for both API and Service catalogue pages. Code change has been doen to push the link name to GA events.

![image](https://github.com/NHS-digital-website/hippo/assets/164230338/dcc89e96-e5da-4180-a1c4-412c440b147b)

