### PR TITLE
[WSP-382] Remove RAW HTML

### DIFF
--- a/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/common/SearchPage.java
+++ b/acceptance-tests/src/test/java/uk/nhs/digital/ps/test/acceptance/pages/site/common/SearchPage.java
@@ -31,7 +31,10 @@ public class SearchPage extends AbstractSitePage {
     }
 
     public String getResultCount() {
-        return helper.findElement(By.xpath("//*[@data-uipath='ps.search-results.count']")).getText();
+        By resultCountSelector = By.xpath("//*[@data-uipath='ps.search-results.count']");
+        return helper.waitForElementUntil(
+            ExpectedConditions.visibilityOfElementLocated(resultCountSelector)
+        ).getText();
     }
 
     public String getResultDescription() {

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/WSP-382-remove-service-general-html-code.groovy
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/WSP-382-remove-service-general-html-code.groovy
@@ -1,0 +1,50 @@
+package org.hippoecm.frontend.plugins.cms.admin.updater
+
+import org.hippoecm.repository.util.JcrUtils
+import org.onehippo.repository.update.BaseNodeUpdateVisitor
+
+import javax.jcr.Node
+import javax.jcr.RepositoryException
+
+class RemoveServiceGeneralHtmlCode extends BaseNodeUpdateVisitor {
+
+    private static final String HTML_CODE = "website:htmlCode"
+    private static final Set<String> SUPPORTED_TYPES = [
+        "website:service",
+        "website:general"
+    ] as Set
+
+    @Override
+    boolean doUpdate(Node node) {
+        String nodeType = jcrPrimaryType(node)
+
+        if (!SUPPORTED_TYPES.contains(nodeType)) {
+            log.error("Can only be invoked for Service or General documents but actual node type was ${nodeType}. Backing off: ${node.path}")
+            return false
+        }
+
+        if (!node.hasProperty(HTML_CODE)) {
+            log.info("No ${HTML_CODE} property found on ${node.path}")
+            return false
+        }
+
+        String value = node.getProperty(HTML_CODE).getString()
+        boolean hasValue = value != null && value.trim().length() > 0
+        log.info("Found ${HTML_CODE} on ${node.path}; non-empty=${hasValue}; length=${value == null ? 0 : value.length()}")
+
+        JcrUtils.ensureIsCheckedOut(node)
+        node.getProperty(HTML_CODE).remove()
+        log.info("Removed ${HTML_CODE} from ${node.path}")
+
+        return true
+    }
+
+    @Override
+    boolean undoUpdate(Node node) throws RepositoryException, UnsupportedOperationException {
+        throw new UnsupportedOperationException("Removal of ${HTML_CODE} cannot be reverted by this updater.")
+    }
+
+    private String jcrPrimaryType(Node node) {
+        node.getProperty("jcr:primaryType").value.getString()
+    }
+}

--- a/repository-data/application/src/main/resources/hcm-config/configuration/update/WSP-382-remove-service-general-html-code.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/configuration/update/WSP-382-remove-service-general-html-code.yaml
@@ -1,0 +1,17 @@
+---
+definitions:
+  config:
+    /hippo:configuration/hippo:update/hippo:registry/WSP-382-remove-service-general-html-code:
+      hipposys:batchsize: 1
+      hipposys:description: |
+        Reports and removes `website:htmlCode` from existing Service and General documents.
+        Run once in dry-run/report mode for assessment before enabling cleanup.
+      hipposys:dryrun: true
+      hipposys:loglevel: INFO
+      hipposys:query: /jcr:root/content/documents/corporate-website//*[(@jcr:primaryType='website:service')
+        or (@jcr:primaryType='website:general')]
+      hipposys:script:
+        resource: /configuration/update/WSP-382-remove-service-general-html-code.groovy
+        type: string
+      hipposys:throttle: 2000
+      jcr:primaryType: hipposys:updaterinfo

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/website/general.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/website/general.yaml
@@ -178,16 +178,6 @@ definitions:
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
             wicket.id: ${cluster.id}.field
-          /htmlCode:
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-            caption: Raw HTML - web team only
-            field: htmlHeaderCode
-            hint: This should only be used or edited by the web team.  Misuse of this
-              field could break the website, and could lead to disciplinary action.
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.field
           /metadata:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
@@ -342,16 +332,6 @@ definitions:
             hipposysedit:path: website:gossid
             hipposysedit:primary: false
             hipposysedit:type: Long
-            jcr:primaryType: hipposysedit:field
-          /htmlHeaderCode:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: false
-            hipposysedit:path: website:htmlCode
-            hipposysedit:primary: false
-            hipposysedit:type: Text
-            hipposysedit:validators:
-            - optional
             jcr:primaryType: hipposysedit:field
           /image:
             hipposysedit:mandatory: false

