### PR TITLE
[WSP-1110] Fix for menu tabbing

### DIFF
--- a/repository-data/webfiles/src/main/resources/site/src/js/header/global-header-escape-close.js
+++ b/repository-data/webfiles/src/main/resources/site/src/js/header/global-header-escape-close.js
@@ -1,0 +1,20 @@
+const menuButtonSelector = '#nhsd-global-header__menu-button';
+
+function isMenuOpen(menuButton) {
+    return menuButton.getAttribute('aria-expanded') === 'true';
+}
+
+export default function initGlobalHeaderEscapeClose() {
+    document.addEventListener('keydown', (event) => {
+        if (event.key !== 'Escape') {
+            return;
+        }
+
+        const menuButton = document.querySelector(menuButtonSelector);
+
+        if (menuButton && isMenuOpen(menuButton)) {
+            menuButton.click();
+            menuButton.focus();
+        }
+    });
+}

--- a/repository-data/webfiles/src/main/resources/site/src/js/header/global-header-focus-order.js
+++ b/repository-data/webfiles/src/main/resources/site/src/js/header/global-header-focus-order.js
@@ -1,0 +1,214 @@
+const headerSelector = '#nhsd-global-header';
+const menuButtonSelector = '#nhsd-global-header__menu-button';
+const menuSelector = '#nhsd-global-header__menu';
+const menuCloseButtonSelector = '#nhsd-global-header__menu-close-button';
+
+const focusableSelector = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]',
+].join(',');
+
+const originalTabIndex = new WeakMap();
+
+function rememberTabIndex(element) {
+    if (!originalTabIndex.has(element)) {
+        originalTabIndex.set(element, element.getAttribute('tabindex'));
+    }
+}
+
+function restoreTabIndex(element) {
+    rememberTabIndex(element);
+
+    const tabIndex = originalTabIndex.get(element);
+
+    if (tabIndex === null) {
+        element.removeAttribute('tabindex');
+        return;
+    }
+
+    element.setAttribute('tabindex', tabIndex);
+}
+
+function isHidden(element) {
+    return !element.getClientRects().length
+        || window.getComputedStyle(element).visibility === 'hidden';
+}
+
+function isTabbable(element) {
+    const tabIndex = element.getAttribute('tabindex');
+
+    return tabIndex === null || Number(tabIndex) >= 0;
+}
+
+function getFocusableCandidates(root) {
+    return Array.from(root.querySelectorAll(focusableSelector))
+        .filter((element) => !element.hasAttribute('disabled') && !isHidden(element));
+}
+
+function getFocusableElements(root) {
+    return getFocusableCandidates(root).filter(isTabbable);
+}
+
+function setTabIndex(element, value) {
+    rememberTabIndex(element);
+    element.setAttribute('tabindex', value);
+}
+
+function isMenuButtonVisible(menuButton) {
+    return !isHidden(menuButton);
+}
+
+function isMenuOpen(menuButton) {
+    return menuButton.getAttribute('aria-expanded') === 'true';
+}
+
+function toggleMenu(menuButton) {
+    menuButton.click();
+}
+
+function getNextFocusableAfterContainer(container) {
+    const focusableElements = getFocusableElements(document);
+    const containerFocusableElements = focusableElements
+        .filter((element) => container.contains(element));
+    const lastContainerElement = containerFocusableElements[containerFocusableElements.length - 1];
+    const lastContainerElementIndex = focusableElements.indexOf(lastContainerElement);
+
+    if (lastContainerElementIndex === -1) {
+        return null;
+    }
+
+    return focusableElements[lastContainerElementIndex + 1] || null;
+}
+
+function initGlobalHeader(header) {
+    const menuButton = header.querySelector(menuButtonSelector);
+    const menu = header.querySelector(menuSelector);
+    const menuCloseButton = header.querySelector(menuCloseButtonSelector);
+    const pageHeader = header.closest('header') || header;
+
+    if (!menuButton || !menu || !menuCloseButton) {
+        return;
+    }
+
+    let closeButtonActivated = false;
+    let menuOpenedByKeyboard = false;
+
+    Array.from(header.querySelectorAll(focusableSelector))
+        .forEach(rememberTabIndex);
+
+    const getMenuFocusableElements = () => getFocusableElements(menu);
+
+    const applyState = () => {
+        const menuButtonIsVisible = isMenuButtonVisible(menuButton);
+        const menuIsOpen = isMenuOpen(menuButton);
+
+        getFocusableCandidates(header).forEach(restoreTabIndex);
+
+        if (menuButtonIsVisible && !menuIsOpen) {
+            getFocusableCandidates(menu).forEach((element) => setTabIndex(element, '-1'));
+        }
+    };
+
+    const scheduleApplyState = () => {
+        window.setTimeout(applyState, 0);
+    };
+
+    menuButton.addEventListener('keydown', (event) => {
+        if ((event.key === 'Enter' || event.key === ' ') && !isMenuOpen(menuButton)) {
+            menuOpenedByKeyboard = true;
+            return;
+        }
+
+        if (event.key !== 'Tab' || !isMenuOpen(menuButton)) {
+            return;
+        }
+
+        if (event.shiftKey) {
+            toggleMenu(menuButton);
+            scheduleApplyState();
+            return;
+        }
+
+        const firstMenuItem = getMenuFocusableElements()[0];
+
+        if (firstMenuItem) {
+            event.preventDefault();
+            firstMenuItem.focus();
+        }
+    });
+
+    menu.addEventListener('keydown', (event) => {
+        if ((event.key === 'Enter' || event.key === ' ') && event.target === menuCloseButton) {
+            closeButtonActivated = true;
+            scheduleApplyState();
+            return;
+        }
+
+        if (event.key !== 'Tab' || !isMenuOpen(menuButton)) {
+            return;
+        }
+
+        const menuFocusableElements = getMenuFocusableElements();
+        const firstMenuItem = menuFocusableElements[0];
+        const lastMenuItem = menuFocusableElements[menuFocusableElements.length - 1];
+
+        if (event.shiftKey && event.target === firstMenuItem) {
+            event.preventDefault();
+            menuButton.focus();
+            return;
+        }
+
+        if (!event.shiftKey && event.target === lastMenuItem) {
+            const nextFocusable = getNextFocusableAfterContainer(pageHeader);
+
+            toggleMenu(menuButton);
+            scheduleApplyState();
+
+            if (nextFocusable) {
+                event.preventDefault();
+                window.setTimeout(() => nextFocusable.focus(), 0);
+            }
+        }
+    });
+
+    menuCloseButton.addEventListener('click', () => {
+        closeButtonActivated = true;
+        scheduleApplyState();
+    });
+
+    const observer = new MutationObserver(() => {
+        const menuIsOpen = isMenuOpen(menuButton);
+
+        scheduleApplyState();
+
+        if (menuIsOpen && menuOpenedByKeyboard) {
+            menuOpenedByKeyboard = false;
+            window.setTimeout(() => menuButton.focus(), 0);
+        }
+
+        if (!menuIsOpen && closeButtonActivated) {
+            closeButtonActivated = false;
+            window.setTimeout(() => menuButton.focus(), 0);
+        }
+    });
+
+    observer.observe(menuButton, {
+        attributes: true,
+        attributeFilter: ['aria-expanded'],
+    });
+
+    window.addEventListener('resize', scheduleApplyState);
+    scheduleApplyState();
+}
+
+export default function initGlobalHeaderFocusOrder() {
+    const header = document.querySelector(headerSelector);
+
+    if (header) {
+        initGlobalHeader(header);
+    }
+}

