### PR TITLE
[AMP-3153] Fixed section header height adjustment in api spec page

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/apispecification/rapidoc-customisation.js
+++ b/repository-data/webfiles/src/main/resources/site/apispecification/rapidoc-customisation.js
@@ -157,6 +157,24 @@
         });
     }
 
+    function navigateToAnchorWithOffset() {
+        const anchorId = window.location.hash;
+        if (anchorId) {
+            setTimeout(() => {
+                rapiDocEl = document.getElementById('rapi-doc-spec').shadowRoot;
+                const escapedId = CSS.escape(anchorId.substring(1));
+                const targetElement = rapiDocEl.querySelector(`#${escapedId}`);
+                if (targetElement) {
+                    // Adjust the scroll position with an offset to bring the element into full view
+                    const offset = 20;
+                    const elementPosition = targetElement.getBoundingClientRect().top
+                        + window.scrollY - offset;
+                    window.scrollTo({ top: elementPosition });
+                }
+            }, 100);
+        }
+    }
+
     function customiseRapiDoc() {
         rapiDocEl = document.getElementById('rapi-doc-spec').shadowRoot;
         makeTablesResponsive();
@@ -164,6 +182,7 @@
         highlightNavbarOnScroll();
         addSecNavEventInLeftNav('nav-bar-h2', 'section-nav-event');
         addSecNavEventInLeftNav('nav-bar-path', 'section-nav-event');
+        navigateToAnchorWithOffset();
     }
 
     document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
The changes has been done in the 'Developer hub' landing page for the external users. The page has been changed as per the new prototype.

![image](https://github.com/user-attachments/assets/b94fe3d7-6cc3-4f03-b066-1daaaf7708ad)
![image](https://github.com/user-attachments/assets/7285281c-6781-458c-a33e-0647a38a4a53)
