### PR TITLE
[WSP-000] Prevent Draft Guard failing on Dependabot PRs

### DIFF
--- a/.github/workflows/pull-request-to-draft-guard.yml
+++ b/.github/workflows/pull-request-to-draft-guard.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   convert:
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

Exclude Dependabot pull requests from the Pull Request to Draft Guard workflow and explicitly declare the permissions required for the workflow to operate on standard pull requests.

## Problem

The workflow automatically converts newly opened pull requests to draft status and adds an instructional review comment.

Dependabot pull requests are created with a more restricted GitHub token. As a result, attempts to convert a Dependabot pull request to draft fail with:

```
GraphQL: Resource not accessible by integration (convertPullRequestToDraft)
```

This causes the workflow to fail unnecessarily.

The workflow also relies on permissions to update pull requests and create review comments. At present, these permissions are inherited from the repository or organisation defaults. Explicitly declaring:

```yaml
permissions:
  contents: read
  pull-requests: write
```

makes the required token scopes clear, follows the principle of least privilege, and protects the workflow from unexpected failures if repository or organisation default permissions are tightened in future.

## Change

* Add a condition to skip the workflow when the pull request author is `dependabot[bot]`.
* Explicitly declare the workflow permissions required to convert pull requests to draft status and create review comments:

  * `contents: read`
  * `pull-requests: write`

## Result

* Human-created pull requests continue to be converted to draft and receive the instructional comment.
* The workflow explicitly declares the minimum permissions it requires to perform these actions.
* The workflow remains resilient if repository or organisation default token permissions are changed in future.
* Dependabot pull requests are left unchanged.
* The workflow no longer fails on Dependabot-generated pull requests.

