### PR TITLE
[WSP-1087] Sanitise Icon Library's parameter input

### DIFF
--- a/site/components/src/main/java/uk/nhs/digital/common/components/IconLibraryComponent.java
+++ b/site/components/src/main/java/uk/nhs/digital/common/components/IconLibraryComponent.java
@@ -8,6 +8,9 @@ import org.hippoecm.hst.core.component.HstComponentException;
 import org.hippoecm.hst.core.component.HstRequest;
 import org.hippoecm.hst.core.component.HstResponse;
 import org.hippoecm.hst.core.request.HstRequestContext;
+import org.hippoecm.hst.util.SearchInputParsingUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.nhs.digital.svg.library.Icon;
 
 import java.util.ArrayList;
@@ -24,6 +27,8 @@ import javax.jcr.query.RowIterator;
 
 public class IconLibraryComponent extends BaseHstComponent {
 
+    private static final Logger log = LoggerFactory.getLogger(IconLibraryComponent.class);
+
     @Override
     public void doBeforeRender(final HstRequest request, final HstResponse response) throws HstComponentException {
         super.doBeforeRender(request, response);
@@ -32,11 +37,17 @@ public class IconLibraryComponent extends BaseHstComponent {
             QueryManager jcrQueryManager = requestContext.getSession().getWorkspace().getQueryManager();
             Query jcrQuery = jcrQueryManager.createQuery("/jcr:root/content/gallery/website/icons//element(*, hippogallery:imageset)[jcr:contains(., '.svg/')]", "xpath");
             QueryResult queryResult = jcrQuery.execute();
-            request.setAttribute("icons", buildListOfIcons(queryResult.getRows(), requestContext, request.getRequestContext().getServletRequest().getParameter("icon-search")));
+            request.setAttribute("icons", buildListOfIcons(queryResult.getRows(), requestContext, getSanitisedSearchTerm(request)));
             request.setAttribute("requestContext", requestContext);
         } catch (RepositoryException e) {
-            e.printStackTrace();
+            log.error("Failed to load icon library icons", e);
         }
+    }
+
+    private static String getSanitisedSearchTerm(final HstRequest request) {
+        final String searchTerm = request.getRequestContext().getServletRequest().getParameter("icon-search");
+
+        return SearchInputParsingUtils.parse(searchTerm, false);
     }
 
     private static List<Icon> buildListOfIcons(RowIterator rowIterator, HstRequestContext requestContext, String search) throws RepositoryException {

--- a/site/components/src/test/java/uk/nhs/digital/common/components/IconLibraryComponentTest.java
+++ b/site/components/src/test/java/uk/nhs/digital/common/components/IconLibraryComponentTest.java
@@ -1,0 +1,117 @@
+package uk.nhs.digital.common.components;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.hippoecm.hst.core.component.HstRequest;
+import org.hippoecm.hst.core.component.HstResponse;
+import org.hippoecm.hst.core.linking.HstLink;
+import org.hippoecm.hst.core.linking.HstLinkCreator;
+import org.hippoecm.hst.core.request.HstRequestContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.List;
+import javax.jcr.Node;
+import javax.jcr.Property;
+import javax.jcr.Session;
+import javax.jcr.Value;
+import javax.jcr.Workspace;
+import javax.jcr.query.Query;
+import javax.jcr.query.QueryManager;
+import javax.jcr.query.QueryResult;
+import javax.jcr.query.Row;
+import javax.jcr.query.RowIterator;
+import javax.servlet.http.HttpServletRequest;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IconLibraryComponentTest {
+
+    private static final String ICON_PATH = "/icons/neutral.svg";
+
+    @Mock private HstRequest request;
+    @Mock private HstResponse response;
+    @Mock private HstRequestContext requestContext;
+    @Mock private HttpServletRequest servletRequest;
+    @Mock private Session session;
+    @Mock private Workspace workspace;
+    @Mock private QueryManager queryManager;
+    @Mock private Query query;
+    @Mock private QueryResult queryResult;
+    @Mock private RowIterator rowIterator;
+    @Mock private Row row;
+    @Mock private Node node;
+    @Mock private Node parentNode;
+    @Mock private Node grandparentNode;
+    @Mock private Property descriptionProperty;
+    @Mock private Value descriptionValue;
+    @Mock private HstLinkCreator hstLinkCreator;
+    @Mock private HstLink hstLink;
+
+    private IconLibraryComponent component;
+
+    @Before
+    public void setUp() throws Exception {
+        component = new IconLibraryComponent();
+
+        when(request.getRequestContext()).thenReturn(requestContext);
+        when(requestContext.getServletRequest()).thenReturn(servletRequest);
+        when(requestContext.getSession()).thenReturn(session);
+        when(requestContext.getHstLinkCreator()).thenReturn(hstLinkCreator);
+        when(session.getWorkspace()).thenReturn(workspace);
+        when(workspace.getQueryManager()).thenReturn(queryManager);
+        when(queryManager.createQuery(anyString(), eq("xpath"))).thenReturn(query);
+        when(query.execute()).thenReturn(queryResult);
+        when(queryResult.getRows()).thenReturn(rowIterator);
+        when(rowIterator.hasNext()).thenReturn(true, false);
+        when(rowIterator.nextRow()).thenReturn(row);
+        when(row.getNode()).thenReturn(node);
+        when(hstLinkCreator.create(node, requestContext)).thenReturn(hstLink);
+        when(hstLink.getPath()).thenReturn(ICON_PATH);
+
+        when(node.getIdentifier()).thenReturn("id");
+        when(node.getParent()).thenReturn(parentNode);
+        when(parentNode.hasProperty("hippo:name")).thenReturn(false);
+        when(parentNode.getParent()).thenReturn(grandparentNode);
+        when(grandparentNode.isNodeType("hippostd:folder")).thenReturn(false);
+    }
+
+    @Test
+    public void sanitisesIconSearchParameterBeforeFilteringIcons() throws Exception {
+        when(servletRequest.getParameter("icon-search")).thenReturn("download[");
+        when(node.getName()).thenReturn("neutral.svg");
+        when(node.hasProperty("hippogallery:description")).thenReturn(true);
+        when(node.getProperty("hippogallery:description")).thenReturn(descriptionProperty);
+        when(descriptionProperty.getValue()).thenReturn(descriptionValue);
+        when(descriptionValue.getString()).thenReturn("[");
+
+        component.doBeforeRender(request, response);
+
+        assertIconsAttributeSize(0);
+    }
+
+    @Test
+    public void keepsNormalIconSearchFilteringBehaviour() throws Exception {
+        when(servletRequest.getParameter("icon-search")).thenReturn("download");
+        when(node.getName()).thenReturn("download.svg");
+        when(node.hasProperty("hippogallery:description")).thenReturn(false);
+
+        component.doBeforeRender(request, response);
+
+        assertIconsAttributeSize(1);
+    }
+
+    private void assertIconsAttributeSize(final int expectedSize) {
+        final ArgumentCaptor<List> iconsCaptor = ArgumentCaptor.forClass(List.class);
+
+        verify(request).setAttribute(eq("icons"), iconsCaptor.capture());
+        assertEquals(expectedSize, iconsCaptor.getValue().size());
+    }
+}


### PR DESCRIPTION
`IconLibraryComponent` was reading `icon-search` directly from the servlet request and using it during icon filtering. Although this is not interpolated into the JCR query, the BR audit flagged unsanitised request parameters
  as requiring cleanup before use.

## Change Summary

  - Add sanitisation for the `icon-search` request parameter in `IconLibraryComponent`
  - Replace `e.printStackTrace()` with structured SLF4J error logging
  - Add unit coverage for unsafe icon search input and existing normal search behaviour

## Testing

```sh
  mvn -pl site/components -am test -Dtest=IconLibraryComponentTest -Dsurefire.failIfNoSpecifiedTests=false