--- a/repository-data/webfiles/src/main/resources/site/src/js/ndrs-frontend-scripts.js
+++ b/repository-data/webfiles/src/main/resources/site/src/js/ndrs-frontend-scripts.js
@@ -1,25 +1,29 @@
 import './utils/public-path';
 import cookies from './utils/cookies';
+import initGlobalHeaderEscapeClose from './header/global-header-escape-close';
+import initGlobalHeaderFocusOrder from './header/global-header-focus-order';
 
 /**
  * Scripts to load just before `</body>`
  */
-import {initCookieConsent} from "./relevance/relevance-cookie";
-import {printingEvents} from "./events/printingEvents";
-import {activateCodeBlocks} from "./highlighter/highlighter-copy-button";
-import "./print-publication";
-import "./feed-page";
-import "./show-hide-articles";
+import { initCookieConsent } from './relevance/relevance-cookie';
+import { printingEvents } from './events/printingEvents';
+import { activateCodeBlocks } from './highlighter/highlighter-copy-button';
+import './print-publication';
+import './feed-page';
+import './show-hide-articles';
 
 initCookieConsent();
 printingEvents();
 activateCodeBlocks();
+initGlobalHeaderEscapeClose();
+initGlobalHeaderFocusOrder();
 
 if (document.querySelector('[data-chartsource=highchart]')) {
-    import(/* webpackChunkName: "highchart-setup" */ './highcharts/highchart-setup').then(module => {
+    import(/* webpackChunkName: "highchart-setup" */ './highcharts/highchart-setup').then((module) => {
         const charts = module.default;
         charts();
-    })
+    });
 }
 
 // Download org prompt