--- a/repository-data/application/src/main/resources/hcm-config/namespaces/website/service.yaml
+++ b/repository-data/application/src/main/resources/hcm-config/namespaces/website/service.yaml
@@ -201,16 +201,6 @@ definitions:
             jcr:primaryType: frontend:plugin
             plugin.class: org.hippoecm.frontend.editor.plugins.field.NodeFieldPlugin
             wicket.id: ${cluster.id}.field
-          /htmlCode:
-            /cluster.options:
-              jcr:primaryType: frontend:pluginconfig
-            caption: Raw HTML - web team only
-            field: htmlCode
-            hint: This should only be used or edited by the web team.  Misuse of this
-              field could break the website, and could lead to disciplinary action.
-            jcr:primaryType: frontend:plugin
-            plugin.class: org.hippoecm.frontend.editor.plugins.field.PropertyFieldPlugin
-            wicket.id: ${cluster.id}.field
           /rawMetadata:
             /cluster.options:
               jcr:primaryType: frontend:pluginconfig
@@ -371,16 +361,6 @@ definitions:
             hipposysedit:path: website:gossid
             hipposysedit:primary: false
             hipposysedit:type: Long
-            jcr:primaryType: hipposysedit:field
-          /htmlCode:
-            hipposysedit:mandatory: false
-            hipposysedit:multiple: false
-            hipposysedit:ordered: true
-            hipposysedit:path: website:htmlCode
-            hipposysedit:primary: false
-            hipposysedit:type: Text
-            hipposysedit:validators:
-            - optional
             jcr:primaryType: hipposysedit:field
           /image:
             hipposysedit:mandatory: false
@@ -662,7 +642,6 @@ definitions:
           jcr:primaryType: website:service
           website:earlyaccesskey: ''
           website:gossid: 0
-          website:htmlCode: ''
           website:metadata: []
           website:navigationcontroller: withNav
           website:noIndexControl: ''

--- a/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/services.yaml
+++ b/repository-data/application/src/main/resources/hcm-content/content/documents/corporate-website/services.yaml
@@ -113,7 +113,6 @@
         jcr:uuid: 85c3bdb5-3fec-437c-9ca8-4fede3eca9f6
         website:earlyaccesskey: ''
         website:gossid: 0
-        website:htmlCode: ''
         website:metadata: []
         website:navigationcontroller: withNav
         website:noIndexControl: ''
@@ -239,7 +238,6 @@
         jcr:uuid: b7faefbf-af1b-4366-ba8c-f74cbb23aaa1
         website:earlyaccesskey: ''
         website:gossid: 0
-        website:htmlCode: ''
         website:metadata: []
         website:navigationcontroller: withNav
         website:noIndexControl: ''
@@ -365,7 +363,6 @@
         jcr:uuid: 48322a0b-86ad-44e0-85d8-5994a44be571
         website:earlyaccesskey: ''
         website:gossid: 0
-        website:htmlCode: ''
         website:metadata: []
         website:navigationcontroller: withNav
         website:noIndexControl: ''

--- a/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/services/data-security-centre/test-security-model.yaml
+++ b/repository-data/development/src/main/resources/hcm-content/content/documents/corporate-website/services/data-security-centre/test-security-model.yaml
@@ -36,7 +36,6 @@
     - mix:referenceable
     jcr:primaryType: website:service
     website:gossid: 0
-    website:htmlCode: ''
     website:metadata: []
     website:rawMetadata:
     - ''
@@ -81,7 +80,6 @@
     - mix:versionable
     jcr:primaryType: website:service
     website:gossid: 0
-    website:htmlCode: ''
     website:metadata: []
     website:rawMetadata:
     - ''
@@ -126,7 +124,6 @@
     - mix:referenceable
     jcr:primaryType: website:service
     website:gossid: 0
-    website:htmlCode: ''
     website:metadata: []
     website:rawMetadata:
     - ''

--- a/repository-data/local/script/YamlFormatter.groovy
+++ b/repository-data/local/script/YamlFormatter.groovy
@@ -142,8 +142,8 @@ class YamlFormatter extends Script {
                         if (diff != 0) {
                             return diff;
                         }
-                        s1Part.setLength(0);
-                        s2Part.setLength(0);
+                        s1Part.delete(0, s1Part.length());
+                        s2Part.delete(0, s2Part.length());
                     }
                 }
 

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/general-article.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/general-article.ftl
@@ -35,7 +35,6 @@
 <#assign hasSummaryContent = document.summary.content?has_content />
 <#assign hasSectionContent = document.sections?has_content />
 <#assign hasChildPages = childPages?has_content />