@@ -28,10 +32,15 @@ if (document.querySelector('[data-org-prompt]')) {
 }
 
 if (document.querySelector('[data-eforms="setup"]')) {
-    import(/* webpackChunkName: "eform-setup" */ './eforms/eforms').then(module => {
+    import(/* webpackChunkName: "eform-setup" */ './eforms/eforms').then((module) => {
         const eform = module.default;
-        const {name, conditions, ajaxValidationUrl, ajaxSubmissionUrl} = window.eformsInfo;
+        const {
+            name,
+            conditions,
+            ajaxValidationUrl,
+            ajaxSubmissionUrl,
+        } = window.eformsInfo;
 
-        eform(name, conditions, ajaxValidationUrl, ajaxSubmissionUrl)
-    })
+        eform(name, conditions, ajaxValidationUrl, ajaxSubmissionUrl);
+    });
 }

--- a/repository-data/webfiles/src/main/resources/site/src/js/nhsd-frontend-scripts.js
+++ b/repository-data/webfiles/src/main/resources/site/src/js/nhsd-frontend-scripts.js
@@ -1,5 +1,7 @@
 import './utils/public-path';
 import cookies from './utils/cookies';
+import initGlobalHeaderEscapeClose from './header/global-header-escape-close';
+import initGlobalHeaderFocusOrder from './header/global-header-focus-order';
 
 /**
  * Scripts to load just before `</body>`
@@ -12,6 +14,8 @@ import './show-hide-articles';
 
 initCookieConsent();
 printingEvents();
+initGlobalHeaderEscapeClose();
+initGlobalHeaderFocusOrder();
 
 if (document.querySelector('[data-chartsource=highchart]')) {
     import(/* webpackChunkName: "highchart-setup" */ './highcharts/highchart-setup').then((module) => {


### PR DESCRIPTION
PR ready for review and testing. 

I have implemented a small runtime enhancement for the responsive NHS Digital global header menu keyboard behaviour.

  Summary of change:

  - Added a new global-header-focus-order.js module to correct keyboard focus order when the responsive global header menu is open.
  - Added a separate global-header-escape-close.js module so pressing Escape closes the open menu via the existing design-system menu button handler and returns focus to the menu
    button.

  - Wired both modules into the NHS Digital and NDRS frontend script entry points.
  - Also lint-formatted ndrs-frontend-scripts.js, as the Maven build lints all changed JS files against origin/master.

  Behaviour covered:

  - Menu content is removed from tab order while the responsive menu is closed.
  - When the menu is opened with keyboard, focus remains on the Menu button until the user tabs forward.
  - Tab from the Menu button moves into the menu links.
  - Shift+Tab from the first menu item moves back to the Menu button.
  - Shift+Tab from the Menu button closes the menu and allows focus to continue back up the page.
  - Tab from the last menu item closes the menu and moves focus to the next focusable element after the header, for example the breadcrumb link, rather than jumping back to the
    Search button.

  - Activating Close menu closes the menu and returns focus to the Menu button.
  - Escape closes the menu only when it is actually open and returns focus to the Menu button.

  Validation:

  - npm run lint passes.
  - npm run build-js passes.
  - Existing build warnings remain unchanged.

Testing:
 - I have tested on Chrome only.