-<#assign hasHtmlCode = document.htmlCode?has_content />
 <#assign sectionTitlesFound = countSectionTitles(document.sections) />
 <#assign renderNav = ((hasSummaryContent || hasChildPages) && sectionTitlesFound gte 1) || sectionTitlesFound gt 1 || (hasSummaryContent && hasChildPages) />
 <#assign idsuffix = slugify(document.title) />
@@ -120,7 +119,3 @@
         </div>
     </div>
 </article>
-
-<#if hasHtmlCode>
-    ${document.htmlCode?no_esc}
-</#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/common/service/service-article.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/common/service/service-article.ftl
@@ -183,6 +183,3 @@
         </div>
     </div>
 </article>
-<#if document.htmlCode?has_content>
-    ${document.htmlCode?no_esc}
-</#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/nhsd-common/general-article.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/nhsd-common/general-article.ftl
@@ -36,7 +36,6 @@
 <#assign hasSummaryContent = document.summary.content?has_content />
 <#assign hasSectionContent = document.sections?has_content />
 <#assign hasChildPages = childPages?has_content />
-<#assign hasHtmlCode = document.htmlCode?has_content />
 <#assign sectionTitlesFound = countSectionTitles(document.sections) />
 <#assign renderNav = ((hasSummaryContent || hasChildPages) && sectionTitlesFound gte 1) || sectionTitlesFound gt 1 || (hasSummaryContent && hasChildPages) />
 <#assign idsuffix = slugify(document.title) />
@@ -204,7 +203,3 @@
     </#if>
     </#if>
 </article>
-
-<#if hasHtmlCode>
-    ${document.htmlCode?no_esc}
-</#if>

--- a/repository-data/webfiles/src/main/resources/site/freemarker/nhsd-common/service/service-article.ftl
+++ b/repository-data/webfiles/src/main/resources/site/freemarker/nhsd-common/service/service-article.ftl
@@ -174,6 +174,3 @@
         </div>
     </div>
 </article>
-<#if document.htmlCode?has_content>
-    ${document.htmlCode?no_esc}
-</#if>

--- a/site/components/src/main/java/uk/nhs/digital/website/beans/General.java
+++ b/site/components/src/main/java/uk/nhs/digital/website/beans/General.java
@@ -36,11 +36,6 @@ public class General extends CommonFieldsBean {
         return getSingleProperty("website:gossid");
     }
 
-    @HippoEssentialsGenerated(internalName = "website:htmlCode")
-    public String getHtmlCode() {
-        return getSingleProperty("website:htmlCode");
-    }
-
     @HippoEssentialsGenerated(internalName = "website:metadata")
     public String[] getMetadata() {
         return getMultipleProperty("website:metadata");

--- a/site/components/src/main/java/uk/nhs/digital/website/beans/Service.java
+++ b/site/components/src/main/java/uk/nhs/digital/website/beans/Service.java
@@ -55,11 +55,6 @@ public class Service extends CommonFieldsBean {
         return getBean("website:friendlyurls", Friendlyurls.class);
     }
 
-    @HippoEssentialsGenerated(internalName = "website:htmlCode")
-    public String getHtmlCode() {
-        return getSingleProperty("website:htmlCode");
-    }
-
     @HippoEssentialsGenerated(internalName = "website:rawMetadata")
     public String[] getRawMetadata() {
         return getMultipleProperty("website:rawMetadata");


### PR DESCRIPTION
- Removed the `website:htmlCode` raw HTML field from `website:general` and `website:service` document type definitions, including the CMS editor field configuration.
- Removed rendering of `document.htmlCode?no_esc` from the General and Service Freemarker templates in both `common` and `nhsd-common`.
- Removed the generated `getHtmlCode()` accessors from the `General` and `Service` Java beans.
- Cleaned exported repository content by removing empty `website:htmlCode` properties from existing service content.
- Added a dry-run repository updater, `WSP-382-remove-service-general-html-code`, to report and remove existing `website:htmlCode` properties from Service and General documents.
- Fixed `make format-yaml` by replacing the Groovy/SnakeYAML formatter’s `StringBuilder.setLength(0)` reset with `delete(0, length())`, avoiding the Groovy dispatch failure I was getting with this PR.
- Hardened the search acceptance page object so result-count reads wait for a refreshed visible element, reducing stale element failures seen in CI. This test was flaky and failing on this PR.

Verified locally:
- `make format-yaml` passes.
- `mvn -f acceptance-tests/pom.xml test-compile` passes.
